### PR TITLE
Remove deprecated assertion usage

### DIFF
--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -489,14 +489,25 @@ class BarcodeTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Barcode('code25');
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Barcode::FAILED,
+                Barcode::INVALID_CHARS,
+                Barcode::INVALID_LENGTH,
+                Barcode::INVALID,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = new Barcode('code25');
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $validator        = new Barcode('code25');
+        $messageVariables = [
+            'length' => ['options' => 'length'],
+        ];
+        $this->assertSame($messageVariables, $validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $validator->getMessageVariables());
     }
 }

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -246,15 +246,27 @@ class BetweenTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Between(['min' => 1, 'max' => 10]);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Between::NOT_BETWEEN,
+                Between::NOT_BETWEEN_STRICT,
+                Between::VALUE_NOT_NUMERIC,
+                Between::VALUE_NOT_STRING,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = new Between(['min' => 1, 'max' => 10]);
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $validator        = new Between(['min' => 1, 'max' => 10]);
+        $messageVariables = [
+            'min' => ['options' => 'min'],
+            'max' => ['options' => 'max'],
+        ];
+        $this->assertSame($messageVariables, $validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $validator->getMessageVariables());
     }
 
     /**

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -7,6 +7,7 @@ use Laminas\Validator\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+use function array_keys;
 use function func_get_args;
 
 /**
@@ -73,7 +74,13 @@ class CallbackTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Callback([$this, 'objectCallback']);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Callback::INVALID_VALUE,
+                Callback::INVALID_CALLBACK,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -7,6 +7,7 @@ use Laminas\Validator\CreditCard;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
 use function current;
 
 /**
@@ -187,9 +188,9 @@ class CreditCardTest extends TestCase
     /**
      * Data provider
      *
-     * @return string[][]|bool[][]
+     * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function jcbValues()
+    public function jcbValues(): array
     {
         return [
             ['3566003566003566', true],
@@ -223,9 +224,9 @@ class CreditCardTest extends TestCase
     /**
      * Data provider
      *
-     * @return string[][]|bool[][]
+     * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function mastercardValues()
+    public function mastercardValues(): array
     {
         return [
             ['4111111111111111', false],
@@ -260,9 +261,9 @@ class CreditCardTest extends TestCase
     /**
      * Data provider
      *
-     * @return string[][]|bool[][]
+     * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function mirValues()
+    public function mirValues(): array
     {
         return [
             ['3011111111111000', false],
@@ -366,7 +367,18 @@ class CreditCardTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new CreditCard();
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                CreditCard::CHECKSUM,
+                CreditCard::CONTENT,
+                CreditCard::INVALID,
+                CreditCard::LENGTH,
+                CreditCard::PREFIX,
+                CreditCard::SERVICE,
+                CreditCard::SERVICEFAILURE,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -12,6 +12,7 @@ use Laminas\Validator;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
+use function array_keys;
 use function date;
 
 /**
@@ -148,7 +149,15 @@ class DateStepTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Validator\DateStep([]);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Validator\DateStep::INVALID,
+                Validator\DateStep::INVALID_DATE,
+                Validator\DateStep::FALSEFORMAT,
+                Validator\DateStep::NOT_STEP,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -161,16 +161,24 @@ class DateTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Validator\Date::INVALID,
+                Validator\Date::INVALID_DATE,
+                Validator\Date::FALSEFORMAT,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'format' => 'format',
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
     public function testConstructorWithFormatParameter(): void

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -221,8 +221,12 @@ class NoRecordExistsTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = new NoRecordExists('users', 'field1');
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $validator        = new NoRecordExists('users', 'field1');
+        $messageTemplates = [
+            'noRecordFound' => 'No record matching the input was found',
+            'recordFound'   => 'A record matching the input was found',
+        ];
+        $this->assertSame($messageTemplates, $validator->getOption('messageTemplates'));
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -266,8 +266,12 @@ class RecordExistsTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = new RecordExists('users', 'field1');
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $validator        = new RecordExists('users', 'field1');
+        $messageTemplates = [
+            'noRecordFound' => 'No record matching the input was found',
+            'recordFound'   => 'A record matching the input was found',
+        ];
+        $this->assertSame($messageTemplates, $validator->getOption('messageTemplates'));
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -5,6 +5,8 @@ namespace LaminasTest\Validator;
 use Laminas\Validator\Digits;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+
 /**
  * @group      Laminas_Validator
  */
@@ -96,8 +98,14 @@ class DigitsTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Digits::NOT_DIGITS,
+                Digits::STRING_EMPTY,
+                Digits::INVALID,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 }

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -361,11 +361,11 @@ class EmailAddressTest extends TestCase
         }
     }
 
-   /**
-    * Ensures that the validator follows expected behavior for checking MX records
-    *
-    * @return void
-    */
+    /**
+     * Ensures that the validator follows expected behavior for checking MX records
+     *
+     * @return void
+     */
     public function testMXRecords()
     {
         $this->skipIfOnlineTestsDisabled();
@@ -431,11 +431,11 @@ class EmailAddressTest extends TestCase
         $this->assertTrue($validator->isValid($email), implode("\n", $validator->getMessages()));
     }
 
-   /**
-    * Test changing hostname settings via EmailAddress object
-    *
-    * @return void
-    */
+    /**
+     * Test changing hostname settings via EmailAddress object
+     *
+     * @return void
+     */
     public function testHostnameSettings()
     {
         $validator = new EmailAddress();
@@ -736,16 +736,31 @@ class EmailAddressTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                EmailAddress::INVALID,
+                EmailAddress::INVALID_FORMAT,
+                EmailAddress::INVALID_HOSTNAME,
+                EmailAddress::INVALID_MX_RECORD,
+                EmailAddress::INVALID_SEGMENT,
+                EmailAddress::DOT_ATOM,
+                EmailAddress::QUOTED_STRING,
+                EmailAddress::INVALID_LOCAL_PART,
+                EmailAddress::LENGTH_EXCEEDED,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'hostname'  => 'hostname',
+            'localPart' => 'localPart',
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
     /**

--- a/test/ExplodeTest.php
+++ b/test/ExplodeTest.php
@@ -103,15 +103,20 @@ class ExplodeTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Explode([]);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Explode::INVALID,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
         $validator = new Explode([]);
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $this->assertSame([], $validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys([]), $validator->getMessageVariables());
     }
 
     public function testSetValidatorAsArray(): void

--- a/test/GreaterThanTest.php
+++ b/test/GreaterThanTest.php
@@ -133,15 +133,24 @@ class GreaterThanTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new GreaterThan(1);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                GreaterThan::NOT_GREATER,
+                GreaterThan::NOT_GREATER_INCLUSIVE,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = new GreaterThan(1);
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $validator        = new GreaterThan(1);
+        $messageVariables = [
+            'min' => 'min',
+        ];
+        $this->assertSame($messageVariables, $validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $validator->getMessageVariables());
     }
 
     /**

--- a/test/HexTest.php
+++ b/test/HexTest.php
@@ -5,6 +5,8 @@ namespace LaminasTest\Validator;
 use Laminas\Validator\Hex;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+
 /**
  * @group      Laminas_Validator
  */
@@ -32,7 +34,7 @@ class HexTest extends TestCase
 
     /**
      * @psalm-return array<string, array{
-     *     0: mixed,
+     *     0: int|string,
      *     1: bool
      * }>
      */
@@ -74,8 +76,13 @@ class HexTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Hex::INVALID,
+                Hex::NOT_HEX,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 }

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -663,16 +663,32 @@ class HostnameTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Hostname::CANNOT_DECODE_PUNYCODE,
+                Hostname::INVALID,
+                Hostname::INVALID_DASH,
+                Hostname::INVALID_HOSTNAME,
+                Hostname::INVALID_HOSTNAME_SCHEMA,
+                Hostname::INVALID_LOCAL_NAME,
+                Hostname::INVALID_URI,
+                Hostname::IP_ADDRESS_NOT_ALLOWED,
+                Hostname::LOCAL_NAME_NOT_ALLOWED,
+                Hostname::UNDECIPHERABLE_TLD,
+                Hostname::UNKNOWN_TLD,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'tld' => 'tld',
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
     public function testHostnameWithOnlyIpChars(): void

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -6,6 +6,7 @@ use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Iban as IbanValidator;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
 use function array_merge;
 use function implode;
 
@@ -157,7 +158,15 @@ class IbanTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new IbanValidator();
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                IbanValidator::NOTSUPPORTED,
+                IbanValidator::SEPANOTSUPPORTED,
+                IbanValidator::FALSEFORMAT,
+                IbanValidator::CHECKFAILED,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 

--- a/test/IdenticalTest.php
+++ b/test/IdenticalTest.php
@@ -113,16 +113,23 @@ class IdenticalTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Identical::NOT_SAME,
+                Identical::MISSING_TOKEN,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'token' => 'tokenString',
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
     public function testValidatingStringTokenInContext(): void

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -6,6 +6,8 @@ use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\InArray;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+
 use const PHP_MAJOR_VERSION;
 
 /**
@@ -417,9 +419,13 @@ class InArrayTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                InArray::NOT_IN_ARRAY,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     /**

--- a/test/IpTest.php
+++ b/test/IpTest.php
@@ -6,6 +6,8 @@ use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Ip;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+
 /**
  * @group      Laminas_Validator
  */
@@ -362,9 +364,14 @@ class IpTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Ip::INVALID,
+                Ip::NOT_IP_ADDRESS,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     /**

--- a/test/IsbnTest.php
+++ b/test/IsbnTest.php
@@ -6,6 +6,8 @@ use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Isbn;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
+
 /**
  * @group      Laminas_Validator
  */
@@ -223,7 +225,13 @@ class IsbnTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Isbn();
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Isbn::INVALID,
+                Isbn::NO_ISBN,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/LessThanTest.php
+++ b/test/LessThanTest.php
@@ -129,15 +129,24 @@ class LessThanTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new LessThan(10);
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                LessThan::NOT_LESS,
+                LessThan::NOT_LESS_INCLUSIVE,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = new LessThan(10);
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $validator        = new LessThan(10);
+        $messageVariables = [
+            'max' => 'max',
+        ];
+        $this->assertSame($messageVariables, $validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $validator->getMessageVariables());
     }
 
     public function testConstructorAllowsSettingAllOptionsAsDiscreteArguments(): void

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -260,15 +260,25 @@ class MessageTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                StringLength::INVALID,
+                StringLength::TOO_SHORT,
+                StringLength::TOO_LONG,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'min'    => ['options' => 'min'],
+            'max'    => ['options' => 'max'],
+            'length' => ['options' => 'length'],
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 }

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -952,8 +952,11 @@ class NotEmptyTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $messageTemplates = [
+            'isEmpty'         => "Value is required and can't be empty",
+            'notEmptyInvalid' => "Invalid type given. String, integer, float, boolean or array expected",
+        ];
+        $this->assertSame($messageTemplates, $this->validator->getOption('messageTemplates'));
     }
 
     public function testTypeAutoDetectionHasNoSideEffect(): void

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -137,15 +137,24 @@ class RegexTest extends TestCase
     public function testEqualsMessageTemplates(): void
     {
         $validator = new Regex('//');
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertSame(
+            [
+                Regex::INVALID,
+                Regex::NOT_MATCH,
+                Regex::ERROROUS,
+            ],
+            array_keys($validator->getMessageTemplates())
+        );
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = new Regex('//');
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $validator        = new Regex('//');
+        $messageVariables = [
+            'pattern' => 'pattern',
+        ];
+        $this->assertSame($messageVariables, $validator->getOption('messageVariables'));
     }
 
     /**

--- a/test/StringLengthTest.php
+++ b/test/StringLengthTest.php
@@ -162,15 +162,25 @@ class StringLengthTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                StringLength::INVALID,
+                StringLength::TOO_SHORT,
+                StringLength::TOO_LONG,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables(): void
     {
-        $validator = $this->validator;
-        $this->assertObjectHasAttribute('messageVariables', $validator);
-        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
+        $messageVariables = [
+            'min'    => ['options' => 'min'],
+            'max'    => ['options' => 'max'],
+            'length' => ['options' => 'length'],
+        ];
+        $this->assertSame($messageVariables, $this->validator->getOption('messageVariables'));
+        $this->assertEquals(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -10,6 +10,8 @@ use Laminas\Validator\Uri;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function array_keys;
+
 /**
  * @group      Laminas_Validator
  */
@@ -163,9 +165,14 @@ class UriTest extends TestCase
 
     public function testEqualsMessageTemplates(): void
     {
-        $validator = $this->validator;
-        self::assertObjectHasAttribute('messageTemplates', $validator);
-        self::assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+        $this->assertSame(
+            [
+                Validator\Uri::INVALID,
+                Validator\Uri::NOT_URI,
+            ],
+            array_keys($this->validator->getMessageTemplates())
+        );
+        $this->assertEquals($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     public function testUriHandlerCanBeSpecifiedAsString(): void


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Remove some deprecated phpunit assertions that test non public attribute

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
