### PR TITLE
Fix regression regarding InArray validator with boolean strict options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- [#83](https://github.com/laminas/laminas-validator/pull/83) Deprecates the ability to pass a boolean `strict` option to the `InArray` validator
 
 ### Removed
 
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#83](https://github.com/laminas/laminas-validator/pull/83) Fixes regression regarding boolean `strict` option in `InArray` validator
 
 ## 2.14.0 - 2021-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- [#83](https://github.com/laminas/laminas-validator/pull/83) Deprecates the ability to pass a boolean `strict` option to the `InArray` validator
+- Nothing.
 
 ### Removed
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
         <ini name="date.timezone" value="UTC"/>
         <ini name="xdebug.max_nesting_level" value="3000"/>
 
+        <!-- Disable E_USER_DEPRECATED -->
+        <ini name="error_reporting" value="16383"/>
+
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for
              Laminas\Soap and Laminas\Session, which require that headers not be sent

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,9 +27,6 @@
         <ini name="date.timezone" value="UTC"/>
         <ini name="xdebug.max_nesting_level" value="3000"/>
 
-        <!-- Disable E_USER_DEPRECATED -->
-        <ini name="error_reporting" value="16383"/>
-
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for
              Laminas\Soap and Laminas\Session, which require that headers not be sent

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -10,6 +10,9 @@ namespace Laminas\Validator;
 
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
+use function is_bool;
+use function trigger_error;
+use const E_USER_DEPRECATED;
 
 class InArray extends AbstractValidator
 {
@@ -113,12 +116,25 @@ class InArray extends AbstractValidator
      * InArray::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY
      * InArray::COMPARE_NOT_STRICT
      *
-     * @param  int $strict
+     * @param  int|bool $strict
      * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setStrict($strict)
     {
+        if (is_bool($strict)) {
+            trigger_error(
+                sprintf(
+                    'Using `boolean` to define `strict` validation of the `%1$s` validator is deprecated.' .
+                    ' Please migrate to the `%1$s::COMPARE_` constants.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $strict = $strict ? self::COMPARE_STRICT : self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY;
+        }
+
         $checkTypes = [
             self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY,    // 0
             self::COMPARE_STRICT,                                             // 1

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -11,8 +11,6 @@ namespace Laminas\Validator;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
 use function is_bool;
-use function trigger_error;
-use const E_USER_DEPRECATED;
 
 class InArray extends AbstractValidator
 {
@@ -123,15 +121,6 @@ class InArray extends AbstractValidator
     public function setStrict($strict)
     {
         if (is_bool($strict)) {
-            trigger_error(
-                sprintf(
-                    'Using `boolean` to define `strict` validation of the `%1$s` validator is deprecated.' .
-                    ' Please migrate to the `%1$s::COMPARE_` constants.',
-                    self::class
-                ),
-                E_USER_DEPRECATED
-            );
-
             $strict = $strict ? self::COMPARE_STRICT : self::COMPARE_NOT_STRICT_AND_PREVENT_STR_TO_INT_VULNERABILITY;
         }
 

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -20,6 +20,64 @@ class InArrayTest extends TestCase
     /** @var InArray */
     protected $validator;
 
+    /**
+     * @return array<string,array{0:list<mixed>,1:mixed,2:mixed}>
+     */
+    public function nonStrictValidationSet(): array
+    {
+        return [
+            'strings' => [
+                ['Y', 'N'],
+                'Y',
+                'X',
+            ],
+            'integers' => [
+                [1, 2],
+                1,
+                3,
+            ],
+            'integerish haystack' => [
+                ['1', '2'],
+                1,
+                3,
+            ],
+            'integerish values' => [
+                [1, 2],
+                '1',
+                '3',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,array{0:list<mixed>,1:mixed,2:mixed}>
+     */
+    public function strictValidationSet(): array
+    {
+        return [
+            'strings' => [
+                ['Y', 'N'],
+                'Y',
+                'X',
+            ],
+            'integers' => [
+                [1, 2],
+                1,
+                3,
+            ],
+            'integerish haystack' => [
+                ['1', '2'],
+                '1',
+                1,
+            ],
+            'integerish values' => [
+                [1, 2],
+                1,
+                '1',
+            ],
+        ];
+    }
+
     protected function setUp() : void
     {
         $this->validator = new InArray(
@@ -368,5 +426,41 @@ class InArrayTest extends TestCase
         $validator = $this->validator;
         $this->assertObjectHasAttribute('messageTemplates', $validator);
         $this->assertEquals($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
+    }
+
+    /**
+     * @param list<mixed> $haystack
+     * @param mixed $valid
+     * @param mixed $invalid
+     * @dataProvider strictValidationSet
+     * @link https://github.com/laminas/laminas-validator/issues/81
+     */
+    public function testBooleanStrictEnforcesStrictMode(array $haystack, $valid, $invalid): void
+    {
+        $validator = new InArray([
+            'haystack' => $haystack,
+            'strict'   => true,
+        ]);
+
+        self::assertTrue($validator->isValid($valid));
+        self::assertFalse($validator->isValid($invalid));
+    }
+
+    /**
+     * @param list<mixed> $haystack
+     * @param mixed $valid
+     * @param mixed $invalid
+     * @dataProvider nonStrictValidationSet
+     * @link https://github.com/laminas/laminas-validator/issues/81
+     */
+    public function testBooleanNotStrictEnforcesNonStrictMode(array $haystack, $valid, $invalid): void
+    {
+        $validator = new InArray([
+            'haystack' => $haystack,
+            'strict'   => false,
+        ]);
+
+        self::assertTrue($validator->isValid($valid));
+        self::assertFalse($validator->isValid($invalid));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Fixing regression boolean `strict` option in `InArray` validator.

Closes #81 