### PR TITLE
File extension comparison treats some distinct extensions as equal #98

### DIFF
--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -60,7 +60,7 @@ class ExcludeExtension extends Extension
             return true;
         } elseif (! $this->getCase()) {
             foreach ($extensions as $ext) {
-                if (strtolower($ext) == strtolower($extension)) {
+                if (strtolower($ext) === strtolower($extension)) {
                     if (preg_match('/nofile\.mo$/', $fileInfo['file'])) {
                     }
                     $this->error(self::FALSE_EXTENSION);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This change is necessary because it fixes a bug of file extension comparison
  - You can reproduce the bug trying to compare a file with extension '10' with another with extension '010'
  - Class ExcludeExtension must return FALSE, because extensions are different
  - However, current implementation will said that both of files have the same extension.
  - TARGET THE master BRANCH

