### PR TITLE
Removed hardcoded `version` field from `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "laminas/laminas-validator",
     "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
     "license": "BSD-3-Clause",
-    "version": "2.14.0",
     "keywords": [
         "laminas",
         "validator"


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Here we remove the `"version"` field from `composer.json`, which prevents packagist from updating its metadata for new tags.

Fixes #86