### PR TITLE
Fix regression in `RoyalMail` barcode validation due to type mismatch in checksum verification

### DIFF
--- a/src/Barcode/Royalmail.php
+++ b/src/Barcode/Royalmail.php
@@ -124,7 +124,7 @@ class Royalmail extends AbstractAdapter
         $rowchkvalue = array_keys($this->rows, $rowvalue);
         $colchkvalue = array_keys($this->columns, $colvalue);
         $intersect   = array_intersect($rowchkvalue, $colchkvalue);
-        $chkvalue    = (string)current($intersect);
+        $chkvalue    = (string) current($intersect);
 
         if ($chkvalue === $checksum) {
             return true;

--- a/src/Barcode/Royalmail.php
+++ b/src/Barcode/Royalmail.php
@@ -124,7 +124,8 @@ class Royalmail extends AbstractAdapter
         $rowchkvalue = array_keys($this->rows, $rowvalue);
         $colchkvalue = array_keys($this->columns, $colvalue);
         $intersect   = array_intersect($rowchkvalue, $colchkvalue);
-        $chkvalue    = current($intersect);
+        $chkvalue    = (string)current($intersect);
+
         if ($chkvalue === $checksum) {
             return true;
         }

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -2,7 +2,6 @@
 
 namespace LaminasTest\Validator;
 
-use Laminas\Config\Config;
 use Laminas\Validator\Barcode;
 use Laminas\Validator\Barcode\AdapterInterface;
 use Laminas\Validator\Barcode\Ean13;
@@ -163,19 +162,13 @@ class BarcodeTest extends TestCase
 
     public function testConfigConstructAdapter(): void
     {
-        $array  = ['adapter' => 'Ean13', 'options' => 'unknown', 'useChecksum' => false];
-        $config = new Config($array);
-
-        $barcode = new Barcode($config);
+        $barcode = new Barcode(['adapter' => 'Ean13', 'options' => 'unknown', 'useChecksum' => false]);
         $this->assertTrue($barcode->isValid('0075678164125'));
     }
 
     public function testRoyalmailIsValid(): void
     {
-        $array  = ['adapter' => 'Royalmail', 'useChecksum' => true];
-        $config = new Config($array);
-
-        $barcode = new Barcode($config);
+        $barcode = new Barcode(['adapter' => 'Royalmail', 'useChecksum' => true]);
         $this->assertTrue($barcode->isValid('1234562'));
     }
 

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -170,6 +170,15 @@ class BarcodeTest extends TestCase
         $this->assertTrue($barcode->isValid('0075678164125'));
     }
 
+    public function testRoyalmailIsValid(): void
+    {
+        $array  = ['adapter' => 'Royalmail', 'useChecksum' => true];
+        $config = new Config($array);
+
+        $barcode = new Barcode($config);
+        $this->assertTrue($barcode->isValid('1234562'));
+    }
+
     public function testCODE25(): void
     {
         $barcode = new Barcode('code25');


### PR DESCRIPTION
Discovered in Fedora CI for laminas/barcode
https://koschei.fedoraproject.org/package/php-laminas-barcode

```
There was 1 error:
1) LaminasTest\Barcode\Object\RoyalmailTest::testProvidedChecksum
Laminas\Barcode\Object\Exception\BarcodeValidationException: The input failed checksum validation
/builddir/build/BUILDROOT/php-laminas-barcode-2.9.0-2.fc35.noarch/usr/share/php/Laminas/Barcode/Object/AbstractObject.php:1313
/builddir/build/BUILDROOT/php-laminas-barcode-2.9.0-2.fc35.noarch/usr/share/php/Laminas/Barcode/Object/AbstractObject.php:1284
/builddir/build/BUILDROOT/php-laminas-barcode-2.9.0-2.fc35.noarch/usr/share/php/Laminas/Barcode/Object/AbstractObject.php:959
/builddir/build/BUILDROOT/php-laminas-barcode-2.9.0-2.fc35.noarch/usr/share/php/Laminas/Barcode/Object/AbstractObject.php:633
/builddir/build/BUILD/laminas-barcode-74034895076d2305ce6716f93dd8d821f3c1e4fc/test/Object/RoyalmailTest.php:151
```

Since https://github.com/laminas/laminas-validator/commit/641382417563a3995809788bf9c462f8e6963b75

```
-        if ($chkvalue == $checksum) {
+        if ($chkvalue === $checksum) {
```

As `$checksum` is a string (result of substr), `$chkvalue `  must also be a string.

