### PR TITLE
bugfix: allows Laminas\Uri\Uri as uriHandler in Uri validator

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -89,22 +89,17 @@ class Uri extends AbstractValidator
             // Instantiate string Uri handler that references a class
             $this->uriHandler = new $this->uriHandler;
         }
-
-        if (! $this->uriHandler instanceof UriHandler) {
-            throw new InvalidArgumentException('URI handler is expected to be a Laminas\Uri\Uri object');
-        }
-
         return $this->uriHandler;
     }
 
     /**
-     * @param  UriHandler $uriHandler
+     * @param  UriHandler|string  $uriHandler
      * @throws InvalidArgumentException
      * @return Uri
      */
     public function setUriHandler($uriHandler)
     {
-        if (! is_subclass_of($uriHandler, 'Laminas\Uri\Uri')) {
+        if (! is_a($uriHandler, UriHandler::class, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Expecting a subclass name or instance of %s as $uriHandler',
                 UriHandler::class

--- a/test/TestAsset/CustomTraversable.php
+++ b/test/TestAsset/CustomTraversable.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LaminasTest\Validator\TestAsset;
+
+use Iterator;
+
+class CustomTraversable implements Iterator
+{
+    /** @var array */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function next()
+    {
+        return next($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function valid()
+    {
+        return $this->key() !== null;
+    }
+
+    public function rewind()
+    {
+        return reset($this->data);
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix | yes
| QA            | yes

### Description
Add constructor test for traversable object
Add constructor tests for invalid uri handler
Remode dead code on urihandler validation
Replace assertion calls by static calls
Replace `Laminas\Uri\Uri` by the class keyword 
Use the same alias `UriHandler` for `Laminas\Uri\Uri` as in the `Validator\Uri` class

