### PR TITLE
Fix using array_key_exists() on objects is deprecated (7.4)

### DIFF
--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -51,13 +51,18 @@ class Barcode extends AbstractValidator
             $options = [];
         }
 
-        if (! is_array($options) && ! ($options instanceof Traversable)) {
+        if (is_array($options)) {
+            if (array_key_exists('options', $options)) {
+                $options['options'] = ['options' => $options['options']];
+            }
+        } else if ($options instanceof Traversable) {
+            if (property_exists($options, 'options')) {
+                $options['options'] = ['options' => $options['options']];
+            }
+        } else {
             $options = ['adapter' => $options];
         }
 
-        if (array_key_exists('options', $options)) {
-            $options['options'] = ['options' => $options['options']];
-        }
 
         parent::__construct($options);
     }


### PR DESCRIPTION
Without:

There was 1 error:

```
1) ZendTest\Validator\BarcodeTest::testConfigConstructAdapter
array_key_exists(): Using array_key_exists() on objects is deprecated. Use isset() or property_exists() instead

/dev/shm/BUILDROOT/php-zendframework-zend-validator-2.13.0-1.fc31.remi.x86_64/usr/share/php/Zend/Validator/Barcode.php:59
/dev/shm/BUILD/zend-validator-b54acef1f407741c5347f2a97f899ab21f2229ef/test/BarcodeTest.php:168

```