### PR TITLE
Fix Type Error when validating a `DateTimeImmutable` instance to the `DateStep` validator

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -118,7 +118,7 @@ class Date extends AbstractValidator
     /**
      * Returns true if $value is a DateTime instance or can be converted into one.
      *
-     * @param  string|array|int|DateTime $value
+     * @param  string|array|int|DateTime|DateTimeImmutable $value
      * @return bool
      */
     public function isValid($value)

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -10,6 +10,8 @@ namespace Laminas\Validator;
 
 use DateInterval;
 use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
@@ -187,7 +189,7 @@ class DateStep extends Date
     /**
      * Returns true if a date is within a valid step
      *
-     * @param  string|int|\DateTime $value
+     * @param  string|int|DateTime|DateTimeImmutable $value
      * @return bool
      * @throws Exception\InvalidArgumentException
      */
@@ -199,7 +201,12 @@ class DateStep extends Date
 
         $valueDate = $this->convertToDateTime($value, false); // avoid duplicate errors
         $baseDate  = $this->convertToDateTime($this->baseValue, false);
-        $step      = $this->getStep();
+
+        if (false === $valueDate || false === $baseDate) {
+            return false;
+        }
+
+        $step = $this->getStep();
 
         // Same date?
         if ($valueDate == $baseDate) {
@@ -338,17 +345,17 @@ class DateStep extends Date
      * iterations by starting at the lower bound of steps needed to reach
      * the target
      *
-     * @param DateTime     $baseDate
-     * @param DateTime     $valueDate
-     * @param int[]        $intervalParts
-     * @param int[]        $diffParts
-     * @param DateInterval $step
+     * @param DateTimeInterface     $baseDate
+     * @param DateTimeInterface     $valueDate
+     * @param int[]                 $intervalParts
+     * @param int[]                 $diffParts
+     * @param DateInterval          $step
      *
      * @return bool
      */
     private function fallbackIncrementalIterationLogic(
-        DateTime $baseDate,
-        DateTime $valueDate,
+        DateTimeInterface $baseDate,
+        DateTimeInterface $valueDate,
         array $intervalParts,
         array $diffParts,
         DateInterval $step

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Validator;
 
 use DateInterval;
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 use Laminas\Validator;
 use PHPUnit\Framework\TestCase;
@@ -97,8 +98,6 @@ class DateStepTest extends TestCase
 
     /**
      * @dataProvider stepTestsDataProvider
-     *
-     * @return void
      */
     public function testDateStepValidation($interval, $format, $baseValue, $value, $isValid): void
     {
@@ -109,6 +108,28 @@ class DateStepTest extends TestCase
         ]);
 
         $this->assertEquals($isValid, $validator->isValid($value));
+    }
+
+    public function testWithDateTimeType() : void
+    {
+        $validator = new Validator\DateStep([
+            'format'    => DateTime::ISO8601,
+            'baseValue' => new DateTime('1970-01-01T00:00:00Z'),
+            'step'      => new DateInterval('PT1S'),
+        ]);
+
+        $this->assertTrue($validator->isValid(new DateTime('1970-01-01T00:00:02Z')));
+    }
+
+    public function testWithDateTimeImmutableType() : void
+    {
+        $validator = new Validator\DateStep([
+            'format'    => DateTime::ISO8601,
+            'baseValue' => new DateTimeImmutable('1970-01-01T00:00:00Z'),
+            'step'      => new DateInterval('PT1S'),
+        ]);
+
+        $this->assertTrue($validator->isValid(new DateTimeImmutable('1970-01-01T00:00:02Z')));
     }
 
     public function testGetMessagesReturnsDefaultValue(): void


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `DateStep` validator fails when providing a `DateTimeImmutable` instance since the `fallbackIncrementalIterationLogic` function typehints to `DateTime`. This PR primarily fixes that issue.

Besides that I've added several typing improvements regarding `DateTime` instances and other primitives on the `Date` validator (which `DateStep` extends).
Meanwhile fixed a bunch of psalm errors as well.
