### PR TITLE
Add docs for csrf validator to 2.14.x

### DIFF
--- a/docs/book/set.md
+++ b/docs/book/set.md
@@ -6,6 +6,7 @@ The following validators come with the laminas-validator distribution.
 - [Between](validators/between.md)
 - [Callback](validators/callback.md)
 - [CreditCard](validators/credit-card.md)
+- [CSRF (Cross-site request forgery](validators/csrf.md)
 - [Date](validators/date.md)
 - [RecordExists and NoRecordExists (database)](validators/db.md)
 - [Digits](validators/digits.md)

--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -9,15 +9,15 @@ The typical mitigation is to create a one-time token that is transmitted as part
 This token expires after first submission or after a short amount of time, preventing replays or further submissions.
 If the token provided does not match what was originally sent, an error should be returned.
 
-## Installation Requirements
-
-The CSRF validator depends on [laminas-math](https://docs.laminas.dev/laminas-math/) to generate the hash and on [laminas-session](https://docs.laminas.dev/laminas-session/) to persist the generated token between requests.
-Consequently, both components must be installed before the validator can be used.
-To install both components, run the following command.
-
-```bash
-composer require laminas/laminas-math laminas/laminas-session
-```
+> ### Installation Requirements
+>
+> The CSRF validator depends on [laminas-math](https://docs.laminas.dev/laminas-math/) to generate the hash and on [laminas-session](https://docs.laminas.dev/laminas-session/) to persist the generated token between requests.
+> Consequently, both components must be installed before the validator can be used.
+> To install both components, run the following command.
+>
+> ```bash
+> composer require laminas/laminas-math laminas/laminas-session
+> ```
 
 ## Supported Options
 

--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -32,15 +32,11 @@ Before you can use this validator, you have to install the following, additional
 Here is a basic, working, example.
 
 ```php
-<?php
-
-use Laminas\Session\Container;
-
-require_once('vendor/autoload.php');
-
 // Initialise a new session container
 // or use the existing one in your application
-$session = new Container();
+$session = new Laminas\Session\Container();
+
+// Create the validator
 $validator = new Laminas\Validator\Csrf([
     'session' => $session,
 ]);
@@ -53,4 +49,3 @@ echo ($validator->isValid($hash))
     ? "Token is valid"
     : "Token is NOT valid";
 ```
-

--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -9,7 +9,17 @@ The typical mitigation is to create a one-time token that is transmitted as part
 This token expires after first submission or after a short amount of time, preventing replays or further submissions.
 If the token provided does not match what was originally sent, an error should be returned.
 
-## Supported options
+## Installation Requirements
+
+The CSRF validator depends on [laminas-math](https://docs.laminas.dev/laminas-math/) to generate the hash and on [laminas-session](https://docs.laminas.dev/laminas-session/) to persist the generated token between requests.
+Consequently, both components must be installed before the validator can be used.
+To install both components, run the following command.
+
+```bash
+composer require laminas/laminas-math laminas/laminas-session
+```
+
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Csrf`.
 
@@ -20,16 +30,9 @@ The following options are supported for `Laminas\Validator\Csrf`.
 | `session` | The name of the session element containing the CSRF element | **Mandatory** |
 | `timeout` | The [TTL](https://en.wikipedia.org/wiki/Time_to_live) for the CSRF token | Optional |
 
-## Library requirements
-
-Before you can use this validator, you have to install the following, additional, packages:
-
-- [laminas-math](https://docs.laminas.dev/laminas-math/)
-- [laminas-session](https://docs.laminas.dev/laminas-session/)
-
 ## Basic Usage
 
-Here is a basic, working, example.
+Here is a basic example.
 
 ```php
 // Initialise a new session container

--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -1,0 +1,56 @@
+# CSRF Validator
+
+`Laminas\Validator\Csrf` provides the ability to both generate and validate CSRF tokens.
+This allows you to validate if a form submission originated from the same site, by confirming the value of the CSRF field in the submitted form is the same as the one contained in the original form.
+
+[Cross-Site Request Forgery (CSRF)](https://en.wikipedia.org/wiki/Cross-site_request_forgery) is a security vector in which an unauthorized request is accepted by a server on behalf of another user; it is essentially an exploit of the trust a site places on a user's browser.
+
+The typical mitigation is to create a one-time token that is transmitted as part of the original form, and which must then be transmitted back by the client.
+This token expires after first submission or after a short amount of time, preventing replays or further submissions.
+If the token provided does not match what was originally sent, an error should be returned.
+
+## Supported options
+
+The following options are supported for `Laminas\Validator\Csrf`.
+
+| Option | Description | Optional/Mandatory |
+|-|-|-|
+| `name` | The name of the CSRF element | Optional |
+| `salt` | The salt for the CSRF token | Optional |
+| `session` | The name of the session element containing the CSRF element | **Mandatory** |
+| `timeout` | The [TTL](https://en.wikipedia.org/wiki/Time_to_live) for the CSRF token | Optional |
+
+## Library requirements
+
+Before you can use this validator, you have to install the following, additional, packages:
+
+- [laminas-math](https://docs.laminas.dev/laminas-math/)
+- [laminas-session](https://docs.laminas.dev/laminas-session/)
+
+## Basic usages
+
+Here is a basic, working, example.
+
+```php
+<?php
+
+use Laminas\Session\Container;
+
+require_once('vendor/autoload.php');
+
+// Initialise a new session container
+// or use the existing one in your application
+$session = new Container();
+$validator = new Laminas\Validator\Csrf([
+    'session' => $session,
+]);
+$hash = $validator->getHash();
+
+// ...Render the hash in the form.
+
+// Validate the hash after form submission.
+echo ($validator->isValid($hash))
+    ? "Token is valid"
+    : "Token is NOT valid";
+```
+

--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -27,7 +27,7 @@ Before you can use this validator, you have to install the following, additional
 - [laminas-math](https://docs.laminas.dev/laminas-math/)
 - [laminas-session](https://docs.laminas.dev/laminas-session/)
 
-## Basic usages
+## Basic Usage
 
 Here is a basic, working, example.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
             - Between: validators/between.md
             - Callback: validators/callback.md
             - CreditCard: validators/credit-card.md
+            - Csrf: validators/csrf.md
             - Date: validators/date.md
             - "Db\\RecordExists and Db\\NoRecordExists": validators/db.md
             - Digits: validators/digits.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Adding initial documentation on the CSRF validator.

**Note:** I'm opening this PR in place of #99 as there was corruption on the branch after changing the base branch from 2.15.x to 2.14.x.
