### PR TITLE
Fix hostname validation for domain parts with 2+ dashes and with dash at the end

### DIFF
--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -2091,7 +2091,7 @@ class Hostname extends AbstractValidator
                                 && $utf8StrWrapper->strpos($domainPart, '-', 3) == 3
                             )
                             || (
-                                $utf8StrWrapper->strpos($domainPart, '-') === (
+                                $utf8StrWrapper->strpos($domainPart, '-', $utf8StrWrapper->strlen($domainPart) - 1) === (
                                 $utf8StrWrapper->strlen($domainPart) - 1
                                 )
                             )

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -104,7 +104,7 @@ class HostnameTest extends TestCase
     {
         $valuesExpected = [
             [Hostname::ALLOW_DNS, true, ['domain.com', 'doma-in.com']],
-            [Hostname::ALLOW_DNS, false, ['-domain.com', 'domain-.com', 'do--main.com']]
+            [Hostname::ALLOW_DNS, false, ['-domain.com', 'domain-.com', 'do--main.com', 'do-main-.com']]
             ];
         foreach ($valuesExpected as $element) {
             $validator = new Hostname($element[0]);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Without it, domains like `do-main-.com` will pass validation

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
