### PR TITLE
Failing tests for IDN TLD that contains uppercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php": "^7.3 || ~8.0.0",
         "container-interop/container-interop": "^1.1",
         "laminas/laminas-stdlib": "^3.3",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.0",
+        "symfony/polyfill-mbstring": "^1.20"
     },
     "require-dev": {
         "laminas/laminas-cache": "^2.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bac4c172b99d1afb1fb682b753b157d5",
+    "content-hash": "a7f748a75fbff62b0b294f5968054738",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -211,6 +211,86 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
             "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
         }
     ],
     "packages-dev": [
@@ -5749,86 +5829,6 @@
                 }
             ],
             "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -1995,8 +1995,8 @@ class Hostname extends AbstractValidator
         $this->setValue($value);
         // Check input against IP address schema
         if (
-            ((preg_match('/^[0-9.]*$/', $value) && strpos($value, '.') !== false)
-                || (preg_match('/^[0-9a-f:.]*$/i', $value) && strpos($value, ':') !== false))
+            ((preg_match('/^[0-9.]*$/', $value) && mb_strpos($value, '.') !== false)
+                || (preg_match('/^[0-9a-f:.]*$/i', $value) && mb_strpos($value, ':') !== false))
             && $this->getIpValidator()->setTranslator($this->getTranslator())->isValid($value)
         ) {
             if (! ($this->getAllow() & self::ALLOW_IP)) {
@@ -2010,16 +2010,16 @@ class Hostname extends AbstractValidator
         // Handle Regex compilation failure that may happen on .biz domain with has @ character, eg: tapi4457@hsoqvf.biz
         // Technically, hostname with '@' character is invalid, so mark as invalid immediately
         // @see https://github.com/laminas/laminas-validator/issues/8
-        if (strpos($value, '@') !== false) {
+        if (mb_strpos($value, '@') !== false) {
             $this->error(self::INVALID_HOSTNAME);
             return false;
         }
 
         // Local hostnames are allowed to be partial (ending '.')
         if ($this->getAllow() & self::ALLOW_LOCAL) {
-            if (substr($value, -1) === '.') {
-                $value = substr($value, 0, -1);
-                if (substr($value, -1) === '.') {
+            if (mb_substr($value, -1) === '.') {
+                $value = mb_substr($value, 0, -1);
+                if (mb_substr($value, -1) === '.') {
                     // Empty hostnames (ending '..') are not allowed
                     $this->error(self::INVALID_LOCAL_NAME);
                     return false;
@@ -2063,20 +2063,20 @@ class Hostname extends AbstractValidator
 
                     $this->tld = $matches[1];
                     // Decode Punycode TLD to IDN
-                    if (strpos($this->tld, 'xn--') === 0) {
-                        $this->tld = $this->decodePunycode(substr($this->tld, 4));
+                    if (mb_strpos($this->tld, 'xn--') === 0) {
+                        $this->tld = $this->decodePunycode(mb_substr($this->tld, 4));
                         if ($this->tld === false) {
                             return false;
                         }
                     } else {
-                        $this->tld = strtoupper($this->tld);
+                        $this->tld = mb_strtoupper($this->tld);
                     }
 
                     // Match TLD against known list
                     $removedTld = false;
                     if ($this->getTldCheck()) {
                         if (
-                            ! in_array(strtolower($this->tld), $this->validTlds)
+                            ! in_array(mb_strtolower($this->tld), $this->validTlds)
                             && ! in_array($this->tld, $this->validTlds)
                         ) {
                             $this->error(self::UNKNOWN_TLD);
@@ -2112,8 +2112,8 @@ class Hostname extends AbstractValidator
                     }
                     foreach ($domainParts as $domainPart) {
                         // Decode Punycode domain names to IDN
-                        if (strpos($domainPart, 'xn--') === 0) {
-                            $domainPart = $this->decodePunycode(substr($domainPart, 4));
+                        if (mb_strpos($domainPart, 'xn--') === 0) {
+                            $domainPart = $this->decodePunycode(mb_substr($domainPart, 4));
                             if ($domainPart === false) {
                                 return false;
                             }
@@ -2240,7 +2240,7 @@ class Hostname extends AbstractValidator
         }
 
         $decoded   = [];
-        $separator = strrpos($encoded, '-');
+        $separator = mb_strrpos($encoded, '-');
         if ($separator > 0) {
             for ($x = 0; $x < $separator; ++$x) {
                 // prepare decoding matrix
@@ -2249,7 +2249,7 @@ class Hostname extends AbstractValidator
         }
 
         $lengthd = count($decoded);
-        $lengthe = strlen($encoded);
+        $lengthe = mb_strlen($encoded);
 
         // decoding
         $init  = true;

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -619,8 +619,10 @@ class HostnameTest extends TestCase
         // @codingStandardsIgnoreStart
         return [
             'ASCII label + UTF-8 TLD'                    => ['test123.онлайн'],
+            'ASCII label + UTF-8 TLD (Uppercase chars)'  => ['test123.оНлАйН'],
             'ASCII label + Punycoded TLD'                => ['test123.xn--80asehdb'],
             'UTF-8 label + UTF-8 TLD (cyrillic)'         => ['тест.рф'],
+            'UTF-8 label + UTF-8 TLD (cyrillic) + CAPS'  => ['ТЕСТ.РФ'],
             'Punycoded label + Punycoded TLD (cyrillic)' => ['xn--e1aybc.xn--p1ai'],
         ];
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

These are just failing tests for top-level IDN domains that contain uppercase letters.

I tried to fix it, but found that the fix would be non-trivial. The problem is caused by using the built-in PHP functions `strtoupper()` and `strtolower()`. For example: https://github.com/laminas/laminas-validator/blob/3f5e678db331a21cd4b90af9db8208749288cd89/src/Hostname.php#L2037

These functions do not work correctly with multi-byte encodings. But for processing multi-byte encodings, the code uses wrappers in the `\Laminas\Stdlib\StringWrapper` namespace, which do not yet contain functions `strtoupper()` and `strtolower()`.

Thus, a full fix will look like this:
- [ ] Add to `\Laminas\Stdlib\StringWrapper\StringWrapperInterface` methods `strtoupper()` and `strtolower()` 
- [ ] Implement these in the concrete wrappers
- [ ] Release new version of https://github.com/laminas/laminas-stdlib
- [ ] Use the new methods to fix the problem in the current package

So this is a subject for discussion...
Maybe I misunderstood something.