### PR TITLE
Fix invalid option name in callback validator

### DIFF
--- a/docs/book/validators/callback.md
+++ b/docs/book/validators/callback.md
@@ -8,7 +8,7 @@ validate a given value.
 The following options are supported for `Laminas\Validator\Callback`:
 
 - `callback`: Sets the callback which will be called for the validation.
-- `options`: Sets the additional options which will be given to the validator
+- `callbackOptions`: Sets the additional options which will be given to the validator
   and/or callback.
 
 ## Basic usage


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Additional options option should be named 'callbackOptions' instead of 'options'