### PR TITLE
Fix immutability issue when validating a `DateTimeImmutable` instance with the `DateStep` validator

### DIFF
--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -366,13 +366,13 @@ class DateStep extends Date
         $dateModificationOperation           = $isIncrementalStepping ? 'add' : 'sub';
 
         for ($offsetIterations = 0; $offsetIterations < $requiredIterations; $offsetIterations += 1) {
-            $baseDate->{$dateModificationOperation}($minimumInterval);
+            $baseDate = $baseDate->{$dateModificationOperation}($minimumInterval);
         }
 
         while (($isIncrementalStepping && $baseDate < $valueDate)
             || (! $isIncrementalStepping && $baseDate > $valueDate)
         ) {
-            $baseDate->{$dateModificationOperation}($step);
+            $baseDate = $baseDate->{$dateModificationOperation}($step);
 
             if ($baseDate == $valueDate) {
                 return true;

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -110,26 +110,34 @@ class DateStepTest extends TestCase
         $this->assertEquals($isValid, $validator->isValid($value));
     }
 
+    /**
+     * The exact base and test value matter here.
+     * By having a different date and a step of seconds the fallbackIncrementalIterationLogic will run.
+     */
     public function testWithDateTimeType() : void
     {
         $validator = new Validator\DateStep([
             'format'    => DateTime::ISO8601,
             'baseValue' => new DateTime('1970-01-01T00:00:00Z'),
-            'step'      => new DateInterval('PT1S'),
+            'step'      => new DateInterval('PT2S'),
         ]);
 
-        $this->assertTrue($validator->isValid(new DateTime('1970-01-01T00:00:02Z')));
+        $this->assertTrue($validator->isValid(new DateTime('1970-01-03T00:00:02Z')));
     }
 
+    /**
+     * The exact base and test value matter here.
+     * By having a different date and a step of seconds the fallbackIncrementalIterationLogic will run.
+     */
     public function testWithDateTimeImmutableType() : void
     {
         $validator = new Validator\DateStep([
             'format'    => DateTime::ISO8601,
             'baseValue' => new DateTimeImmutable('1970-01-01T00:00:00Z'),
-            'step'      => new DateInterval('PT1S'),
+            'step'      => new DateInterval('PT2S'),
         ]);
 
-        $this->assertTrue($validator->isValid(new DateTimeImmutable('1970-01-01T00:00:02Z')));
+        $this->assertTrue($validator->isValid(new DateTimeImmutable('1970-01-03T00:00:02Z')));
     }
 
     public function testGetMessagesReturnsDefaultValue(): void


### PR DESCRIPTION
See #89, but this one actually fixes the bug.