### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,29 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
       env:
         - DEPS=latest
         - EXECUTE_HOSTNAME_CHECK=true
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
+    - php: 8.0
       env:
         - DEPS=latest
-    - php: 7.3
+        - COMPOSER_ARGS="--ignore-platform-reqs"
+    - php: 8.0
       env:
         - DEPS=lowest
-    - php: 7.3
-      env:
-        - DEPS=latest
-    - php: 7.4
-      env:
-        - DEPS=lowest
-    - php: 7.4
-      env:
-        - DEPS=latest
+        - COMPOSER_ARGS="--ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "container-interop/container-interop": "^1.1",
-        "laminas/laminas-stdlib": "^3.2.1",
+        "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
@@ -36,13 +36,14 @@
         "laminas/laminas-config": "^2.6",
         "laminas/laminas-db": "^2.7",
         "laminas/laminas-filter": "^2.6",
-        "laminas/laminas-http": "^2.5.4",
+        "laminas/laminas-http": "^2.14.2",
         "laminas/laminas-i18n": "^2.6",
         "laminas/laminas-math": "^2.6",
         "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
         "laminas/laminas-session": "^2.8",
-        "laminas/laminas-uri": "^2.5",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.2",
+        "laminas/laminas-uri": "^2.7",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.3",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,14 +17,15 @@
         </exclude>
     </groups>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 
     <php>
         <ini name="date.timezone" value="UTC"/>
+        <ini name="xdebug.max_nesting_level" value="3000"/>
 
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -197,10 +197,6 @@ class InArray extends AbstractValidator
                     if ($el == $value) {
                         return true;
                     }
-
-                    if (self::COMPARE_NOT_STRICT == $this->strict) {
-                        return true;
-                    }
                 }
             }
         } else {

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -197,6 +197,10 @@ class InArray extends AbstractValidator
                     if ($el == $value) {
                         return true;
                     }
+
+                    if ($this->isMultidimensionalArray($haystack) && self::COMPARE_NOT_STRICT == $this->strict) {
+                        return true;
+                    }
                 }
             }
         } else {
@@ -216,14 +220,32 @@ class InArray extends AbstractValidator
                         $h = (string) $h;
                     }
                 }
+
+                if (! $this->isMultidimensionalArray($haystack) && in_array($value, $haystack, $this->strict)) {
+                    return true;
+                }
             }
 
-            if (in_array($value, $haystack, self::COMPARE_STRICT == $this->strict)) {
+            if (array_search($value, $haystack, self::COMPARE_STRICT == $this->strict)) {
+                return true;
+            }
+
+            if (self::COMPARE_NOT_STRICT == $this->strict) {
                 return true;
             }
         }
 
         $this->error(self::NOT_IN_ARRAY);
+        return false;
+    }
+
+    private function isMultidimensionalArray(array $array): bool
+    {
+        foreach ($array as $value) {
+            if (is_array($value)) {
+                return true;
+            }
+        }
         return false;
     }
 }

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -198,7 +198,7 @@ class InArray extends AbstractValidator
                         return true;
                     }
 
-                    if ($this->isMultidimensionalArray($haystack) && self::COMPARE_NOT_STRICT == $this->strict) {
+                    if (self::COMPARE_NOT_STRICT == $this->strict) {
                         return true;
                     }
                 }
@@ -221,7 +221,7 @@ class InArray extends AbstractValidator
                     }
                 }
 
-                if (! $this->isMultidimensionalArray($haystack) && in_array($value, $haystack, $this->strict)) {
+                if (in_array($value, $haystack, $this->strict)) {
                     return true;
                 }
             }
@@ -236,16 +236,6 @@ class InArray extends AbstractValidator
         }
 
         $this->error(self::NOT_IN_ARRAY);
-        return false;
-    }
-
-    private function isMultidimensionalArray(array $array): bool
-    {
-        foreach ($array as $value) {
-            if (is_array($value)) {
-                return true;
-            }
-        }
         return false;
     }
 }

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -185,50 +185,58 @@ class InArray extends AbstractValidator
                     if ($element === $value) {
                         return true;
                     }
-                } else {
-                    // add protection to prevent string to int vuln's
-                    $el = $element;
-                    if (self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY == $this->strict
-                        && is_string($value) && (is_int($el) || is_float($el))
-                    ) {
-                        $el = (string) $el;
-                    }
 
-                    if ($el == $value) {
-                        return true;
-                    }
-                }
-            }
-        } else {
-            /**
-             * If the check is not strict, then, to prevent "asdf" being converted to 0
-             * and returning a false positive if 0 is in haystack, we type cast
-             * the haystack to strings. To prevent "56asdf" == 56 === TRUE we also
-             * type cast values like 56 to strings as well.
-             *
-             * This occurs only if the input is a string and a haystack member is an int
-             */
-            if (self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY == $this->strict
-                && is_string($value)
-            ) {
-                foreach ($haystack as &$h) {
-                    if (is_int($h) || is_float($h)) {
-                        $h = (string) $h;
-                    }
+                    continue;
                 }
 
-                if (in_array($value, $haystack, $this->strict)) {
+                // add protection to prevent string to int vuln's
+                $el = $element;
+                if (self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY == $this->strict
+                    && is_string($value) && (is_int($el) || is_float($el))
+                ) {
+                    $el = (string) $el;
+                }
+
+                if ($el == $value) {
                     return true;
                 }
             }
 
-            if (array_search($value, $haystack, self::COMPARE_STRICT == $this->strict)) {
+            $this->error(self::NOT_IN_ARRAY);
+            return false;
+        }
+
+        /**
+         * If the check is not strict, then, to prevent "asdf" being converted to 0
+         * and returning a false positive if 0 is in haystack, we type cast
+         * the haystack to strings. To prevent "56asdf" == 56 === TRUE we also
+         * type cast values like 56 to strings as well.
+         *
+         * This occurs only if the input is a string and a haystack member is an int
+         */
+        if (self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY == $this->strict
+            && is_string($value)
+        ) {
+            foreach ($haystack as &$h) {
+                if (is_int($h) || is_float($h)) {
+                    $h = (string) $h;
+                }
+            }
+
+            if (in_array($value, $haystack, (bool) $this->strict)) {
                 return true;
             }
 
-            if (self::COMPARE_NOT_STRICT == $this->strict) {
-                return true;
-            }
+            $this->error(self::NOT_IN_ARRAY);
+            return false;
+        }
+
+        if (in_array($value, $haystack, self::COMPARE_STRICT == $this->strict)) {
+            return true;
+        }
+
+        if (self::COMPARE_NOT_STRICT == $this->strict) {
+            return true;
         }
 
         $this->error(self::NOT_IN_ARRAY);

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -487,20 +487,14 @@ class BarcodeTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Barcode('code25');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new Barcode('code25');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 }

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -238,13 +238,15 @@ class BetweenTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Between(['min' => 1, 'max' => 10]);
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'), 'messageTemplates', $validator);
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new Between(['min' => 1, 'max' => 10]);
-        $this->assertAttributeEquals($validator->getOption('messageVariables'), 'messageVariables', $validator);
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     /**

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -77,11 +77,8 @@ class CallbackTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Callback([$this, 'objectCallback']);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testCanAcceptContextWithoutOptions()

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -362,11 +362,8 @@ class CreditCardTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new CreditCard();
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     /**

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -110,7 +110,7 @@ class DateStepTest extends TestCase
     {
         $validator  = new Validator\DateStep([]);
         $this->assertObjectHasAttribute('messageTemplates', $validator);
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'), 'messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testStepError()

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -160,21 +160,15 @@ class DateTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testConstructorWithFormatParameter()

--- a/test/Db/AbstractDbTest.php
+++ b/test/Db/AbstractDbTest.php
@@ -14,12 +14,14 @@ use Laminas\Db\Sql\Select;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use LaminasTest\Validator\Db\TestAsset\ConcreteDbValidator;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @group      Laminas_Validator
  */
 class AbstractDbTest extends TestCase
 {
+    use ProphecyTrait;
 
     protected $validator;
 
@@ -104,13 +106,15 @@ class AbstractDbTest extends TestCase
      */
     public function testSetAdapterIsEquivalentToSetDbAdapter()
     {
-        $adapterFirst = $this->prophesize(Adapter::class)->reveal();
-        $adapterSecond = $this->prophesize(Adapter::class)->reveal();
+        $adapterFirst = $this->createStub(Adapter::class);
+        $adapterSecond = $this->createStub(Adapter::class);
 
         $this->validator->setAdapter($adapterFirst);
-        $this->assertAttributeSame($adapterFirst, 'adapter', $this->validator);
+        $this->assertObjectHasAttribute('adapter', $this->validator);
+        $this->assertEquals($adapterFirst, $this->validator->getAdapter());
 
         $this->validator->setDbAdapter($adapterSecond);
-        $this->assertAttributeSame($adapterSecond, 'adapter', $this->validator);
+        $this->assertObjectHasAttribute('adapter', $this->validator);
+        $this->assertEquals($adapterSecond, $this->validator->getAdapter());
     }
 }

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -228,10 +228,7 @@ class NoRecordExistsTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator  = new NoRecordExists('users', 'field1');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -245,8 +245,6 @@ class RecordExistsTest extends TestCase
 
     /**
      * Test that schemas are supported and run without error
-     *
-     * @return void
      */
     public function testWithSchemaNoResult()
     {
@@ -275,11 +273,8 @@ class RecordExistsTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator  = new RecordExists('users', 'field1');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     /**

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -96,10 +96,7 @@ class DigitsTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -719,21 +719,15 @@ class EmailAddressTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     /**

--- a/test/ExplodeTest.php
+++ b/test/ExplodeTest.php
@@ -93,21 +93,15 @@ class ExplodeTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Explode([]);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new Explode([]);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testSetValidatorAsArray()

--- a/test/File/FileInformationTraitTest.php
+++ b/test/File/FileInformationTraitTest.php
@@ -10,12 +10,15 @@ namespace LaminasTest\Validator\File;
 
 use LaminasTest\Validator\File\TestAsset\FileInformation;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
 class FileInformationTraitTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy|StreamInterface */
     public $stream;
 

--- a/test/File/UploadTest.php
+++ b/test/File/UploadTest.php
@@ -11,6 +11,7 @@ namespace LaminasTest\Validator\File;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\UploadedFileInterface;
 
 /**
@@ -18,6 +19,8 @@ use Psr\Http\Message\UploadedFileInterface;
  */
 class UploadTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * Ensures that the validator follows expected behavior
      *
@@ -196,7 +199,7 @@ class UploadTest extends TestCase
         $upload = $this->prophesize(UploadedFileInterface::class);
         $upload->getClientFilename()->willReturn('test9');
         $upload->getError()->willReturn(8);
-        yield 'cannot write' => [['test9' => $upload->reveal()], 'test9', 'fileUploadErrorExtension'];
+        yield 'extension' => [['test9' => $upload->reveal()], 'test9', 'fileUploadErrorExtension'];
 
         $uploads['test9'] = $upload->reveal();
 

--- a/test/GreaterThanTest.php
+++ b/test/GreaterThanTest.php
@@ -84,21 +84,15 @@ class GreaterThanTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new GreaterThan(1);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new GreaterThan(1);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testCorrectInclusiveMessageReturn()

--- a/test/HexTest.php
+++ b/test/HexTest.php
@@ -71,10 +71,7 @@ class HexTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -694,13 +694,15 @@ class HostnameTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageTemplates'), 'messageTemplates', $validator);
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals($validator->getOption('messageVariables'), 'messageVariables', $validator);
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testHostnameWithOnlyIpChars()

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -159,11 +159,8 @@ class IbanTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new IbanValidator();
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testConstructorAllowsSettingOptionsViaOptionsArray()

--- a/test/IdenticalTest.php
+++ b/test/IdenticalTest.php
@@ -117,21 +117,15 @@ class IdenticalTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testValidatingStringTokenInContext()

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -230,12 +230,14 @@ class InArrayTest extends TestCase
         $validator->setStrict(InArray::COMPARE_NOT_STRICT);
         $validator->setRecursive(true);
 
+        $stringToNumericComparisonAssertion = PHP_MAJOR_VERSION < 8 ? 'assertTrue' : 'assertFalse';
+
         $this->assertEquals(InArray::COMPARE_NOT_STRICT, $validator->getStrict());
-        $this->assertTrue($validator->isValid('b'));
+        $this->$stringToNumericComparisonAssertion($validator->isValid('b'));
         $this->assertTrue($validator->isValid('a'));
         $this->assertTrue($validator->isValid('A'));
         $this->assertTrue($validator->isValid('0'));
-        $this->assertTrue($validator->isValid('1a'));
+        $this->$stringToNumericComparisonAssertion($validator->isValid('1a'));
         $this->assertTrue($validator->isValid(0));
     }
 

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -140,12 +140,13 @@ class InArrayTest extends TestCase
         $validator->setStrict(InArray::COMPARE_STRICT);
 
         $this->assertTrue($validator->getStrict());
+
+        $this->assertTrue($validator->isValid('A'));
+        $this->assertTrue($validator->isValid(0));
         $this->assertFalse($validator->isValid('b'));
         $this->assertFalse($validator->isValid('a'));
-        $this->assertTrue($validator->isValid('A'));
         $this->assertFalse($validator->isValid('0'));
         $this->assertFalse($validator->isValid('1a'));
-        $this->assertTrue($validator->isValid(0));
     }
 
     public function testNonStrictComparisons()
@@ -360,10 +361,8 @@ class InArrayTest extends TestCase
 
     public function testEqualsMessageTemplates()
     {
-        $this->assertAttributeEquals(
-            $this->validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $this->validator
-        );
+        $validator = $this->validator;
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/IpTest.php
+++ b/test/IpTest.php
@@ -368,11 +368,8 @@ class IpTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function invalidIpV4Addresses()

--- a/test/IsbnTest.php
+++ b/test/IsbnTest.php
@@ -226,10 +226,7 @@ class IsbnTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Isbn();
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/LessThanTest.php
+++ b/test/LessThanTest.php
@@ -84,21 +84,15 @@ class LessThanTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new LessThan(10);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new LessThan(10);
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function testConstructorAllowsSettingAllOptionsAsDiscreteArguments()

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -266,20 +266,14 @@ class MessageTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 }

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -995,11 +995,7 @@ class NotEmptyTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
     }
 
     public function testTypeAutoDetectionHasNoSideEffect()

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -122,21 +122,15 @@ class RegexTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Regex('//');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = new Regex('//');
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 
     public function invalidConstructorArgumentsProvider()

--- a/test/StepTest.php
+++ b/test/StepTest.php
@@ -213,25 +213,24 @@ class StepTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = new Validator\Step();
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testSetStepFloat()
     {
         $step = 0.01;
         $this->validator->setStep($step);
-        $this->assertAttributeSame($step, 'step', $this->validator);
+        $this->assertObjectHasAttribute('step', $this->validator);
+        $this->assertEquals($step, $this->validator->getStep());
     }
 
     public function testSetStepString()
     {
         $step = '0.01';
         $this->validator->setStep($step);
-        $this->assertAttributeSame((float) $step, 'step', $this->validator);
+        $this->assertObjectHasAttribute('step', $this->validator);
+        $this->assertEquals((float) $step, $this->validator->getStep());
     }
 
     public function testConstructorCanAcceptAllOptionsAsDiscreteArguments()

--- a/test/StringLengthTest.php
+++ b/test/StringLengthTest.php
@@ -154,20 +154,14 @@ class StringLengthTest extends TestCase
     public function testEqualsMessageTemplates()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageTemplates'),
-            'messageTemplates',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageTemplates', $validator);
+        $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testEqualsMessageVariables()
     {
         $validator = $this->validator;
-        $this->assertAttributeEquals(
-            $validator->getOption('messageVariables'),
-            'messageVariables',
-            $validator
-        );
+        $this->assertObjectHasAttribute('messageVariables', $validator);
+        $this->assertEquals(array_keys($validator->getOption('messageVariables')), $validator->getMessageVariables());
     }
 }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -163,7 +163,7 @@ class UriTest extends TestCase
     {
         $validator = $this->validator;
         self::assertObjectHasAttribute('messageTemplates', $validator);
-        self::assertAttributeEquals($validator->getOption('messageTemplates'), 'messageTemplates', $validator);
+        self::assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testUriHandlerCanBeSpecifiedAsString()

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -15,9 +15,11 @@ use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use Laminas\Validator\ValidatorPluginManagerFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ValidatorPluginManagerFactoryTest extends TestCase
 {
+    use ProphecyTrait;
     public function testFactoryReturnsPluginManager()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
@@ -25,14 +27,6 @@ class ValidatorPluginManagerFactoryTest extends TestCase
 
         $validators = $factory($container, ValidatorPluginManagerFactory::class);
         $this->assertInstanceOf(ValidatorPluginManager::class, $validators);
-
-        if (method_exists($validators, 'configure')) {
-            // laminas-servicemanager v3
-            $this->assertAttributeSame($container, 'creationContext', $validators);
-        } else {
-            // laminas-servicemanager v2
-            $this->assertSame($container, $validators->getServiceLocator());
-        }
     }
 
     /**

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -15,12 +15,15 @@ use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @group      Laminas_Validator
  */
 class ValidatorPluginManagerTest extends TestCase
 {
+    use ProphecyTrait;
+
     protected function setUp() : void
     {
         $this->validators = new ValidatorPluginManager(new ServiceManager);


### PR DESCRIPTION
**_Issue_** #74 

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x]  Modify composer.json to drop support for PHP less than 7.3
- [x] Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
- [x] Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [x] Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x] Modify source code in case there are incompatibilities with PHP 8.0
