### PR TITLE
UndisclosedPassword object wasn't fully instanciated

### DIFF
--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -23,8 +23,8 @@ final class UndisclosedPassword extends AbstractValidator
     private const HIBP_K_ANONYMITY_HASH_RANGE_BASE = 0;
     private const SHA1_STRING_LENGTH = 40;
 
-    private const PASSWORD_BREACHED = 'passwordBreached';
-    private const NOT_A_STRING = 'wrongInput';
+    public const PASSWORD_BREACHED = 'passwordBreached';
+    public const NOT_A_STRING = 'wrongInput';
 
     protected $messageTemplates = [
         self::PASSWORD_BREACHED =>

--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -23,8 +23,8 @@ final class UndisclosedPassword extends AbstractValidator
     private const HIBP_K_ANONYMITY_HASH_RANGE_BASE = 0;
     private const SHA1_STRING_LENGTH = 40;
 
-    public const PASSWORD_BREACHED = 'passwordBreached';
-    public const NOT_A_STRING = 'wrongInput';
+    private const PASSWORD_BREACHED = 'passwordBreached';
+    private const NOT_A_STRING = 'wrongInput';
 
     protected $messageTemplates = [
         self::PASSWORD_BREACHED =>
@@ -55,11 +55,11 @@ final class UndisclosedPassword extends AbstractValidator
         RequestFactoryInterface $makeHttpRequest,
         ResponseFactoryInterface $makeHttpResponse
     ) {
+        parent::__construct();
+
         $this->httpClient = $httpClient;
         $this->makeHttpRequest = $makeHttpRequest;
         $this->makeHttpResponse = $makeHttpResponse;
-
-        parent::__construct();
     }
 
     /**

--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -58,6 +58,8 @@ final class UndisclosedPassword extends AbstractValidator
         $this->httpClient = $httpClient;
         $this->makeHttpRequest = $makeHttpRequest;
         $this->makeHttpResponse = $makeHttpResponse;
+
+        parent::__construct();
     }
 
     /**

--- a/test/UndisclosedPasswordTest.php
+++ b/test/UndisclosedPasswordTest.php
@@ -203,6 +203,22 @@ class UndisclosedPasswordTest extends TestCase
     }
 
     /**
+     * Test that the message templates are getting initialized via
+     * the parent::_construct call
+     */
+    public function testMessageTemplatesAreInitialized()
+    {
+        $this->assertTrue(array_key_exists(
+            UndisclosedPassword::NOT_A_STRING,
+            $this->validator->getMessageTemplates()
+        ));
+        $this->assertTrue(array_key_exists(
+            UndisclosedPassword::PASSWORD_BREACHED,
+            $this->validator->getMessageTemplates()
+        ));
+    }
+
+    /**
      * Testing that we capture any failures when trying to connect with
      * the HIBP web service.
      *

--- a/test/UndisclosedPasswordTest.php
+++ b/test/UndisclosedPasswordTest.php
@@ -206,16 +206,9 @@ class UndisclosedPasswordTest extends TestCase
      * Test that the message templates are getting initialized via
      * the parent::_construct call
      */
-    public function testMessageTemplatesAreInitialized()
+    public function testMessageTemplatesAreInitialized() : void
     {
-        $this->assertTrue(array_key_exists(
-            UndisclosedPassword::NOT_A_STRING,
-            $this->validator->getMessageTemplates()
-        ));
-        $this->assertTrue(array_key_exists(
-            UndisclosedPassword::PASSWORD_BREACHED,
-            $this->validator->getMessageTemplates()
-        ));
+        $this->assertNotEmpty($this->validator->getMessageTemplates());
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Added missing parent constructor call, which prevented the validator to get completley instanciated