### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,5 @@
+{
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -66,12 +66,7 @@
     },
     "autoload-dev": {
         "files": [
-            "test/TestAsset/Db/AbstractResultSet.php",
-            "test/TestAsset/Db/Join.php",
-            "test/TestAsset/Db/ParameterContainer.php",
-            "test/TestAsset/Db/PredicateSet.php",
-            "test/TestAsset/Db/ResultSet.php",
-            "test/TestAsset/Uri/Uri.php"
+            "test/autoload.php"
         ],
         "psr-4": {
             "LaminasTest\\Validator\\": "test/"

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,9 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "container-interop/container-interop": "^1.1",
-        "laminas/laminas-stdlib": "^3.3",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-stdlib": "^3.3"
     },
     "require-dev": {
         "laminas/laminas-cache": "^2.6.1",
@@ -43,7 +42,7 @@
         "laminas/laminas-session": "^2.8",
         "laminas/laminas-uri": "^2.7",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.15.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
@@ -82,7 +81,7 @@
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "static-analysis": "psalm --shepherd --stats"
     },
-    "replace": {
-        "zendframework/zend-validator": "^2.13.0"
+    "conflict": {
+        "zendframework/zend-validator": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,13 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "test/TestAsset/Db/AbstractResultSet.php",
+            "test/TestAsset/Db/Join.php",
+            "test/TestAsset/Db/ParameterContainer.php",
+            "test/TestAsset/Db/PredicateSet.php",
+            "test/TestAsset/Db/ResultSet.php"
+        ],
         "psr-4": {
             "LaminasTest\\Validator\\": "test/"
         }

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
             "test/TestAsset/Db/Join.php",
             "test/TestAsset/Db/ParameterContainer.php",
             "test/TestAsset/Db/PredicateSet.php",
-            "test/TestAsset/Db/ResultSet.php"
+            "test/TestAsset/Db/ResultSet.php",
+            "test/TestAsset/Uri/Uri.php"
         ],
         "psr-4": {
             "LaminasTest\\Validator\\": "test/"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "require-dev": {
         "laminas/laminas-cache": "^2.6.1",
         "laminas/laminas-coding-standard": "~2.2.1",
-        "laminas/laminas-config": "^2.6",
         "laminas/laminas-db": "^2.7",
         "laminas/laminas-filter": "^2.6",
         "laminas/laminas-http": "^2.14.2",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "container-interop/container-interop": "^1.1",
-        "laminas/laminas-stdlib": "^3.3"
+        "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
         "laminas/laminas-cache": "^2.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -2041,31 +2041,31 @@
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "966c859b67867b179fde1eff0cd38df51472ce4a"
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/966c859b67867b179fde1eff0cd38df51472ce4a",
-                "reference": "966c859b67867b179fde1eff0cd38df51472ce4a",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-eventmanager": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
                 "container-interop/container-interop": "^1.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
-                "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "^8.5.8"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-stdlib": "^3.6",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
@@ -2103,7 +2103,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-03-08T15:24:29+00:00"
+            "time": "2021-09-07T22:35:32+00:00"
         },
         {
             "name": "laminas/laminas-filter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bac4c172b99d1afb1fb682b753b157d5",
+    "content-hash": "a68b095d762a094deafcfa2474ea2a2b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -44,24 +44,23 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.4.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "e89c2268c9cad25099f562f7f015c28c5dd383c9"
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e89c2268c9cad25099f562f7f015c28c5dd383c9",
-                "reference": "e89c2268c9cad25099f562f7f015c28c5dd383c9",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/c53d8537f108fac3fae652677a19735db730ba46",
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-stdlib": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.3.0",
@@ -100,69 +99,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-06-28T21:37:31+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
-                "reference": "13af2502d9bb6f7d33be2de4b51fb68c6cdb476e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-06-24T12:49:22+00:00"
+            "time": "2021-09-02T16:11:32+00:00"
         },
         {
             "name": "psr/container",
@@ -216,27 +153,27 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.5.2",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6.0.9 | ^7",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
                 "psalm/phar": "^3.11@dev",
                 "react/promise": "^2"
             },
@@ -293,7 +230,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+                "source": "https://github.com/amphp/amp/tree/v2.6.0"
             },
             "funding": [
                 {
@@ -301,7 +238,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-10T17:06:37+00:00"
+            "time": "2021-07-16T20:06:06+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -382,16 +319,16 @@
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.2",
+            "version": "1.11.99.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+                "reference": "fff576ac850c045158a250e7e27666e146e78d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
-                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/fff576ac850c045158a250e7e27666e146e78d18",
+                "reference": "fff576ac850c045158a250e7e27666e146e78d18",
                 "shasum": ""
             },
             "require": {
@@ -435,7 +372,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.3"
             },
             "funding": [
                 {
@@ -451,7 +388,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-24T07:46:03+00:00"
+            "time": "2021-08-17T13:49:14+00:00"
         },
         {
             "name": "composer/semver",
@@ -536,21 +473,21 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.55",
@@ -580,7 +517,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
             },
             "funding": [
                 {
@@ -596,7 +533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-05T19:37:51+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -877,16 +814,16 @@
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "2.11.3",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "775cf8815cfd5a654f9b7b341ebaf28e72aa457d"
+                "reference": "566948e32f30881cb903ffbd0e3e20dac00cd83e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/775cf8815cfd5a654f9b7b341ebaf28e72aa457d",
-                "reference": "775cf8815cfd5a654f9b7b341ebaf28e72aa457d",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/566948e32f30881cb903ffbd0e3e20dac00cd83e",
+                "reference": "566948e32f30881cb903ffbd0e3e20dac00cd83e",
                 "shasum": ""
             },
             "require": {
@@ -913,6 +850,9 @@
                 "psr/cache": "^1.0",
                 "psr/simple-cache": "^1.0"
             },
+            "conflict": {
+                "symfony/console": "<5.1"
+            },
             "provide": {
                 "psr/cache-implementation": "1.0",
                 "psr/simple-cache-implementation": "1.0"
@@ -921,13 +861,17 @@
                 "zendframework/zend-cache": "^2.9.0"
             },
             "require-dev": {
+                "laminas/laminas-cli": "^1.0",
                 "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config-aggregator": "^1.5",
+                "laminas/laminas-feed": "^2.14",
                 "laminas/laminas-serializer": "^2.6",
                 "phpbench/phpbench": "^1.0.0-beta2",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5"
             },
             "suggest": {
+                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
                 "laminas/laminas-serializer": "Laminas\\Serializer component"
             },
             "type": "library",
@@ -971,7 +915,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-07-08T18:22:59+00:00"
+            "time": "2021-08-08T10:21:18+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-apc",
@@ -1223,16 +1167,16 @@
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-ext-mongodb",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb.git",
-                "reference": "5810c3ffb442527b8b3429b0d29dce1ddabc92f2"
+                "reference": "72f68589cc8323fa688167a4720b795dd0907f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-ext-mongodb/zipball/5810c3ffb442527b8b3429b0d29dce1ddabc92f2",
-                "reference": "5810c3ffb442527b8b3429b0d29dce1ddabc92f2",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-ext-mongodb/zipball/72f68589cc8323fa688167a4720b795dd0907f4e",
+                "reference": "72f68589cc8323fa688167a4720b795dd0907f4e",
                 "shasum": ""
             },
             "require": {
@@ -1248,10 +1192,11 @@
             "require-dev": {
                 "laminas/laminas-cache": "^2.10.3",
                 "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.0",
                 "laminas/laminas-serializer": "^2.10.1",
                 "mongodb/mongodb": "^1.8.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.9"
             },
             "suggest": {
                 "mongodb/mongodb": "MongoDB, to use the ExtMongoDb storage adapter"
@@ -1284,7 +1229,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-05-06T07:52:48+00:00"
+            "time": "2021-08-10T18:17:48+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-filesystem",
@@ -1413,20 +1358,20 @@
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memcached",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memcached.git",
-                "reference": "f5d35cc2ef6264c76021bcc798569182103baa91"
+                "reference": "d05f33e43a352b85c6d0208e9cfbf2a59f02ede3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcached/zipball/f5d35cc2ef6264c76021bcc798569182103baa91",
-                "reference": "f5d35cc2ef6264c76021bcc798569182103baa91",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcached/zipball/d05f33e43a352b85c6d0208e9cfbf2a59f02ede3",
+                "reference": "d05f33e43a352b85c6d0208e9cfbf2a59f02ede3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1437,9 +1382,8 @@
             "require-dev": {
                 "laminas/laminas-cache": "^2.10",
                 "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^7.5.20",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "phpunit/phpunit": "^9.5.8"
             },
             "suggest": {
                 "ext-memcached": "Memcached >= 1.0.0 to use the Memcached storage adapter"
@@ -1473,7 +1417,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-04-24T20:06:16+00:00"
+            "time": "2021-08-08T14:51:12+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
@@ -2103,24 +2047,23 @@
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "2d6dce99668b413610e9544183fa10392437f542"
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/2d6dce99668b413610e9544183fa10392437f542",
-                "reference": "2d6dce99668b413610e9544183fa10392437f542",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-escaper": "^2.6.1"
+            "conflict": {
+                "zendframework/zend-escaper": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.3.0",
@@ -2162,7 +2105,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-06-26T14:26:08+00:00"
+            "time": "2021-09-02T17:10:53+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
@@ -2380,16 +2323,16 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.11.1",
+            "version": "2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "5e85a8facc5534e856cc7f5b4326533eede84b8a"
+                "reference": "78adb53ebf6c0bc63f92273fd7809dabc554f786"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/5e85a8facc5534e856cc7f5b4326533eede84b8a",
-                "reference": "5e85a8facc5534e856cc7f5b4326533eede84b8a",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/78adb53ebf6c0bc63f92273fd7809dabc554f786",
+                "reference": "78adb53ebf6c0bc63f92273fd7809dabc554f786",
                 "shasum": ""
             },
             "require": {
@@ -2461,31 +2404,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-04-07T21:10:50+00:00"
+            "time": "2021-08-20T08:23:04+00:00"
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "bcf8a566cb9925a2e7cc41a16db09235ec9fb616"
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/bcf8a566cb9925a2e7cc41a16db09235ec9fb616",
-                "reference": "bcf8a566cb9925a2e7cc41a16db09235ec9fb616",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-loader": "^2.6.1"
+            "conflict": {
+                "zendframework/zend-loader": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "phpunit/phpunit": "^9.3"
             },
             "type": "library",
@@ -2518,7 +2460,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-12T16:08:18+00:00"
+            "time": "2021-09-02T18:30:53+00:00"
         },
         {
             "name": "laminas/laminas-math",
@@ -2584,16 +2526,16 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.6.4",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
+                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
                 "shasum": ""
             },
             "require": {
@@ -2616,14 +2558,16 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.0",
                 "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.8",
                 "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.0-alpha3",
+                "phpbench/phpbench": "^1.0.4",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.4",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -2667,7 +2611,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-03T08:44:41+00:00"
+            "time": "2021-07-24T19:33:07+00:00"
         },
         {
             "name": "laminas/laminas-session",
@@ -2811,6 +2755,68 @@
             "time": "2021-02-17T21:53:05+00:00"
         },
         {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-03T17:53:30+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.10.2",
             "source": {
@@ -2921,16 +2927,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.11.0",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/fe14cf3672a149364fb66dfe11bf6549af899f94",
-                "reference": "fe14cf3672a149364fb66dfe11bf6549af899f94",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -2971,9 +2977,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.11.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
-            "time": "2021-07-03T13:36:55+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -3030,16 +3036,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -3084,9 +3090,9 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -3789,16 +3795,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.6",
+            "version": "9.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
-                "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
                 "shasum": ""
             },
             "require": {
@@ -3810,7 +3816,7 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
@@ -3876,7 +3882,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
             },
             "funding": [
                 {
@@ -3888,7 +3894,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-23T05:14:38+00:00"
+            "time": "2021-08-31T06:47:40+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -5113,6 +5119,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
@@ -5343,16 +5350,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.2",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
-                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
                 "shasum": ""
             },
             "require": {
@@ -5360,11 +5367,12 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2",
                 "symfony/string": "^5.1"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -5372,10 +5380,10 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^4.4|^5.0",
@@ -5421,7 +5429,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.2"
+                "source": "https://github.com/symfony/console/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -5437,7 +5445,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-12T09:42:48+00:00"
+            "time": "2021-08-25T20:02:16+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5587,16 +5595,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
-                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
                 "shasum": ""
             },
             "require": {
@@ -5648,7 +5656,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5664,7 +5672,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:17:38+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -5752,16 +5760,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
-                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -5812,7 +5820,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5828,7 +5836,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:27:20+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -5911,16 +5919,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -5974,7 +5982,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5990,7 +5998,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6073,16 +6081,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.3",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
-                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
                 "shasum": ""
             },
             "require": {
@@ -6136,7 +6144,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.3"
+                "source": "https://github.com/symfony/string/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -6152,20 +6160,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-27T11:44:38+00:00"
+            "time": "2021-08-26T08:00:08+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -6194,7 +6202,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -6202,20 +6210,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.8.1",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69"
+                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f73f2299dbc59a3e6c4d66cff4605176e728ee69",
-                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/916b098b008f6de4543892b1e0651c1c3b92cbfa",
+                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa",
                 "shasum": ""
             },
             "require": {
@@ -6225,6 +6233,7 @@
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^1.1 || ^2.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -6234,7 +6243,7 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.10.5",
+                "nikic/php-parser": "^4.12",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
@@ -6257,7 +6266,6 @@
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3 || ^5.0",
-                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
@@ -6305,9 +6313,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.8.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.10.0"
             },
-            "time": "2021-06-20T23:03:20+00:00"
+            "time": "2021-09-04T21:00:09+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -6479,7 +6487,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a68b095d762a094deafcfa2474ea2a2b",
+    "content-hash": "7941e2cc92df01b90bdea881c31889ce",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1903,74 +1903,6 @@
                 }
             ],
             "time": "2021-05-17T17:39:41+00:00"
-        },
-        {
-            "name": "laminas/laminas-config",
-            "version": "2.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "71ba6d5dd703196ce66b25abc4d772edb094dae1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/71ba6d5dd703196ce66b25abc4d772edb094dae1",
-                "reference": "71ba6d5dd703196ce66b25abc4d772edb094dae1",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^2.7 || ^3.0",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.5 || ^7.0"
-            },
-            "replace": {
-                "zendframework/zend-config": "self.version"
-            },
-            "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "laminas/laminas-filter": "^2.6",
-                "laminas/laminas-i18n": "^2.5",
-                "laminas/laminas-json": "^2.6.1",
-                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "laminas/laminas-filter": "Laminas\\Filter component",
-                "laminas/laminas-i18n": "Laminas\\I18n component",
-                "laminas/laminas-json": "Laminas\\Json to use the Json reader or writer classes",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager for use with the Config Factory to retrieve reader and writer instances"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Config\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides a nested object property based user interface for accessing this configuration data within application code",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "config",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-config/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-config/issues",
-                "rss": "https://github.com/laminas/laminas-config/releases.atom",
-                "source": "https://github.com/laminas/laminas-config"
-            },
-            "time": "2019-12-31T16:30:04+00:00"
         },
         {
             "name": "laminas/laminas-db",
@@ -6490,5 +6422,5 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7941e2cc92df01b90bdea881c31889ce",
+    "content-hash": "bc4f33831a23b75ea9e304229fc02605",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2264,9 +2264,6 @@
     <MixedOperand occurrences="1">
       <code>$_SERVER['REQUEST_TIME']</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>testTimeoutIsMutable</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
     <DeprecatedMethod occurrences="2">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
   <file src="bin/update_hostname_validator.php">
     <MissingClosureParamType occurrences="2">
       <code>$domain</code>
@@ -41,10 +41,11 @@
       <code>$this-&gt;options</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion occurrences="4">
       <code>$key</code>
       <code>$key</code>
       <code>$messageKey</code>
+      <code>$value</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="5">
       <code>$this-&gt;messageVariables[$property]</code>
@@ -492,24 +493,17 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$operator</code>
     </InvalidPropertyAssignmentValue>
-    <MixedAssignment occurrences="4">
-      <code>$result</code>
+    <MixedAssignment occurrences="3">
       <code>$temp['control']</code>
       <code>$temp['operator']</code>
       <code>$temp['strict']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>bool</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="4">
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$result</code>
-    </MixedReturnStatement>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$temp</code>
     </PossiblyUndefinedVariable>
@@ -641,6 +635,9 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Date.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$value</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="1">
       <code>$temp['format']</code>
     </MixedAssignment>
@@ -668,6 +665,10 @@
       <code>$step</code>
       <code>$timezone</code>
     </PropertyNotSetInConstructor>
+    <TypeDoesNotContainType occurrences="2">
+      <code>$baseDate instanceof DateTime || $baseDate instanceof DateTimeImmutable</code>
+      <code>$baseDate instanceof DateTimeImmutable</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Db/AbstractDb.php">
     <MixedArgument occurrences="8">
@@ -1046,6 +1047,9 @@
       <code>$fileInfo['filename']</code>
       <code>$this-&gt;options['extension']</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$extensions</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="5">
       <code>$case</code>
       <code>$case</code>
@@ -1297,6 +1301,9 @@
       <code>static::NOT_DETECTED</code>
       <code>static::NOT_READABLE</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$mimetypes</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="4">
       <code>$file</code>
       <code>$mime</code>
@@ -1558,9 +1565,6 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
-      <code>str_word_count($content)</code>
-    </PossiblyInvalidPropertyAssignmentValue>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$count</code>
     </PropertyNotSetInConstructor>
@@ -2188,9 +2192,8 @@
       <code>06510000.4327</code>
       <code>106510000.4327</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message['barcodeInvalidLength']</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
   </file>
   <file src="test/BetweenTest.php">
@@ -2198,9 +2201,9 @@
       <code>1</code>
     </InvalidArgument>
     <LessSpecificReturnStatement occurrences="1"/>
-    <MixedArgument occurrences="1">
-      <code>$validator-&gt;getOption('messageVariables')</code>
-    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$validator-&gt;getMessages()</code>
+    </MixedArgumentTypeCoercion>
     <MixedOperand occurrences="1">
       <code>$value</code>
     </MixedOperand>
@@ -2216,14 +2219,6 @@
       <code>0x1</code>
       <code>0x1</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
-      <code>$validator::NOT_AND</code>
-      <code>$validator::NOT_AND_STRICT</code>
-    </MixedArgument>
-    <MixedArrayOffset occurrences="2">
-      <code>$messages[$validator::NOT_AND]</code>
-      <code>$messages[$validator::NOT_AND_STRICT]</code>
-    </MixedArrayOffset>
   </file>
   <file src="test/CallbackTest.php">
     <MissingClosureParamType occurrences="5">
@@ -2251,11 +2246,6 @@
     <MixedArgument occurrences="1">
       <code>current($message)</code>
     </MixedArgument>
-    <PossiblyInvalidArgument occurrences="3">
-      <code>testJcbCard</code>
-      <code>testMastercardCard</code>
-      <code>testMirCard</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="test/CsrfTest.php">
     <InvalidArgument occurrences="1">
@@ -2282,11 +2272,6 @@
       <code>testTimeoutIsMutable</code>
     </PossiblyInvalidArgument>
     <TooManyArguments occurrences="1"/>
-  </file>
-  <file src="test/DateTest.php">
-    <MixedArgument occurrences="1">
-      <code>$validator-&gt;getOption('messageVariables')</code>
-    </MixedArgument>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
     <DeprecatedMethod occurrences="2">
@@ -2366,8 +2351,7 @@
     <InvalidCast occurrences="1">
       <code>[1 =&gt; 1]</code>
     </InvalidCast>
-    <MixedArgument occurrences="12">
-      <code>$validator-&gt;getOption('messageVariables')</code>
+    <MixedArgument occurrences="11">
       <code>current($messages)</code>
       <code>current($messages)</code>
       <code>current($messages)</code>
@@ -2380,6 +2364,19 @@
       <code>next($messages)</code>
       <code>next($messages)</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="11">
+      <code>$this-&gt;validator-&gt;getMessages()</code>
+      <code>$this-&gt;validator-&gt;getMessages()</code>
+      <code>$this-&gt;validator-&gt;getMessages()</code>
+      <code>$this-&gt;validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="6">
       <code>$message</code>
       <code>$message</code>
@@ -2407,9 +2404,6 @@
       <code>$c</code>
       <code>$v</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="1">
-      <code>$validator-&gt;getOption('messageVariables')</code>
-    </MixedArgument>
     <UnusedClosureParam occurrences="1">
       <code>$v</code>
     </UnusedClosureParam>
@@ -2645,9 +2639,8 @@
       <code>10</code>
       <code>10</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$options</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
     <PossiblyInvalidArgument occurrences="1">
       <code>testBasic</code>
@@ -2663,9 +2656,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$input</code>
     </InvalidScalarArgument>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>testBasic</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="test/HostnameTest.php">
     <InvalidArgument occurrences="14">
@@ -2687,9 +2677,11 @@
     <InvalidCast occurrences="1">
       <code>[1 =&gt; 1]</code>
     </InvalidCast>
-    <MixedArgument occurrences="1">
-      <code>$validator-&gt;getOption('messageVariables')</code>
-    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$this-&gt;validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+      <code>$validator-&gt;getMessages()</code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="1">
       <code>$translations[$code]</code>
     </MixedArrayOffset>
@@ -2711,11 +2703,13 @@
     <InvalidCast occurrences="1">
       <code>[]</code>
     </InvalidCast>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>array_merge($validator-&gt;getMessages())</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="test/IdenticalTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$context</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
   </file>
   <file src="test/IsCountableTest.php">
@@ -2757,18 +2751,14 @@
       <code>10</code>
       <code>10</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$options</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
     <PossiblyInvalidArgument occurrences="1">
       <code>testBasic</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/MessageTest.php">
-    <MixedArgument occurrences="1">
-      <code>$validator-&gt;getOption('messageVariables')</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$var</code>
     </MixedAssignment>
@@ -2819,11 +2809,13 @@
     <InvalidCast occurrences="1">
       <code>[1 =&gt; 1]</code>
     </InvalidCast>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$options</code>
       <code>$options</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$validator-&gt;getMessages()</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="test/Sitemap/ChangefreqTest.php">
     <InvalidScalarArgument occurrences="1">
@@ -2904,9 +2896,8 @@
     <InvalidCast occurrences="1">
       <code>[1 =&gt; 1]</code>
     </InvalidCast>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$options</code>
-      <code>$validator-&gt;getOption('messageVariables')</code>
     </MixedArgument>
   </file>
   <file src="test/TimezoneTest.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -619,9 +619,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullArgument occurrences="1">
-      <code>$hash</code>
-    </PossiblyNullArgument>
     <PossiblyNullArrayOffset occurrences="1">
       <code>$session-&gt;tokenList</code>
     </PossiblyNullArrayOffset>
@@ -1040,12 +1037,11 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/File/Extension.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$ext</code>
       <code>$fileInfo['file']</code>
       <code>$fileInfo['filename']</code>
       <code>$fileInfo['filename']</code>
-      <code>$this-&gt;options['extension']</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$extensions</code>
@@ -2271,7 +2267,6 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>testTimeoutIsMutable</code>
     </PossiblyInvalidArgument>
-    <TooManyArguments occurrences="1"/>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
     <DeprecatedMethod occurrences="2">

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -355,6 +355,10 @@ class Csrf extends AbstractValidator
 
     protected function getTokenFromHash(?string $hash): ?string
     {
+        if (null === $hash) {
+            return null;
+        }
+
         $data = explode('-', $hash);
         return $data[0] ?: null;
     }

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -121,6 +121,13 @@ class Extension extends AbstractValidator
      */
     public function getExtension()
     {
+        if (
+            ! array_key_exists('extension', $this->options)
+            || ! is_string($this->options['extension'])
+        ) {
+            return [];
+        }
+
         return explode(',', $this->options['extension']);
     }
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 
 namespace Laminas\Validator;
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -5,6 +5,7 @@ namespace Laminas\Validator;
 use Countable;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\PriorityQueue;
+use ReturnTypeWillChange;
 
 use function array_replace_recursive;
 use function count;
@@ -51,6 +52,7 @@ class ValidatorChain implements
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->validators);

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Validator;
 
-use Laminas\Config\Config;
+use ArrayObject;
 use Laminas\Validator\Barcode;
 use Laminas\Validator\Barcode\AdapterInterface;
 use Laminas\Validator\Barcode\Ean13;
@@ -161,10 +161,10 @@ class BarcodeTest extends TestCase
         $this->assertTrue($barcode->isValid('0075678164125'));
     }
 
-    public function testConfigConstructAdapter(): void
+    public function testTraversableConstructAdapter(): void
     {
         $array  = ['adapter' => 'Ean13', 'options' => 'unknown', 'useChecksum' => false];
-        $config = new Config($array);
+        $config = new ArrayObject($array);
 
         $barcode = new Barcode($config);
         $this->assertTrue($barcode->isValid('0075678164125'));

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -319,7 +319,7 @@ class CreditCardTest extends TestCase
     public function testTraversableObject()
     {
         $options = ['type' => 'Visa'];
-        $config  = new ArrayObject($options, false);
+        $config  = new ArrayObject($options);
 
         $validator = new CreditCard($config);
         $this->assertEquals(['Visa'], $validator->getType());

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Validator;
 
-use Laminas\Config;
+use ArrayObject;
 use Laminas\Validator\CreditCard;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -316,10 +316,10 @@ class CreditCardTest extends TestCase
      *
      * @return void
      */
-    public function testConfigObject()
+    public function testTraversableObject()
     {
         $options = ['type' => 'Visa'];
-        $config  = new Config\Config($options, false);
+        $config  = new ArrayObject($options, false);
 
         $validator = new CreditCard($config);
         $this->assertEquals(['Visa'], $validator->getType());
@@ -330,9 +330,9 @@ class CreditCardTest extends TestCase
      *
      * @return void
      */
-    public function testOptionalConstructorParameterByConfigObject()
+    public function testOptionalConstructorParameterByTraversableObject()
     {
-        $config = new Config\Config(
+        $config = new ArrayObject(
             ['type' => 'Visa', 'service' => [self::class, 'staticCallback']]
         );
 

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -33,8 +33,8 @@ class CsrfTest extends TestCase
     protected function setUp(): void
     {
         // Setup session handling
-        $_SESSION       = [];
-        $sessionManager = new TestAsset\SessionManager(
+        $_SESSION             = [];
+        $sessionManager       = new TestAsset\SessionManager(
             new StandardConfig(),
             new ArrayStorage()
         );
@@ -111,7 +111,7 @@ class CsrfTest extends TestCase
 
     /**
      * @dataProvider timeoutValuesDataProvider
-     * @param null|int|numeric $timeout
+     * @param null|int|string $timeout
      */
     public function testTimeoutIsMutable($timeout, ?int $expected): void
     {

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -6,6 +6,7 @@ use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Container;
 use Laminas\Session\Storage\ArrayStorage;
 use Laminas\Validator\Csrf;
+use LaminasTest\Validator\TestAsset\SessionArrayStorage;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -33,11 +34,11 @@ class CsrfTest extends TestCase
     protected function setUp(): void
     {
         // Setup session handling
-        $_SESSION             = [];
-        $sessionConfig        = new StandardConfig([
-            'storage' => ArrayStorage::class,
-        ]);
-        $sessionManager       = new TestAsset\SessionManager($sessionConfig);
+        $_SESSION       = [];
+        $sessionManager = new TestAsset\SessionManager(
+            new StandardConfig(),
+            new SessionArrayStorage()
+        );
         $this->sessionManager = $sessionManager;
         Container::setDefaultManager($sessionManager);
 

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -6,7 +6,6 @@ use Laminas\Session\Config\StandardConfig;
 use Laminas\Session\Container;
 use Laminas\Session\Storage\ArrayStorage;
 use Laminas\Validator\Csrf;
-use LaminasTest\Validator\TestAsset\SessionArrayStorage;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -37,7 +36,7 @@ class CsrfTest extends TestCase
         $_SESSION       = [];
         $sessionManager = new TestAsset\SessionManager(
             new StandardConfig(),
-            new SessionArrayStorage()
+            new ArrayStorage()
         );
         $this->sessionManager = $sessionManager;
         Container::setDefaultManager($sessionManager);

--- a/test/File/IsCompressedTest.php
+++ b/test/File/IsCompressedTest.php
@@ -14,6 +14,7 @@ use function in_array;
 use function is_array;
 
 use const FILEINFO_MIME_TYPE;
+use const PHP_VERSION_ID;
 
 /**
  * IsCompressed testbed

--- a/test/File/IsCompressedTest.php
+++ b/test/File/IsCompressedTest.php
@@ -227,6 +227,9 @@ class IsCompressedTest extends TestCase
         $this->assertArrayHasKey('fileIsCompressedFalseType', $error);
     }
 
+    /**
+     * @todo Restore test branches under PHP 8.1 when https://bugs.php.net/bug.php?id=81426 is resolved
+     */
     public function testOptionsAtConstructor(): void
     {
         if (! extension_loaded('fileinfo')) {
@@ -234,14 +237,24 @@ class IsCompressedTest extends TestCase
         }
 
         $magicFile = $this->getMagicMime();
-        $validator = new File\IsCompressed([
-            'image/gif',
-            'image/jpg',
-            'magicFile'         => $magicFile,
-            'enableHeaderCheck' => true,
-        ]);
+        $options   = PHP_VERSION_ID >= 80100
+            ? [
+                'image/gif',
+                'image/jpg',
+                'enableHeaderCheck' => true,
+            ]
+            : [
+                'image/gif',
+                'image/jpg',
+                'magicFile'         => $magicFile,
+                'enableHeaderCheck' => true,
+            ];
+        $validator = new File\IsCompressed($options);
 
-        $this->assertEquals($magicFile, $validator->getMagicFile());
+        if (PHP_VERSION_ID < 80100) {
+            $this->assertEquals($magicFile, $validator->getMagicFile());
+        }
+
         $this->assertTrue($validator->getHeaderCheck());
         $this->assertEquals('image/gif,image/jpg', $validator->getMimeType());
     }

--- a/test/File/IsImageTest.php
+++ b/test/File/IsImageTest.php
@@ -10,6 +10,8 @@ use function current;
 use function extension_loaded;
 use function is_array;
 
+use const PHP_VERSION_ID;
+
 /**
  * IsImage testbed
  *

--- a/test/File/IsImageTest.php
+++ b/test/File/IsImageTest.php
@@ -161,6 +161,9 @@ class IsImageTest extends TestCase
         $this->assertArrayHasKey('fileIsImageFalseType', $error);
     }
 
+    /**
+     * @todo Restore test branches under PHP 8.1 when https://bugs.php.net/bug.php?id=81426 is resolved
+     */
     public function testOptionsAtConstructor(): void
     {
         if (! extension_loaded('fileinfo')) {
@@ -168,14 +171,25 @@ class IsImageTest extends TestCase
         }
 
         $magicFile = $this->getMagicMime();
-        $validator = new File\IsImage([
-            'image/gif',
-            'image/jpg',
-            'magicFile'         => $magicFile,
-            'enableHeaderCheck' => true,
-        ]);
+        $options   = PHP_VERSION_ID >= 80100
+            ? [
+                'image/gif',
+                'image/jpg',
+                'enableHeaderCheck' => true,
+            ]
+            : [
+                'image/gif',
+                'image/jpg',
+                'magicFile'         => $magicFile,
+                'enableHeaderCheck' => true,
+            ];
 
-        $this->assertEquals($magicFile, $validator->getMagicFile());
+        $validator = new File\IsImage($options);
+
+        if (PHP_VERSION_ID < 80100) {
+            $this->assertEquals($magicFile, $validator->getMagicFile());
+        }
+
         $this->assertTrue($validator->getHeaderCheck());
         $this->assertEquals('image/gif,image/jpg', $validator->getMimeType());
     }

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Validator;
 
-use Laminas\Config\Config;
+use ArrayObject;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\NotEmpty;
 use PHPUnit\Framework\TestCase;
@@ -768,10 +768,10 @@ class NotEmptyTest extends TestCase
      * @return void
      * @dataProvider configObjectProvider
      */
-    public function testConfigObject($value, $valid)
+    public function testTraversableObject($value, $valid)
     {
         $options = ['type' => 'all'];
-        $config  = new Config($options);
+        $config  = new ArrayObject($options);
 
         $this->validator = new NotEmpty(
             $config

--- a/test/TestAsset/CustomTraversable.php
+++ b/test/TestAsset/CustomTraversable.php
@@ -19,32 +19,28 @@ class CustomTraversable implements Iterator
         $this->data = $data;
     }
 
-    /** @return mixed */
-    public function current()
+    public function current(): mixed
     {
         return current($this->data);
     }
 
-    /** @return void */
-    public function next()
+    public function next(): void
     {
         next($this->data);
     }
 
     /** @return int|string */
-    public function key()
+    public function key(): mixed
     {
         return key($this->data);
     }
 
-    /** @return bool */
-    public function valid()
+    public function valid(): bool
     {
         return $this->key() !== null;
     }
 
-    /** @return void */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->data);
     }

--- a/test/TestAsset/CustomTraversable.php
+++ b/test/TestAsset/CustomTraversable.php
@@ -3,6 +3,7 @@
 namespace LaminasTest\Validator\TestAsset;
 
 use Iterator;
+use ReturnTypeWillChange;
 
 use function current;
 use function key;
@@ -19,7 +20,9 @@ class CustomTraversable implements Iterator
         $this->data = $data;
     }
 
-    public function current(): mixed
+    /** @return mixed */
+    #[ReturnTypeWillChange]
+    public function current()
     {
         return current($this->data);
     }
@@ -30,7 +33,8 @@ class CustomTraversable implements Iterator
     }
 
     /** @return int|string */
-    public function key(): mixed
+    #[ReturnTypeWillChange]
+    public function key()
     {
         return key($this->data);
     }

--- a/test/TestAsset/CustomTraversable.php
+++ b/test/TestAsset/CustomTraversable.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 
 namespace LaminasTest\Validator\TestAsset;
 

--- a/test/TestAsset/Db/AbstractResultSet.php
+++ b/test/TestAsset/Db/AbstractResultSet.php
@@ -8,6 +8,15 @@ use Iterator;
 use IteratorAggregate;
 use Laminas\Db\Adapter\Driver\ResultInterface;
 
+use function count;
+use function current;
+use function gettype;
+use function is_array;
+use function is_object;
+use function key;
+use function method_exists;
+use function reset;
+
 /**
  * Test shim for PHP 8.1 compatibility
  *
@@ -24,28 +33,21 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * if false, explicitly disabled
      * if null, default state - nothing, but can buffer until iteration started
      * if array, already buffering
+     *
      * @var mixed
      */
-    protected $buffer = null;
+    protected $buffer;
 
-    /**
-     * @var null|int
-     */
-    protected $count = null;
+    /** @var null|int */
+    protected $count;
 
-    /**
-     * @var Iterator|IteratorAggregate|ResultInterface
-     */
-    protected $dataSource = null;
+    /** @var Iterator|IteratorAggregate|ResultInterface */
+    protected $dataSource;
 
-    /**
-     * @var int
-     */
-    protected $fieldCount = null;
+    /** @var int */
+    protected $fieldCount;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $position = 0;
 
     /**
@@ -80,7 +82,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             reset($dataSource);
             $this->fieldCount = $first === false ? 0 : count($first);
             $this->dataSource = new ArrayIterator($dataSource);
-            $this->buffer = -1; // array's are a natural buffer
+            $this->buffer     = -1; // array's are a natural buffer
         } elseif ($dataSource instanceof IteratorAggregate) {
             $this->dataSource = $dataSource->getIterator();
         } elseif ($dataSource instanceof Iterator) {
@@ -111,7 +113,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         return $this;
     }
 
-    public function isBuffered()
+    public function isBuffered(): bool
     {
         if ($this->buffer === -1 || is_array($this->buffer)) {
             return true;
@@ -157,7 +159,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             return $this->fieldCount;
         }
 
-        $row = (array) $row;
+        $row              = (array) $row;
         $this->fieldCount = count($row);
         return $this->fieldCount;
     }
@@ -170,7 +172,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
         if ($this->buffer === null) {
             $this->buffer = -2; // implicitly disable buffering from here on
         }
-        if (! is_array($this->buffer) || $this->position == $this->dataSource->key()) {
+        if (! is_array($this->buffer) || $this->position === $this->dataSource->key()) {
             $this->dataSource->next();
         }
         $this->position++;
@@ -220,7 +222,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             return $this->dataSource->valid();
         } else {
             $key = key($this->dataSource);
-            return ($key !== null);
+            return $key !== null;
         }
     }
 
@@ -259,7 +261,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * Cast result set to array of arrays
      *
      * @return array
-     * @throws Exception\RuntimeException if any row is not castable to an array
+     * @throws Exception\RuntimeException If any row is not castable to an array.
      */
     public function toArray()
     {

--- a/test/TestAsset/Db/AbstractResultSet.php
+++ b/test/TestAsset/Db/AbstractResultSet.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Laminas\Db\ResultSet;
+
+use ArrayIterator;
+use Countable;
+use Iterator;
+use IteratorAggregate;
+use Laminas\Db\Adapter\Driver\ResultInterface;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-db equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-db has a release targetting PHP 8.1.
+ */
+abstract class AbstractResultSet implements Iterator, ResultSetInterface
+{
+    /**
+     * if -1, datasource is already buffered
+     * if -2, implicitly disabling buffering in ResultSet
+     * if false, explicitly disabled
+     * if null, default state - nothing, but can buffer until iteration started
+     * if array, already buffering
+     * @var mixed
+     */
+    protected $buffer = null;
+
+    /**
+     * @var null|int
+     */
+    protected $count = null;
+
+    /**
+     * @var Iterator|IteratorAggregate|ResultInterface
+     */
+    protected $dataSource = null;
+
+    /**
+     * @var int
+     */
+    protected $fieldCount = null;
+
+    /**
+     * @var int
+     */
+    protected $position = 0;
+
+    /**
+     * Set the data source for the result set
+     *
+     * @param  array|Iterator|IteratorAggregate|ResultInterface $dataSource
+     * @return self Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function initialize($dataSource)
+    {
+        // reset buffering
+        if (is_array($this->buffer)) {
+            $this->buffer = [];
+        }
+
+        if ($dataSource instanceof ResultInterface) {
+            $this->fieldCount = $dataSource->getFieldCount();
+            $this->dataSource = $dataSource;
+            if ($dataSource->isBuffered()) {
+                $this->buffer = -1;
+            }
+            if (is_array($this->buffer)) {
+                $this->dataSource->rewind();
+            }
+            return $this;
+        }
+
+        if (is_array($dataSource)) {
+            // its safe to get numbers from an array
+            $first = current($dataSource);
+            reset($dataSource);
+            $this->fieldCount = $first === false ? 0 : count($first);
+            $this->dataSource = new ArrayIterator($dataSource);
+            $this->buffer = -1; // array's are a natural buffer
+        } elseif ($dataSource instanceof IteratorAggregate) {
+            $this->dataSource = $dataSource->getIterator();
+        } elseif ($dataSource instanceof Iterator) {
+            $this->dataSource = $dataSource;
+        } else {
+            throw new Exception\InvalidArgumentException(
+                'DataSource provided is not an array, nor does it implement Iterator or IteratorAggregate'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return self Provides a fluent interface
+     * @throws Exception\RuntimeException
+     */
+    public function buffer()
+    {
+        if ($this->buffer === -2) {
+            throw new Exception\RuntimeException('Buffering must be enabled before iteration is started');
+        } elseif ($this->buffer === null) {
+            $this->buffer = [];
+            if ($this->dataSource instanceof ResultInterface) {
+                $this->dataSource->rewind();
+            }
+        }
+        return $this;
+    }
+
+    public function isBuffered()
+    {
+        if ($this->buffer === -1 || is_array($this->buffer)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get the data source used to create the result set
+     *
+     * @return null|Iterator
+     */
+    public function getDataSource()
+    {
+        return $this->dataSource;
+    }
+
+    /**
+     * Retrieve count of fields in individual rows of the result set
+     *
+     * @return int
+     */
+    public function getFieldCount()
+    {
+        if (null !== $this->fieldCount) {
+            return $this->fieldCount;
+        }
+
+        $dataSource = $this->getDataSource();
+        if (null === $dataSource) {
+            return 0;
+        }
+
+        $dataSource->rewind();
+        if (! $dataSource->valid()) {
+            $this->fieldCount = 0;
+            return 0;
+        }
+
+        $row = $dataSource->current();
+        if (is_object($row) && $row instanceof Countable) {
+            $this->fieldCount = $row->count();
+            return $this->fieldCount;
+        }
+
+        $row = (array) $row;
+        $this->fieldCount = count($row);
+        return $this->fieldCount;
+    }
+
+    /**
+     * Iterator: move pointer to next item
+     */
+    public function next(): void
+    {
+        if ($this->buffer === null) {
+            $this->buffer = -2; // implicitly disable buffering from here on
+        }
+        if (! is_array($this->buffer) || $this->position == $this->dataSource->key()) {
+            $this->dataSource->next();
+        }
+        $this->position++;
+    }
+
+    /**
+     * Iterator: retrieve current key
+     */
+    public function key(): mixed
+    {
+        return $this->position;
+    }
+
+    /**
+     * Iterator: get current item
+     *
+     * @return array|null
+     */
+    public function current(): mixed
+    {
+        if (-1 === $this->buffer) {
+            // datasource was an array when the resultset was initialized
+            return $this->dataSource->current();
+        }
+
+        if ($this->buffer === null) {
+            $this->buffer = -2; // implicitly disable buffering from here on
+        } elseif (is_array($this->buffer) && isset($this->buffer[$this->position])) {
+            return $this->buffer[$this->position];
+        }
+        $data = $this->dataSource->current();
+        if (is_array($this->buffer)) {
+            $this->buffer[$this->position] = $data;
+        }
+        return is_array($data) ? $data : null;
+    }
+
+    /**
+     * Iterator: is pointer valid?
+     */
+    public function valid(): bool
+    {
+        if (is_array($this->buffer) && isset($this->buffer[$this->position])) {
+            return true;
+        }
+        if ($this->dataSource instanceof Iterator) {
+            return $this->dataSource->valid();
+        } else {
+            $key = key($this->dataSource);
+            return ($key !== null);
+        }
+    }
+
+    /**
+     * Iterator: rewind
+     */
+    public function rewind(): void
+    {
+        if (! is_array($this->buffer)) {
+            if ($this->dataSource instanceof Iterator) {
+                $this->dataSource->rewind();
+            } else {
+                reset($this->dataSource);
+            }
+        }
+        $this->position = 0;
+    }
+
+    /**
+     * Countable: return count of rows
+     */
+    public function count(): int
+    {
+        if ($this->count !== null) {
+            return $this->count;
+        }
+
+        if ($this->dataSource instanceof Countable) {
+            $this->count = count($this->dataSource);
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * Cast result set to array of arrays
+     *
+     * @return array
+     * @throws Exception\RuntimeException if any row is not castable to an array
+     */
+    public function toArray()
+    {
+        $return = [];
+        foreach ($this as $row) {
+            if (is_array($row)) {
+                $return[] = $row;
+                continue;
+            }
+
+            if (
+                ! is_object($row)
+                || (
+                    ! method_exists($row, 'toArray')
+                    && ! method_exists($row, 'getArrayCopy')
+                )
+            ) {
+                throw new Exception\RuntimeException(
+                    'Rows as part of this DataSource, with type ' . gettype($row) . ' cannot be cast to an array'
+                );
+            }
+
+            $return[] = method_exists($row, 'toArray') ? $row->toArray() : $row->getArrayCopy();
+        }
+        return $return;
+    }
+}

--- a/test/TestAsset/Db/Join.php
+++ b/test/TestAsset/Db/Join.php
@@ -5,6 +5,13 @@ namespace Laminas\Db\Sql;
 use Countable;
 use Iterator;
 
+use function array_shift;
+use function count;
+use function is_array;
+use function is_string;
+use function key;
+use function sprintf;
+
 /**
  * Test shim for PHP 8.1 compatibility
  *
@@ -15,13 +22,13 @@ use Iterator;
  */
 class Join implements Iterator, Countable
 {
-    const JOIN_INNER       = 'inner';
-    const JOIN_OUTER       = 'outer';
-    const JOIN_FULL_OUTER  = 'full outer';
-    const JOIN_LEFT        = 'left';
-    const JOIN_RIGHT       = 'right';
-    const JOIN_RIGHT_OUTER = 'right outer';
-    const JOIN_LEFT_OUTER  = 'left outer';
+    public const JOIN_INNER       = 'inner';
+    public const JOIN_OUTER       = 'outer';
+    public const JOIN_FULL_OUTER  = 'full outer';
+    public const JOIN_LEFT        = 'left';
+    public const JOIN_RIGHT       = 'right';
+    public const JOIN_RIGHT_OUTER = 'right outer';
+    public const JOIN_LEFT_OUTER  = 'left outer';
 
     /**
      * Current iterator position.
@@ -102,9 +109,9 @@ class Join implements Iterator, Countable
      *     the columns to join.
      * @param string $type The JOIN type to use; see the JOIN_* constants.
      * @return self Provides a fluent interface
-     * @throws Exception\InvalidArgumentException for invalid $name values.
+     * @throws Exception\InvalidArgumentException For invalid $name values.
      */
-    public function join($name, $on, $columns = [Select::SQL_STAR], $type = Join::JOIN_INNER)
+    public function join($name, $on, $columns = [Select::SQL_STAR], $type = self::JOIN_INNER)
     {
         if (is_array($name) && (! is_string(key($name)) || count($name) !== 1)) {
             throw new Exception\InvalidArgumentException(
@@ -120,7 +127,7 @@ class Join implements Iterator, Countable
             'name'    => $name,
             'on'      => $on,
             'columns' => $columns,
-            'type'    => $type ? $type : Join::JOIN_INNER
+            'type'    => $type ? $type : self::JOIN_INNER,
         ];
 
         return $this;

--- a/test/TestAsset/Db/Join.php
+++ b/test/TestAsset/Db/Join.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Laminas\Db\Sql;
+
+use Countable;
+use Iterator;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-db equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-db has a release targetting PHP 8.1.
+ */
+class Join implements Iterator, Countable
+{
+    const JOIN_INNER       = 'inner';
+    const JOIN_OUTER       = 'outer';
+    const JOIN_FULL_OUTER  = 'full outer';
+    const JOIN_LEFT        = 'left';
+    const JOIN_RIGHT       = 'right';
+    const JOIN_RIGHT_OUTER = 'right outer';
+    const JOIN_LEFT_OUTER  = 'left outer';
+
+    /**
+     * Current iterator position.
+     *
+     * @var int
+     */
+    private $position = 0;
+
+    /**
+     * JOIN specifications
+     *
+     * @var array
+     */
+    protected $joins = [];
+
+    /**
+     * Initialize iterator position.
+     */
+    public function __construct()
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Rewind iterator.
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Return current join specification.
+     */
+    public function current(): array
+    {
+        return $this->joins[$this->position];
+    }
+
+    /**
+     * Return the current iterator index.
+     */
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * Advance to the next JOIN specification.
+     */
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    /**
+     * Is the iterator at a valid position?
+     */
+    public function valid(): bool
+    {
+        return isset($this->joins[$this->position]);
+    }
+
+    /**
+     * @return array
+     */
+    public function getJoins()
+    {
+        return $this->joins;
+    }
+
+    /**
+     * @param string|array|TableIdentifier $name A table name on which to join, or a single
+     *     element associative array, of the form alias => table, or TableIdentifier instance
+     * @param string|Predicate\Expression $on A specification describing the fields to join on.
+     * @param string|string[]|int|int[] $columns A single column name, an array
+     *     of column names, or (a) specification(s) such as SQL_STAR representing
+     *     the columns to join.
+     * @param string $type The JOIN type to use; see the JOIN_* constants.
+     * @return self Provides a fluent interface
+     * @throws Exception\InvalidArgumentException for invalid $name values.
+     */
+    public function join($name, $on, $columns = [Select::SQL_STAR], $type = Join::JOIN_INNER)
+    {
+        if (is_array($name) && (! is_string(key($name)) || count($name) !== 1)) {
+            throw new Exception\InvalidArgumentException(
+                sprintf("join() expects '%s' as a single element associative array", array_shift($name))
+            );
+        }
+
+        if (! is_array($columns)) {
+            $columns = [$columns];
+        }
+
+        $this->joins[] = [
+            'name'    => $name,
+            'on'      => $on,
+            'columns' => $columns,
+            'type'    => $type ? $type : Join::JOIN_INNER
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Reset to an empty list of JOIN specifications.
+     *
+     * @return self Provides a fluent interface
+     */
+    public function reset()
+    {
+        $this->joins = [];
+        return $this;
+    }
+
+    /**
+     * Get count of attached predicates
+     */
+    public function count(): int
+    {
+        return count($this->joins);
+    }
+}

--- a/test/TestAsset/Db/ParameterContainer.php
+++ b/test/TestAsset/Db/ParameterContainer.php
@@ -1,0 +1,432 @@
+<?php
+
+namespace Laminas\Db\Adapter;
+
+use ArrayAccess;
+use Countable;
+use Iterator;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-db equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-db has a release targetting PHP 8.1.
+ */
+class ParameterContainer implements Iterator, ArrayAccess, Countable
+{
+    const TYPE_AUTO    = 'auto';
+    const TYPE_NULL    = 'null';
+    const TYPE_DOUBLE  = 'double';
+    const TYPE_INTEGER = 'integer';
+    const TYPE_BINARY  = 'binary';
+    const TYPE_STRING  = 'string';
+    const TYPE_LOB     = 'lob';
+
+    /**
+     * Data
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * @var array
+     */
+    protected $positions = [];
+
+    /**
+     * Errata
+     *
+     * @var array
+     */
+    protected $errata = [];
+
+    /**
+     * Max length
+     *
+     * @var array
+     */
+    protected $maxLength = [];
+
+    /**
+     * @var array
+     */
+    protected $nameMapping = [];
+
+    /**
+     * Constructor
+     *
+     * @param array $data
+     */
+    public function __construct(array $data = [])
+    {
+        if ($data) {
+            $this->setFromArray($data);
+        }
+    }
+
+    /**
+     * Offset exists
+     */
+    public function offsetExists(mixed $name): bool
+    {
+        return (isset($this->data[$name]));
+    }
+
+    /**
+     * Offset get
+     */
+    public function offsetGet(mixed $name): mixed
+    {
+        if (isset($this->data[$name])) {
+            return $this->data[$name];
+        }
+
+        $normalizedName = ltrim($name, ':');
+        if (
+            isset($this->nameMapping[$normalizedName])
+            && isset($this->data[$this->nameMapping[$normalizedName]])
+        ) {
+            return $this->data[$this->nameMapping[$normalizedName]];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param $name
+     * @param $from
+     */
+    public function offsetSetReference($name, $from)
+    {
+        $this->data[$name] =& $this->data[$from];
+    }
+
+    /**
+     * Offset set
+     *
+     * @param string|int $name
+     * @param mixed $value
+     * @param mixed $errata
+     * @param mixed $maxLength
+     * @throws Exception\InvalidArgumentException
+     */
+    public function offsetSet(mixed $name, mixed $value, $errata = null, $maxLength = null): void
+    {
+        $position = false;
+
+        // if integer, get name for this position
+        if (is_int($name)) {
+            if (isset($this->positions[$name])) {
+                $position = $name;
+                $name = $this->positions[$name];
+            } else {
+                $name = (string) $name;
+            }
+        } elseif (is_string($name)) {
+            // is a string:
+            $normalizedName = ltrim($name, ':');
+            if (isset($this->nameMapping[$normalizedName])) {
+                // We have a mapping; get real name from it
+                $name = $this->nameMapping[$normalizedName];
+            }
+
+            $position = array_key_exists($name, $this->data);
+
+            // @todo: this assumes that any data begining with a ":" will be considered a parameter
+            if (is_string($value) && strpos($value, ':') === 0) {
+                // We have a named parameter; handle name mapping (container creation)
+                $this->nameMapping[ltrim($value, ':')] = $name;
+            }
+        } elseif ($name === null) {
+            $name = (string) count($this->data);
+        } else {
+            throw new Exception\InvalidArgumentException('Keys must be string, integer or null');
+        }
+
+        if ($position === false) {
+            $this->positions[] = $name;
+        }
+
+        $this->data[$name] = $value;
+
+        if ($errata) {
+            $this->offsetSetErrata($name, $errata);
+        }
+
+        if ($maxLength) {
+            $this->offsetSetMaxLength($name, $maxLength);
+        }
+    }
+
+    /**
+     * Offset unset
+     */
+    public function offsetUnset(mixed $name): void
+    {
+        if (is_int($name) && isset($this->positions[$name])) {
+            $name = $this->positions[$name];
+        }
+        unset($this->data[$name]);
+    }
+
+    /**
+     * Set from array
+     *
+     * @param  array $data
+     * @return self Provides a fluent interface
+     */
+    public function setFromArray(array $data)
+    {
+        foreach ($data as $n => $v) {
+            $this->offsetSet($n, $v);
+        }
+        return $this;
+    }
+
+    /**
+     * Offset set max length
+     *
+     * @param string|int $name
+     * @param mixed $maxLength
+     */
+    public function offsetSetMaxLength($name, $maxLength)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        $this->maxLength[$name] = $maxLength;
+    }
+
+    /**
+     * Offset get max length
+     *
+     * @param  string|int $name
+     * @throws Exception\InvalidArgumentException
+     * @return mixed
+     */
+    public function offsetGetMaxLength($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        if (! array_key_exists($name, $this->data)) {
+            throw new Exception\InvalidArgumentException('Data does not exist for this name/position');
+        }
+        return $this->maxLength[$name];
+    }
+
+    /**
+     * Offset has max length
+     *
+     * @param  string|int $name
+     * @return bool
+     */
+    public function offsetHasMaxLength($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        return (isset($this->maxLength[$name]));
+    }
+
+    /**
+     * Offset unset max length
+     *
+     * @param string|int $name
+     * @throws Exception\InvalidArgumentException
+     */
+    public function offsetUnsetMaxLength($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        if (! array_key_exists($name, $this->maxLength)) {
+            throw new Exception\InvalidArgumentException('Data does not exist for this name/position');
+        }
+        $this->maxLength[$name] = null;
+    }
+
+    /**
+     * Get max length iterator
+     *
+     * @return \ArrayIterator
+     */
+    public function getMaxLengthIterator()
+    {
+        return new \ArrayIterator($this->maxLength);
+    }
+
+    /**
+     * Offset set errata
+     *
+     * @param string|int $name
+     * @param mixed $errata
+     */
+    public function offsetSetErrata($name, $errata)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        $this->errata[$name] = $errata;
+    }
+
+    /**
+     * Offset get errata
+     *
+     * @param  string|int $name
+     * @throws Exception\InvalidArgumentException
+     * @return mixed
+     */
+    public function offsetGetErrata($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        if (! array_key_exists($name, $this->data)) {
+            throw new Exception\InvalidArgumentException('Data does not exist for this name/position');
+        }
+        return $this->errata[$name];
+    }
+
+    /**
+     * Offset has errata
+     *
+     * @param  string|int $name
+     * @return bool
+     */
+    public function offsetHasErrata($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        return (isset($this->errata[$name]));
+    }
+
+    /**
+     * Offset unset errata
+     *
+     * @param string|int $name
+     * @throws Exception\InvalidArgumentException
+     */
+    public function offsetUnsetErrata($name)
+    {
+        if (is_int($name)) {
+            $name = $this->positions[$name];
+        }
+        if (! array_key_exists($name, $this->errata)) {
+            throw new Exception\InvalidArgumentException('Data does not exist for this name/position');
+        }
+        $this->errata[$name] = null;
+    }
+
+    /**
+     * Get errata iterator
+     *
+     * @return \ArrayIterator
+     */
+    public function getErrataIterator()
+    {
+        return new \ArrayIterator($this->errata);
+    }
+
+    /**
+     * getNamedArray
+     *
+     * @return array
+     */
+    public function getNamedArray()
+    {
+        return $this->data;
+    }
+
+    /**
+     * getNamedArray
+     *
+     * @return array
+     */
+    public function getPositionalArray()
+    {
+        return array_values($this->data);
+    }
+
+    /**
+     * count
+     */
+    public function count(): int
+    {
+        return count($this->data);
+    }
+
+    /**
+     * Current
+     */
+    public function current(): mixed
+    {
+        return current($this->data);
+    }
+
+    /**
+     * Next
+     */
+    public function next(): void
+    {
+        next($this->data);
+    }
+
+    /**
+     * Key
+     */
+    public function key(): mixed
+    {
+        return key($this->data);
+    }
+
+    /**
+     * Valid
+     */
+    public function valid(): bool
+    {
+        return (current($this->data) !== false);
+    }
+
+    /**
+     * Rewind
+     */
+    public function rewind(): void
+    {
+        reset($this->data);
+    }
+
+    /**
+     * @param array|ParameterContainer $parameters
+     * @return self Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function merge($parameters)
+    {
+        if (! is_array($parameters) && ! $parameters instanceof ParameterContainer) {
+            throw new Exception\InvalidArgumentException(
+                '$parameters must be an array or an instance of ParameterContainer'
+            );
+        }
+
+        if (count($parameters) == 0) {
+            return $this;
+        }
+
+        if ($parameters instanceof ParameterContainer) {
+            $parameters = $parameters->getNamedArray();
+        }
+
+        foreach ($parameters as $key => $value) {
+            if (is_int($key)) {
+                $key = null;
+            }
+            $this->offsetSet($key, $value);
+        }
+        return $this;
+    }
+}

--- a/test/TestAsset/Db/ParameterContainer.php
+++ b/test/TestAsset/Db/ParameterContainer.php
@@ -3,8 +3,22 @@
 namespace Laminas\Db\Adapter;
 
 use ArrayAccess;
+use ArrayIterator;
 use Countable;
 use Iterator;
+
+use function array_key_exists;
+use function array_values;
+use function count;
+use function current;
+use function is_array;
+use function is_int;
+use function is_string;
+use function key;
+use function ltrim;
+use function next;
+use function reset;
+use function strpos;
 
 /**
  * Test shim for PHP 8.1 compatibility
@@ -16,13 +30,13 @@ use Iterator;
  */
 class ParameterContainer implements Iterator, ArrayAccess, Countable
 {
-    const TYPE_AUTO    = 'auto';
-    const TYPE_NULL    = 'null';
-    const TYPE_DOUBLE  = 'double';
-    const TYPE_INTEGER = 'integer';
-    const TYPE_BINARY  = 'binary';
-    const TYPE_STRING  = 'string';
-    const TYPE_LOB     = 'lob';
+    public const TYPE_AUTO    = 'auto';
+    public const TYPE_NULL    = 'null';
+    public const TYPE_DOUBLE  = 'double';
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_BINARY  = 'binary';
+    public const TYPE_STRING  = 'string';
+    public const TYPE_LOB     = 'lob';
 
     /**
      * Data
@@ -31,9 +45,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      */
     protected $data = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $positions = [];
 
     /**
@@ -50,9 +62,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      */
     protected $maxLength = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $nameMapping = [];
 
     /**
@@ -72,7 +82,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      */
     public function offsetExists(mixed $name): bool
     {
-        return (isset($this->data[$name]));
+        return isset($this->data[$name]);
     }
 
     /**
@@ -96,19 +106,19 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     }
 
     /**
-     * @param $name
-     * @param $from
+     * @param string $name
+     * @param string $from
+     * @return void
      */
     public function offsetSetReference($name, $from)
     {
-        $this->data[$name] =& $this->data[$from];
+        $this->data[$name] = &$this->data[$from];
     }
 
     /**
      * Offset set
      *
      * @param string|int $name
-     * @param mixed $value
      * @param mixed $errata
      * @param mixed $maxLength
      * @throws Exception\InvalidArgumentException
@@ -121,7 +131,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
         if (is_int($name)) {
             if (isset($this->positions[$name])) {
                 $position = $name;
-                $name = $this->positions[$name];
+                $name     = $this->positions[$name];
             } else {
                 $name = (string) $name;
             }
@@ -229,7 +239,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
         if (is_int($name)) {
             $name = $this->positions[$name];
         }
-        return (isset($this->maxLength[$name]));
+        return isset($this->maxLength[$name]);
     }
 
     /**
@@ -252,11 +262,11 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     /**
      * Get max length iterator
      *
-     * @return \ArrayIterator
+     * @return ArrayIterator
      */
     public function getMaxLengthIterator()
     {
-        return new \ArrayIterator($this->maxLength);
+        return new ArrayIterator($this->maxLength);
     }
 
     /**
@@ -302,7 +312,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
         if (is_int($name)) {
             $name = $this->positions[$name];
         }
-        return (isset($this->errata[$name]));
+        return isset($this->errata[$name]);
     }
 
     /**
@@ -325,11 +335,11 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     /**
      * Get errata iterator
      *
-     * @return \ArrayIterator
+     * @return ArrayIterator
      */
     public function getErrataIterator()
     {
-        return new \ArrayIterator($this->errata);
+        return new ArrayIterator($this->errata);
     }
 
     /**
@@ -389,7 +399,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      */
     public function valid(): bool
     {
-        return (current($this->data) !== false);
+        return current($this->data) !== false;
     }
 
     /**
@@ -413,7 +423,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             );
         }
 
-        if (count($parameters) == 0) {
+        if (count($parameters) === 0) {
             return $this;
         }
 

--- a/test/TestAsset/Db/PredicateSet.php
+++ b/test/TestAsset/Db/PredicateSet.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Laminas\Db\Sql\Predicate;
+
+use Countable;
+use Laminas\Db\Sql\Exception;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-db equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-db has a release targetting PHP 8.1.
+ */
+class PredicateSet implements PredicateInterface, Countable
+{
+    const COMBINED_BY_AND = 'AND';
+    const OP_AND          = 'AND';
+
+    const COMBINED_BY_OR  = 'OR';
+    const OP_OR           = 'OR';
+
+    protected $defaultCombination = self::COMBINED_BY_AND;
+    protected $predicates         = [];
+
+    /**
+     * Constructor
+     *
+     * @param  null|array $predicates
+     * @param  string $defaultCombination
+     */
+    public function __construct(array $predicates = null, $defaultCombination = self::COMBINED_BY_AND)
+    {
+        $this->defaultCombination = $defaultCombination;
+        if ($predicates) {
+            foreach ($predicates as $predicate) {
+                $this->addPredicate($predicate);
+            }
+        }
+    }
+
+    /**
+     * Add predicate to set
+     *
+     * @param  PredicateInterface $predicate
+     * @param  string $combination
+     * @return self Provides a fluent interface
+     */
+    public function addPredicate(PredicateInterface $predicate, $combination = null)
+    {
+        if ($combination === null || ! in_array($combination, [self::OP_AND, self::OP_OR])) {
+            $combination = $this->defaultCombination;
+        }
+
+        if ($combination == self::OP_OR) {
+            $this->orPredicate($predicate);
+            return $this;
+        }
+
+        $this->andPredicate($predicate);
+        return $this;
+    }
+
+    /**
+     * Add predicates to set
+     *
+     * @param PredicateInterface|\Closure|string|array $predicates
+     * @param string $combination
+     * @return self Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function addPredicates($predicates, $combination = self::OP_AND)
+    {
+        if ($predicates === null) {
+            throw new Exception\InvalidArgumentException('Predicate cannot be null');
+        }
+        if ($predicates instanceof PredicateInterface) {
+            $this->addPredicate($predicates, $combination);
+            return $this;
+        }
+        if ($predicates instanceof \Closure) {
+            $predicates($this);
+            return $this;
+        }
+        if (is_string($predicates)) {
+            // String $predicate should be passed as an expression
+            $predicate = (strpos($predicates, Expression::PLACEHOLDER) !== false)
+                ? new Expression($predicates) : new Literal($predicates);
+            $this->addPredicate($predicate, $combination);
+            return $this;
+        }
+        if (is_array($predicates)) {
+            foreach ($predicates as $pkey => $pvalue) {
+                // loop through predicates
+                if (is_string($pkey)) {
+                    if (strpos($pkey, '?') !== false) {
+                        // First, process strings that the abstraction replacement character ?
+                        // as an Expression predicate
+                        $predicate = new Expression($pkey, $pvalue);
+                    } elseif ($pvalue === null) {
+                        // Otherwise, if still a string, do something intelligent with the PHP type provided
+                        // map PHP null to SQL IS NULL expression
+                        $predicate = new IsNull($pkey);
+                    } elseif (is_array($pvalue)) {
+                        // if the value is an array, assume IN() is desired
+                        $predicate = new In($pkey, $pvalue);
+                    } elseif ($pvalue instanceof PredicateInterface) {
+                        throw new Exception\InvalidArgumentException(
+                            'Using Predicate must not use string keys'
+                        );
+                    } else {
+                        // otherwise assume that array('foo' => 'bar') means "foo" = 'bar'
+                        $predicate = new Operator($pkey, Operator::OP_EQ, $pvalue);
+                    }
+                } elseif ($pvalue instanceof PredicateInterface) {
+                    // Predicate type is ok
+                    $predicate = $pvalue;
+                } else {
+                    // must be an array of expressions (with int-indexed array)
+                    $predicate = (strpos($pvalue, Expression::PLACEHOLDER) !== false)
+                        ? new Expression($pvalue) : new Literal($pvalue);
+                }
+                $this->addPredicate($predicate, $combination);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Return the predicates
+     *
+     * @return PredicateInterface[]
+     */
+    public function getPredicates()
+    {
+        return $this->predicates;
+    }
+
+    /**
+     * Add predicate using OR operator
+     *
+     * @param  PredicateInterface $predicate
+     * @return self Provides a fluent interface
+     */
+    public function orPredicate(PredicateInterface $predicate)
+    {
+        $this->predicates[] = [self::OP_OR, $predicate];
+        return $this;
+    }
+
+    /**
+     * Add predicate using AND operator
+     *
+     * @param  PredicateInterface $predicate
+     * @return self Provides a fluent interface
+     */
+    public function andPredicate(PredicateInterface $predicate)
+    {
+        $this->predicates[] = [self::OP_AND, $predicate];
+        return $this;
+    }
+
+    /**
+     * Get predicate parts for where statement
+     *
+     * @return array
+     */
+    public function getExpressionData()
+    {
+        $parts = [];
+        for ($i = 0, $count = count($this->predicates); $i < $count; $i++) {
+            /** @var $predicate PredicateInterface */
+            $predicate = $this->predicates[$i][1];
+
+            if ($predicate instanceof PredicateSet) {
+                $parts[] = '(';
+            }
+
+            $parts = array_merge($parts, $predicate->getExpressionData());
+
+            if ($predicate instanceof PredicateSet) {
+                $parts[] = ')';
+            }
+
+            if (isset($this->predicates[$i + 1])) {
+                $parts[] = sprintf(' %s ', $this->predicates[$i + 1][0]);
+            }
+        }
+        return $parts;
+    }
+
+    /**
+     * Get count of attached predicates
+     */
+    public function count(): int
+    {
+        return count($this->predicates);
+    }
+}

--- a/test/TestAsset/Db/ResultSet.php
+++ b/test/TestAsset/Db/ResultSet.php
@@ -4,6 +4,11 @@ namespace Laminas\Db\ResultSet;
 
 use ArrayObject;
 
+use function in_array;
+use function is_array;
+use function is_object;
+use function method_exists;
+
 /**
  * Test shim for PHP 8.1 compatibility
  *
@@ -14,8 +19,8 @@ use ArrayObject;
  */
 class ResultSet extends AbstractResultSet
 {
-    const TYPE_ARRAYOBJECT = 'arrayobject';
-    const TYPE_ARRAY  = 'array';
+    public const TYPE_ARRAYOBJECT = 'arrayobject';
+    public const TYPE_ARRAY       = 'array';
 
     /**
      * Allowed return types
@@ -27,10 +32,8 @@ class ResultSet extends AbstractResultSet
         self::TYPE_ARRAY,
     ];
 
-    /**
-     * @var ArrayObject
-     */
-    protected $arrayObjectPrototype = null;
+    /** @var ArrayObject */
+    protected $arrayObjectPrototype;
 
     /**
      * Return type to use when returning an object from the set
@@ -53,7 +56,7 @@ class ResultSet extends AbstractResultSet
             $this->returnType = self::TYPE_ARRAYOBJECT;
         }
         if ($this->returnType === self::TYPE_ARRAYOBJECT) {
-            $this->setArrayObjectPrototype(($arrayObjectPrototype) ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
+            $this->setArrayObjectPrototype($arrayObjectPrototype ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
         }
     }
 
@@ -102,14 +105,14 @@ class ResultSet extends AbstractResultSet
     }
 
     /**
-     * @return array|\ArrayObject|null
+     * @return array|ArrayObject|null
      */
     public function current(): mixed
     {
         $data = parent::current();
 
         if ($this->returnType === self::TYPE_ARRAYOBJECT && is_array($data)) {
-            /** @var $ao ArrayObject */
+            /** @var ArrayObject $ao */
             $ao = clone $this->arrayObjectPrototype;
             if ($ao instanceof ArrayObject || method_exists($ao, 'exchangeArray')) {
                 $ao->exchangeArray($data);

--- a/test/TestAsset/Db/ResultSet.php
+++ b/test/TestAsset/Db/ResultSet.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Laminas\Db\ResultSet;
+
+use ArrayObject;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-db equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-db has a release targetting PHP 8.1.
+ */
+class ResultSet extends AbstractResultSet
+{
+    const TYPE_ARRAYOBJECT = 'arrayobject';
+    const TYPE_ARRAY  = 'array';
+
+    /**
+     * Allowed return types
+     *
+     * @var array
+     */
+    protected $allowedReturnTypes = [
+        self::TYPE_ARRAYOBJECT,
+        self::TYPE_ARRAY,
+    ];
+
+    /**
+     * @var ArrayObject
+     */
+    protected $arrayObjectPrototype = null;
+
+    /**
+     * Return type to use when returning an object from the set
+     *
+     * @var ResultSet::TYPE_ARRAYOBJECT|ResultSet::TYPE_ARRAY
+     */
+    protected $returnType = self::TYPE_ARRAYOBJECT;
+
+    /**
+     * Constructor
+     *
+     * @param string           $returnType
+     * @param null|ArrayObject $arrayObjectPrototype
+     */
+    public function __construct($returnType = self::TYPE_ARRAYOBJECT, $arrayObjectPrototype = null)
+    {
+        if (in_array($returnType, $this->allowedReturnTypes, true)) {
+            $this->returnType = $returnType;
+        } else {
+            $this->returnType = self::TYPE_ARRAYOBJECT;
+        }
+        if ($this->returnType === self::TYPE_ARRAYOBJECT) {
+            $this->setArrayObjectPrototype(($arrayObjectPrototype) ?: new ArrayObject([], ArrayObject::ARRAY_AS_PROPS));
+        }
+    }
+
+    /**
+     * Set the row object prototype
+     *
+     * @param  ArrayObject $arrayObjectPrototype
+     * @return self Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setArrayObjectPrototype($arrayObjectPrototype)
+    {
+        if (
+            ! is_object($arrayObjectPrototype)
+            || (
+                ! $arrayObjectPrototype instanceof ArrayObject
+                && ! method_exists($arrayObjectPrototype, 'exchangeArray')
+            )
+        ) {
+            throw new Exception\InvalidArgumentException(
+                'Object must be of type ArrayObject, or at least implement exchangeArray'
+            );
+        }
+        $this->arrayObjectPrototype = $arrayObjectPrototype;
+        return $this;
+    }
+
+    /**
+     * Get the row object prototype
+     *
+     * @return ArrayObject
+     */
+    public function getArrayObjectPrototype()
+    {
+        return $this->arrayObjectPrototype;
+    }
+
+    /**
+     * Get the return type to use when returning objects from the set
+     *
+     * @return string
+     */
+    public function getReturnType()
+    {
+        return $this->returnType;
+    }
+
+    /**
+     * @return array|\ArrayObject|null
+     */
+    public function current(): mixed
+    {
+        $data = parent::current();
+
+        if ($this->returnType === self::TYPE_ARRAYOBJECT && is_array($data)) {
+            /** @var $ao ArrayObject */
+            $ao = clone $this->arrayObjectPrototype;
+            if ($ao instanceof ArrayObject || method_exists($ao, 'exchangeArray')) {
+                $ao->exchangeArray($data);
+            }
+            return $ao;
+        }
+
+        return $data;
+    }
+}

--- a/test/TestAsset/Session/ArrayStorage.php
+++ b/test/TestAsset/Session/ArrayStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaminasTest\Validator\TestAsset;
+namespace Laminas\Session\Storage;
 
 use ArrayIterator;
 use Laminas\Session\Exception;
@@ -16,14 +16,14 @@ use function microtime;
 use function sprintf;
 
 /**
- * Array session storage
+ * Test shim for PHP 8.1 compatibility
  *
- * This is inlined here to allow testing against PHP 8.1, and replaces
- * Laminas\Session\Storage\ArrayStorage.
+ * This class replaces the laminas-session equivalent during development only, for
+ * purposes of testing against PHP 8.1.
  *
- * @todo Remove class and references to it once laminas-session has a release targeting PHP 8.1.
+ * @todo Remove when laminas-session has a release targetting PHP 8.1.
  */
-class SessionArrayStorage extends ArrayObject implements StorageInterface
+class ArrayStorage extends ArrayObject implements StorageInterface
 {
     /**
      * Is storage marked isImmutable?

--- a/test/TestAsset/SessionArrayStorage.php
+++ b/test/TestAsset/SessionArrayStorage.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace LaminasTest\Validator\TestAsset;
+
+use ArrayIterator;
+use Laminas\Session\Exception;
+use Laminas\Session\Storage\StorageInterface;
+use Laminas\Stdlib\ArrayObject;
+
+use function array_flip;
+use function array_key_exists;
+use function array_keys;
+use function array_replace_recursive;
+use function is_array;
+use function microtime;
+use function sprintf;
+
+/**
+ * Array session storage
+ *
+ * This is inlined here to allow testing against PHP 8.1, and replaces
+ * Laminas\Session\Storage\ArrayStorage.
+ *
+ * @todo Remove class and references to it once laminas-session has a release targeting PHP 8.1.
+ */
+class SessionArrayStorage extends ArrayObject implements StorageInterface
+{
+    /**
+     * Is storage marked isImmutable?
+     *
+     * @var bool
+     */
+    protected $isImmutable = false;
+
+    /**
+     * Constructor
+     *
+     * Instantiates storage as an ArrayObject, allowing property access.
+     * Also sets the initial request access time.
+     *
+     * @param array  $input
+     * @param int    $flags
+     * @param string $iteratorClass
+     */
+    public function __construct(
+        $input = [],
+        $flags = ArrayObject::ARRAY_AS_PROPS,
+        $iteratorClass = ArrayIterator::class
+    ) {
+        parent::__construct($input, $flags, $iteratorClass);
+        $this->setRequestAccessTime(microtime(true));
+    }
+
+    /**
+     * Set the request access time
+     *
+     * @param  float        $time
+     * @return ArrayStorage
+     */
+    protected function setRequestAccessTime($time)
+    {
+        $this->setMetadata('_REQUEST_ACCESS_TIME', $time);
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the request access time
+     *
+     * @return float
+     */
+    public function getRequestAccessTime()
+    {
+        return $this->getMetadata('_REQUEST_ACCESS_TIME');
+    }
+
+    /**
+     * Set a value in the storage object
+     *
+     * If the object is marked as isImmutable, or the object or key is marked as
+     * locked, raises an exception.
+     *
+     * @throws Exception\RuntimeException
+     */
+    public function offsetSet(mixed $key, mixed $value): void
+    {
+        if ($this->isImmutable()) {
+            throw new Exception\RuntimeException(
+                sprintf('Cannot set key "%s" as storage is marked isImmutable', $key)
+            );
+        }
+        if ($this->isLocked($key)) {
+            throw new Exception\RuntimeException(
+                sprintf('Cannot set key "%s" due to locking', $key)
+            );
+        }
+
+        parent::offsetSet($key, $value);
+    }
+
+    /**
+     * Lock this storage instance, or a key within it
+     *
+     * @param  null|int|string $key
+     * @return ArrayStorage
+     */
+    public function lock($key = null)
+    {
+        if (null === $key) {
+            $this->setMetadata('_READONLY', true);
+
+            return $this;
+        }
+        if (isset($this[$key])) {
+            $this->setMetadata('_LOCKS', [$key => true]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Is the object or key marked as locked?
+     *
+     * @param  null|int|string $key
+     * @return bool
+     */
+    public function isLocked($key = null)
+    {
+        if ($this->isImmutable()) {
+            // isImmutable trumps all
+            return true;
+        }
+
+        if (null === $key) {
+            // testing for global lock
+            return $this->getMetadata('_READONLY');
+        }
+
+        $locks    = $this->getMetadata('_LOCKS');
+        $readOnly = $this->getMetadata('_READONLY');
+
+        if ($readOnly && ! $locks) {
+            // global lock in play; all keys are locked
+            return true;
+        } elseif ($readOnly && $locks) {
+            return array_key_exists($key, $locks);
+        }
+
+        // test for individual locks
+        if (! $locks) {
+            return false;
+        }
+
+        return array_key_exists($key, $locks);
+    }
+
+    /**
+     * Unlock an object or key marked as locked
+     *
+     * @param  null|int|string $key
+     * @return ArrayStorage
+     */
+    public function unlock($key = null)
+    {
+        if (null === $key) {
+            // Unlock everything
+            $this->setMetadata('_READONLY', false);
+            $this->setMetadata('_LOCKS', false);
+
+            return $this;
+        }
+
+        $locks = $this->getMetadata('_LOCKS');
+        if (! $locks) {
+            if (! $this->getMetadata('_READONLY')) {
+                return $this;
+            }
+            $array = $this->toArray();
+            $keys  = array_keys($array);
+            $locks = array_flip($keys);
+            unset($array, $keys);
+        }
+
+        if (array_key_exists($key, $locks)) {
+            unset($locks[$key]);
+            $this->setMetadata('_LOCKS', $locks, true);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Mark the storage container as isImmutable
+     *
+     * @return ArrayStorage
+     */
+    public function markImmutable()
+    {
+        $this->isImmutable = true;
+
+        return $this;
+    }
+
+    /**
+     * Is the storage container marked as isImmutable?
+     *
+     * @return bool
+     */
+    public function isImmutable()
+    {
+        return $this->isImmutable;
+    }
+
+    /**
+     * Set storage metadata
+     *
+     * Metadata is used to store information about the data being stored in the
+     * object. Some example use cases include:
+     * - Setting expiry data
+     * - Maintaining access counts
+     * - localizing session storage
+     * - etc.
+     *
+     * @param  string                     $key
+     * @param  mixed                      $value
+     * @param  bool                       $overwriteArray Whether to overwrite or merge array values; by default, merges
+     * @return ArrayStorage
+     * @throws Exception\RuntimeException
+     */
+    public function setMetadata($key, $value, $overwriteArray = false)
+    {
+        if ($this->isImmutable) {
+            throw new Exception\RuntimeException(
+                sprintf('Cannot set key "%s" as storage is marked isImmutable', $key)
+            );
+        }
+
+        if (! isset($this['__Laminas'])) {
+            $this['__Laminas'] = [];
+        }
+
+        if (isset($this['__Laminas'][$key]) && is_array($value)) {
+            if ($overwriteArray) {
+                $this['__Laminas'][$key] = $value;
+            } else {
+                $this['__Laminas'][$key] = array_replace_recursive($this['__Laminas'][$key], $value);
+            }
+        } else {
+            if ((null === $value) && isset($this['__Laminas'][$key])) {
+                // unset($this['__Laminas'][$key]) led to "indirect modification...
+                // has no effect" errors, so explicitly pulling array and
+                // unsetting key.
+                $array = $this['__Laminas'];
+                unset($array[$key]);
+                $this['__Laminas'] = $array;
+                unset($array);
+            } elseif (null !== $value) {
+                $this['__Laminas'][$key] = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Retrieve metadata for the storage object or a specific metadata key
+     *
+     * Returns false if no metadata stored, or no metadata exists for the given
+     * key.
+     *
+     * @param  null|int|string $key
+     * @return mixed
+     */
+    public function getMetadata($key = null)
+    {
+        if (! isset($this['__Laminas'])) {
+            return false;
+        }
+
+        if (null === $key) {
+            return $this['__Laminas'];
+        }
+
+        if (! array_key_exists($key, $this['__Laminas'])) {
+            return false;
+        }
+
+        return $this['__Laminas'][$key];
+    }
+
+    /**
+     * Clear the storage object or a subkey of the object
+     *
+     * @param  null|int|string            $key
+     * @return ArrayStorage
+     * @throws Exception\RuntimeException
+     */
+    public function clear($key = null)
+    {
+        if ($this->isImmutable()) {
+            throw new Exception\RuntimeException('Cannot clear storage as it is marked immutable');
+        }
+        if (null === $key) {
+            $this->fromArray([]);
+
+            return $this;
+        }
+
+        if (! isset($this[$key])) {
+            return $this;
+        }
+
+        // Clear key data
+        unset($this[$key]);
+
+        // Clear key metadata
+        $this->setMetadata($key, null)
+             ->unlock($key);
+
+        return $this;
+    }
+
+    /**
+     * Load the storage from another array
+     *
+     * Overwrites any data that was previously set.
+     *
+     * @param  array        $array
+     * @return ArrayStorage
+     */
+    public function fromArray(array $array)
+    {
+        $ts = $this->getRequestAccessTime();
+        $this->exchangeArray($array);
+        $this->setRequestAccessTime($ts);
+
+        return $this;
+    }
+
+    /**
+     * Cast the object to an array
+     *
+     * @param  bool $metaData Whether to include metadata
+     * @return array
+     */
+    public function toArray($metaData = false)
+    {
+        $values = $this->getArrayCopy();
+        if ($metaData) {
+            return $values;
+        }
+        if (isset($values['__Laminas'])) {
+            unset($values['__Laminas']);
+        }
+
+        return $values;
+    }
+}

--- a/test/TestAsset/Uri/Uri.php
+++ b/test/TestAsset/Uri/Uri.php
@@ -1,0 +1,1398 @@
+<?php
+
+namespace Laminas\Uri;
+
+use Exception as PhpException;
+use Laminas\Escaper\Escaper;
+use Laminas\Validator;
+
+use function array_intersect_assoc;
+use function array_pop;
+use function array_unshift;
+use function explode;
+use function get_class;
+use function gettype;
+use function http_build_query;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_object;
+use function is_string;
+use function parse_str;
+use function preg_match;
+use function preg_replace_callback;
+use function preg_split;
+use function rawurldecode;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function strtoupper;
+use function substr;
+
+use const PREG_SPLIT_DELIM_CAPTURE;
+use const PREG_SPLIT_NO_EMPTY;
+
+/**
+ * Test shim for PHP 8.1 compatibility
+ *
+ * This class replaces the laminas-uri equivalent during development only, for
+ * purposes of testing against PHP 8.1.
+ *
+ * @todo Remove when laminas-uri has a release targetting PHP 8.1.
+ */
+class Uri implements UriInterface
+{
+    /**
+     * Character classes defined in RFC-3986
+     */
+    public const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
+    public const CHAR_GEN_DELIMS = ':\/\?#\[\]@';
+    public const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
+    public const CHAR_RESERVED   = ':\/\?#\[\]@!\$&\'\(\)\*\+,;=';
+    /**
+     * Not in the spec - those characters have special meaning in urlencoded query parameters
+     */
+    public const CHAR_QUERY_DELIMS = '!\$\'\(\)\*\,';
+
+    /**
+     * Host part types represented as binary masks
+     * The binary mask consists of 5 bits in the following order:
+     * <RegName> | <DNS> | <IPvFuture> | <IPv6> | <IPv4>
+     * Place 1 or 0 in the different positions for enable or disable the part.
+     * Finally use a hexadecimal representation.
+     */
+    public const HOST_IPV4                           = 0x01; //00001
+    public const HOST_IPV6                           = 0x02; //00010
+    public const HOST_IPVFUTURE                      = 0x04; //00100
+    public const HOST_IPVANY                         = 0x07; //00111
+    public const HOST_DNS                            = 0x08; //01000
+    public const HOST_DNS_OR_IPV4                    = 0x09; //01001
+    public const HOST_DNS_OR_IPV6                    = 0x0A; //01010
+    public const HOST_DNS_OR_IPV4_OR_IPV6            = 0x0B; //01011
+    public const HOST_DNS_OR_IPVANY                  = 0x0F; //01111
+    public const HOST_REGNAME                        = 0x10; //10000
+    public const HOST_DNS_OR_IPV4_OR_IPV6_OR_REGNAME = 0x1B; //11011
+    public const HOST_ALL                            = 0x1F; //11111
+
+    /**
+     * URI scheme
+     *
+     * @var string|null
+     */
+    protected $scheme;
+
+    /**
+     * URI userInfo part (usually user:password in HTTP URLs)
+     *
+     * @var string|null
+     */
+    protected $userInfo;
+
+    /**
+     * URI hostname
+     *
+     * @var string|null
+     */
+    protected $host;
+
+    /**
+     * URI port
+     *
+     * @var int|null
+     */
+    protected $port;
+
+    /**
+     * URI path
+     *
+     * @var string|null
+     */
+    protected $path;
+
+    /**
+     * URI query string
+     *
+     * @var string|null
+     */
+    protected $query;
+
+    /**
+     * URI fragment|null
+     *
+     * @var string
+     */
+    protected $fragment;
+
+    /**
+     * Which host part types are valid for this URI?
+     *
+     * @var int
+     */
+    protected $validHostTypes = self::HOST_ALL;
+
+    /**
+     * Array of valid schemes.
+     *
+     * Subclasses of this class that only accept specific schemes may set the
+     * list of accepted schemes here. If not empty, when setScheme() is called
+     * it will only accept the schemes listed here.
+     *
+     * @var array
+     */
+    protected static $validSchemes = [];
+
+    /**
+     * List of default ports per scheme
+     *
+     * Inheriting URI classes may set this, and the normalization methods will
+     * automatically remove the port if it is equal to the default port for the
+     * current scheme
+     *
+     * @var array
+     */
+    protected static $defaultPorts = [];
+
+    /** @var Escaper */
+    protected static $escaper;
+
+    /**
+     * Create a new URI object
+     *
+     * @param  Uri|string|null $uri
+     * @throws Exception\InvalidArgumentException
+     */
+    public function __construct($uri = null)
+    {
+        if (is_string($uri)) {
+            $this->parse($uri);
+        } elseif ($uri instanceof UriInterface) {
+            // Copy constructor
+            $this->setScheme($uri->getScheme());
+            $this->setUserInfo($uri->getUserInfo());
+            $this->setHost($uri->getHost());
+            $this->setPort($uri->getPort());
+            $this->setPath($uri->getPath());
+            $this->setQuery($uri->getQuery());
+            $this->setFragment($uri->getFragment());
+        } elseif ($uri !== null) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string or a URI object, received "%s"',
+                is_object($uri) ? get_class($uri) : gettype($uri)
+            ));
+        }
+    }
+
+    /**
+     * Set Escaper instance
+     */
+    public static function setEscaper(Escaper $escaper)
+    {
+        static::$escaper = $escaper;
+    }
+
+    /**
+     * Retrieve Escaper instance
+     *
+     * Lazy-loads one if none provided
+     *
+     * @return Escaper
+     */
+    public static function getEscaper()
+    {
+        if (null === static::$escaper) {
+            static::setEscaper(new Escaper());
+        }
+        return static::$escaper;
+    }
+
+    /**
+     * Check if the URI is valid
+     *
+     * Note that a relative URI may still be valid
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        if ($this->host) {
+            if (is_string($this->path) && strlen($this->path) > 0 && 0 !== strpos($this->path, '/')) {
+                return false;
+            }
+            return true;
+        }
+
+        if ($this->userInfo || $this->port) {
+            return false;
+        }
+
+        if ($this->path) {
+            // Check path-only (no host) URI
+            if (0 === strpos($this->path, '//')) {
+                return false;
+            }
+            return true;
+        }
+
+        if (! ($this->query || $this->fragment)) {
+            // No host, path, query or fragment - this is not a valid URI
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the URI is a valid relative URI
+     *
+     * @return bool
+     */
+    public function isValidRelative()
+    {
+        if ($this->scheme || $this->host || $this->userInfo || $this->port) {
+            return false;
+        }
+
+        if ($this->path) {
+            // Check path-only (no host) URI
+            if (0 === strpos($this->path, '//')) {
+                return false;
+            }
+            return true;
+        }
+
+        if (! ($this->query || $this->fragment)) {
+            // No host, path, query or fragment - this is not a valid URI
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the URI is an absolute or relative URI
+     *
+     * @return bool
+     */
+    public function isAbsolute()
+    {
+        return $this->scheme !== null;
+    }
+
+    /**
+     * Reset URI parts
+     */
+    protected function reset()
+    {
+        $this->setScheme(null);
+        $this->setPort(null);
+        $this->setUserInfo(null);
+        $this->setHost(null);
+        $this->setPath(null);
+        $this->setFragment(null);
+        $this->setQuery(null);
+    }
+
+    /**
+     * Parse a URI string
+     *
+     * @param  string $uri
+     * @return Uri
+     */
+    public function parse($uri)
+    {
+        $this->reset();
+
+        // Capture scheme
+        if (($scheme = self::parseScheme($uri)) !== null) {
+            $this->setScheme($scheme);
+            $uri = substr($uri, strlen($scheme) + 1) ?: '';
+        }
+
+        // Capture authority part
+        if (preg_match('|^//([^/\?#]*)|', $uri, $match)) {
+            $authority = $match[1];
+            $uri       = substr($uri, strlen($match[0]));
+
+            // Split authority into userInfo and host
+            if (strpos($authority, '@') !== false) {
+                // The userInfo can also contain '@' symbols; split $authority
+                // into segments, and set it to the last segment.
+                $segments  = explode('@', $authority);
+                $authority = array_pop($segments);
+                $userInfo  = implode('@', $segments);
+                unset($segments);
+                $this->setUserInfo($userInfo);
+            }
+
+            $nMatches = preg_match('/:[\d]{0,5}$/', $authority, $matches);
+            if ($nMatches === 1) {
+                $portLength = strlen($matches[0]);
+                $port       = substr($matches[0], 1);
+
+                // If authority ends with colon, port will be empty string.
+                // Remove the colon from authority, but keeps port null
+                if ($port) {
+                    $this->setPort((int) $port);
+                }
+
+                $authority = substr($authority, 0, -$portLength);
+            }
+
+            $this->setHost($authority);
+        }
+
+        if (! $uri) {
+            return $this;
+        }
+
+        // Capture the path
+        if (preg_match('|^[^\?#]*|', $uri, $match)) {
+            $this->setPath($match[0]);
+            $uri = substr($uri, strlen($match[0]));
+        }
+
+        if (! $uri) {
+            return $this;
+        }
+
+        // Capture the query
+        if (preg_match('|^\?([^#]*)|', $uri, $match)) {
+            $this->setQuery($match[1]);
+            $uri = substr($uri, strlen($match[0]));
+        }
+        if (! $uri) {
+            return $this;
+        }
+
+        // All that's left is the fragment
+        if ($uri && 0 === strpos($uri, '#')) {
+            $this->setFragment(substr($uri, 1));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Compose the URI into a string
+     *
+     * @return string
+     * @throws Exception\InvalidUriException
+     */
+    public function toString()
+    {
+        if (! $this->isValid()) {
+            if ($this->isAbsolute() || ! $this->isValidRelative()) {
+                throw new Exception\InvalidUriException(
+                    'URI is not valid and cannot be converted into a string'
+                );
+            }
+        }
+
+        $uri = '';
+
+        if ($this->scheme) {
+            $uri .= $this->scheme . ':';
+        }
+
+        if ($this->host !== null) {
+            $uri .= '//';
+            if ($this->userInfo) {
+                $uri .= $this->userInfo . '@';
+            }
+            $uri .= $this->host;
+            if ($this->port) {
+                $uri .= ':' . $this->port;
+            }
+        }
+
+        if ($this->path) {
+            $uri .= static::encodePath($this->path);
+        } elseif ($this->host && ($this->query || $this->fragment)) {
+            $uri .= '/';
+        }
+
+        if ($this->query) {
+            $uri .= "?" . static::encodeQueryFragment($this->query);
+        }
+
+        if ($this->fragment) {
+            $uri .= "#" . static::encodeQueryFragment($this->fragment);
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Normalize the URI
+     *
+     * Normalizing a URI includes removing any redundant parent directory or
+     * current directory references from the path (e.g. foo/bar/../baz becomes
+     * foo/baz), normalizing the scheme case, decoding any over-encoded
+     * characters etc.
+     *
+     * Eventually, two normalized URLs pointing to the same resource should be
+     * equal even if they were originally represented by two different strings
+     *
+     * @return Uri
+     */
+    public function normalize()
+    {
+        if ($this->scheme) {
+            $this->scheme = static::normalizeScheme($this->scheme);
+        }
+
+        if ($this->host) {
+            $this->host = static::normalizeHost($this->host);
+        }
+
+        if ($this->port) {
+            $this->port = static::normalizePort($this->port, $this->scheme);
+        }
+
+        if ($this->path) {
+            $this->path = static::normalizePath($this->path);
+        }
+
+        if ($this->query) {
+            $this->query = static::normalizeQuery($this->query);
+        }
+
+        if ($this->fragment) {
+            $this->fragment = static::normalizeFragment($this->fragment);
+        }
+
+        // If path is empty (and we have a host), path should be '/'
+        // Isn't this valid ONLY for HTTP-URI?
+        if ($this->host && empty($this->path)) {
+            $this->path = '/';
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert a relative URI into an absolute URI using a base absolute URI as
+     * a reference.
+     *
+     * This is similar to merge() - only it uses the supplied URI as the
+     * base reference instead of using the current URI as the base reference.
+     *
+     * Merging algorithm is adapted from RFC-3986 section 5.2
+     * (@link http://tools.ietf.org/html/rfc3986#section-5.2)
+     *
+     * @param  Uri|string $baseUri
+     * @throws Exception\InvalidArgumentException
+     * @return Uri
+     */
+    public function resolve($baseUri)
+    {
+        // Ignore if URI is absolute
+        if ($this->isAbsolute()) {
+            return $this;
+        }
+
+        if (is_string($baseUri)) {
+            $baseUri = new static($baseUri);
+        } elseif (! $baseUri instanceof Uri) {
+            throw new Exception\InvalidArgumentException(
+                'Provided base URI must be a string or a Uri object'
+            );
+        }
+
+        // Merging starts here...
+        if ($this->getHost()) {
+            $this->setPath(static::removePathDotSegments($this->getPath()));
+        } else {
+            $basePath = $baseUri->getPath();
+            $relPath  = $this->getPath();
+            if (! $relPath) {
+                $this->setPath($basePath);
+                if (! $this->getQuery()) {
+                    $this->setQuery($baseUri->getQuery());
+                }
+            } else {
+                if (0 === strpos($relPath, '/')) {
+                    $this->setPath(static::removePathDotSegments($relPath));
+                } else {
+                    if ($baseUri->getHost() && ! $basePath) {
+                        $mergedPath = '/';
+                    } else {
+                        $mergedPath = substr($basePath, 0, strrpos($basePath, '/') + 1);
+                    }
+                    $this->setPath(static::removePathDotSegments($mergedPath . $relPath));
+                }
+            }
+
+            // Set the authority part
+            $this->setUserInfo($baseUri->getUserInfo());
+            $this->setHost($baseUri->getHost());
+            $this->setPort($baseUri->getPort());
+        }
+
+        $this->setScheme($baseUri->getScheme());
+        return $this;
+    }
+
+    /**
+     * Convert the link to a relative link by substracting a base URI
+     *
+     *  This is the opposite of resolving a relative link - i.e. creating a
+     *  relative reference link from an original URI and a base URI.
+     *
+     *  If the two URIs do not intersect (e.g. the original URI is not in any
+     *  way related to the base URI) the URI will not be modified.
+     *
+     * @param  Uri|string $baseUri
+     * @return Uri
+     */
+    public function makeRelative($baseUri)
+    {
+        // Copy base URI, we should not modify it
+        $baseUri = new static($baseUri);
+
+        $this->normalize();
+        $baseUri->normalize();
+
+        $host     = $this->getHost();
+        $baseHost = $baseUri->getHost();
+        if ($host && $baseHost && ($host !== $baseHost)) {
+            // Not the same hostname
+            return $this;
+        }
+
+        $port     = $this->getPort();
+        $basePort = $baseUri->getPort();
+        if ($port && $basePort && ($port !== $basePort)) {
+            // Not the same port
+            return $this;
+        }
+
+        $scheme     = $this->getScheme();
+        $baseScheme = $baseUri->getScheme();
+        if ($scheme && $baseScheme && ($scheme !== $baseScheme)) {
+            // Not the same scheme (e.g. HTTP vs. HTTPS)
+            return $this;
+        }
+
+        // Remove host, port and scheme
+        $this->setHost(null)
+             ->setPort(null)
+             ->setScheme(null);
+
+        // Is path the same?
+        if ($this->getPath() === $baseUri->getPath()) {
+            $this->setPath('');
+            return $this;
+        }
+
+        $pathParts = preg_split('|(/)|', $this->getPath(), null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $baseParts = preg_split('|(/)|', $baseUri->getPath(), null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
+        // Get the intersection of existing path parts and those from the
+        // provided URI
+        $matchingParts = array_intersect_assoc($pathParts, $baseParts);
+
+        // Loop through the matches
+        foreach ($matchingParts as $index => $segment) {
+            // If we skip an index at any point, we have parent traversal, and
+            // need to prepend the path accordingly
+            if ($index && ! isset($matchingParts[$index - 1])) {
+                array_unshift($pathParts, '../');
+                continue;
+            }
+
+            // Otherwise, we simply unset the given path segment
+            unset($pathParts[$index]);
+        }
+
+        // Reset the path by imploding path segments
+        $this->setPath(implode($pathParts));
+
+        return $this;
+    }
+
+    /**
+     * Get the scheme part of the URI
+     *
+     * @return string|null
+     */
+    public function getScheme()
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * Get the User-info (usually user:password) part
+     *
+     * @return string|null
+     */
+    public function getUserInfo()
+    {
+        return $this->userInfo;
+    }
+
+    /**
+     * Get the URI host
+     *
+     * @return string|null
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Get the URI port
+     *
+     * @return int|null
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * Get the URI path
+     *
+     * @return string|null
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the URI query
+     *
+     * @return string|null
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * Return the query string as an associative array of key => value pairs
+     *
+     * This is an extension to RFC-3986 but is quite useful when working with
+     * most common URI types
+     *
+     * @return array
+     */
+    public function getQueryAsArray()
+    {
+        $query = [];
+        if ($this->query) {
+            parse_str($this->query, $query);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the URI fragment
+     *
+     * @return string|null
+     */
+    public function getFragment()
+    {
+        return $this->fragment;
+    }
+
+    /**
+     * Set the URI scheme
+     *
+     * If the scheme is not valid according to the generic scheme syntax or
+     * is not acceptable by the specific URI class (e.g. 'http' or 'https' are
+     * the only acceptable schemes for the Laminas\Uri\Http class) an exception
+     * will be thrown.
+     *
+     * You can check if a scheme is valid before setting it using the
+     * validateScheme() method.
+     *
+     * @param  string|null $scheme
+     * @throws Exception\InvalidUriPartException
+     * @return Uri
+     */
+    public function setScheme($scheme)
+    {
+        if (($scheme !== null) && (! self::validateScheme($scheme))) {
+            throw new Exception\InvalidUriPartException(sprintf(
+                'Scheme "%s" is not valid or is not accepted by %s',
+                $scheme,
+                static::class
+            ), Exception\InvalidUriPartException::INVALID_SCHEME);
+        }
+
+        $this->scheme = $scheme;
+        return $this;
+    }
+
+    /**
+     * Set the URI User-info part (usually user:password)
+     *
+     * @param  string|null $userInfo
+     * @return Uri
+     * @throws Exception\InvalidUriPartException If the schema definition does not have this part.
+     */
+    public function setUserInfo($userInfo)
+    {
+        $this->userInfo = $userInfo;
+        return $this;
+    }
+
+    /**
+     * Set the URI host
+     *
+     * Note that the generic syntax for URIs allows using host names which
+     * are not necessarily IPv4 addresses or valid DNS host names. For example,
+     * IPv6 addresses are allowed as well, and also an abstract "registered name"
+     * which may be any name composed of a valid set of characters, including,
+     * for example, tilda (~) and underscore (_) which are not allowed in DNS
+     * names.
+     *
+     * Subclasses of Uri may impose more strict validation of host names - for
+     * example the HTTP RFC clearly states that only IPv4 and valid DNS names
+     * are allowed in HTTP URIs.
+     *
+     * @param  string|null $host
+     * @throws Exception\InvalidUriPartException
+     * @return Uri
+     */
+    public function setHost($host)
+    {
+        if (
+            ($host !== '')
+            && ($host !== null)
+            && ! self::validateHost($host, $this->validHostTypes)
+        ) {
+            throw new Exception\InvalidUriPartException(sprintf(
+                'Host "%s" is not valid or is not accepted by %s',
+                $host,
+                static::class
+            ), Exception\InvalidUriPartException::INVALID_HOSTNAME);
+        }
+
+        if ($host !== null) {
+            $host = strtolower($host);
+        }
+
+        $this->host = $host;
+        return $this;
+    }
+
+    /**
+     * Set the port part of the URI
+     *
+     * @param  int|null $port
+     * @return Uri
+     */
+    public function setPort($port)
+    {
+        $this->port = $port;
+        return $this;
+    }
+
+    /**
+     * Set the path
+     *
+     * @param  string|null $path
+     * @return Uri
+     */
+    public function setPath($path)
+    {
+        $this->path = $path;
+        return $this;
+    }
+
+    /**
+     * Set the query string
+     *
+     * If an array is provided, will encode this array of parameters into a
+     * query string. Array values will be represented in the query string using
+     * PHP's common square bracket notation.
+     *
+     * @param  string|array|null $query
+     * @return Uri
+     */
+    public function setQuery($query)
+    {
+        if (is_array($query)) {
+            // We replace the + used for spaces by http_build_query with the
+            // more standard %20.
+            $query = str_replace('+', '%20', http_build_query($query));
+        }
+
+        $this->query = $query;
+        return $this;
+    }
+
+    /**
+     * Set the URI fragment part
+     *
+     * @param  string|null $fragment
+     * @return Uri
+     * @throws Exception\InvalidUriPartException If the schema definition does not have this part.
+     */
+    public function setFragment($fragment)
+    {
+        $this->fragment = $fragment;
+        return $this;
+    }
+
+    /**
+     * Magic method to convert the URI to a string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            return $this->toString();
+        } catch (PhpException $e) {
+            return '';
+        }
+    }
+
+    /**
+     * Encoding and Validation Methods
+     */
+
+    /**
+     * Check if a scheme is valid or not
+     *
+     * Will check $scheme to be valid against the generic scheme syntax defined
+     * in RFC-3986. If the class also defines specific acceptable schemes, will
+     * also check that $scheme is one of them.
+     *
+     * @param  string $scheme
+     * @return bool
+     */
+    public static function validateScheme($scheme)
+    {
+        if (
+            ! empty(static::$validSchemes)
+            && ! in_array(strtolower($scheme), static::$validSchemes)
+        ) {
+            return false;
+        }
+
+        return (bool) preg_match('/^[A-Za-z][A-Za-z0-9\-\.+]*$/', $scheme);
+    }
+
+    /**
+     * Check that the userInfo part of a URI is valid
+     *
+     * @param  string $userInfo
+     * @return bool
+     */
+    public static function validateUserInfo($userInfo)
+    {
+        $regex = '/^(?:[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ':]+|%[A-Fa-f0-9]{2})*$/';
+        return (bool) preg_match($regex, $userInfo);
+    }
+
+    /**
+     * Validate the host part
+     *
+     * Users may control which host types to allow by passing a second parameter
+     * with a bitmask of HOST_* constants which are allowed. If not specified,
+     * all address types will be allowed.
+     *
+     * Note that the generic URI syntax allows different host representations,
+     * including IPv4 addresses, IPv6 addresses and future IP address formats
+     * enclosed in square brackets, and registered names which may be DNS names
+     * or even more complex names. This is different (and is much more loose)
+     * from what is commonly accepted as valid HTTP URLs for example.
+     *
+     * @param  string  $host
+     * @param  int $allowed bitmask of allowed host types
+     * @return bool
+     */
+    public static function validateHost($host, $allowed = self::HOST_ALL)
+    {
+        /*
+         * "first-match-wins" algorithm (RFC 3986):
+         * If host matches the rule for IPv4address, then it should be
+         * considered an IPv4 address literal and not a reg-name
+         */
+        if ($allowed & self::HOST_IPVANY) {
+            if (static::isValidIpAddress($host, $allowed)) {
+                return true;
+            }
+        }
+
+        if ($allowed & self::HOST_REGNAME) {
+            if (static::isValidRegName($host)) {
+                return true;
+            }
+        }
+
+        if ($allowed & self::HOST_DNS) {
+            if (static::isValidDnsHostname($host)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Validate the port
+     *
+     * Valid values include numbers between 1 and 65535, and empty values
+     *
+     * @param  int $port
+     * @return bool
+     */
+    public static function validatePort($port)
+    {
+        if ($port === 0) {
+            return false;
+        }
+
+        if ($port) {
+            $port = (int) $port;
+            if ($port < 1 || $port > 0xffff) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate the path
+     *
+     * @param  string $path
+     * @return bool
+     */
+    public static function validatePath($path)
+    {
+        $pchar   = '(?:[' . self::CHAR_UNRESERVED . ':@&=\+\$,]+|%[A-Fa-f0-9]{2})*';
+        $segment = $pchar . "(?:;{$pchar})*";
+        $regex   = "/^{$segment}(?:\/{$segment})*$/";
+        return (bool) preg_match($regex, $path);
+    }
+
+    /**
+     * Check if a URI query or fragment part is valid or not
+     *
+     * Query and Fragment parts are both restricted by the same syntax rules,
+     * so the same validation method can be used for both.
+     *
+     * You can encode a query or fragment part to ensure it is valid by passing
+     * it through the encodeQueryFragment() method.
+     *
+     * @param  string $input
+     * @return bool
+     */
+    public static function validateQueryFragment($input)
+    {
+        $regex = '/^(?:[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ':@\/\?]+|%[A-Fa-f0-9]{2})*$/';
+        return (bool) preg_match($regex, $input);
+    }
+
+    /**
+     * URL-encode the user info part of a URI
+     *
+     * @param  string $userInfo
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function encodeUserInfo($userInfo)
+    {
+        if (! is_string($userInfo)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string, got %s',
+                is_object($userInfo) ? get_class($userInfo) : gettype($userInfo)
+            ));
+        }
+
+        $regex   = '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:]|%(?![A-Fa-f0-9]{2}))/';
+        $escaper = static::getEscaper();
+        $replace = function ($match) use ($escaper) {
+            return $escaper->escapeUrl($match[0]);
+        };
+
+        return preg_replace_callback($regex, $replace, $userInfo);
+    }
+
+    /**
+     * Encode the path
+     *
+     * Will replace all characters which are not strictly allowed in the path
+     * part with percent-encoded representation
+     *
+     * @param  string $path
+     * @throws Exception\InvalidArgumentException
+     * @return string
+     */
+    public static function encodePath($path)
+    {
+        if (! is_string($path)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string, got %s',
+                is_object($path) ? get_class($path) : gettype($path)
+            ));
+        }
+
+        $regex   = '/(?:[^' . self::CHAR_UNRESERVED . ')(:@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/';
+        $escaper = static::getEscaper();
+        $replace = function ($match) use ($escaper) {
+            return $escaper->escapeUrl($match[0]);
+        };
+
+        return preg_replace_callback($regex, $replace, $path);
+    }
+
+    /**
+     * URL-encode a query string or fragment based on RFC-3986 guidelines.
+     *
+     * Note that query and fragment encoding allows more unencoded characters
+     * than the usual rawurlencode() function would usually return - for example
+     * '/' and ':' are allowed as literals.
+     *
+     * @param  string $input
+     * @return string
+     * @throws Exception\InvalidArgumentException
+     */
+    public static function encodeQueryFragment($input)
+    {
+        if (! is_string($input)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string, got %s',
+                is_object($input) ? get_class($input) : gettype($input)
+            ));
+        }
+
+        $regex   = '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/';
+        $escaper = static::getEscaper();
+        $replace = function ($match) use ($escaper) {
+            return $escaper->escapeUrl($match[0]);
+        };
+
+        return preg_replace_callback($regex, $replace, $input);
+    }
+
+    /**
+     * Extract only the scheme part out of a URI string.
+     *
+     * This is used by the parse() method, but is useful as a standalone public
+     * method if one wants to test a URI string for it's scheme before doing
+     * anything with it.
+     *
+     * Will return the scheme if found, or NULL if no scheme found (URI may
+     * still be valid, but not full)
+     *
+     * @param  string $uriString
+     * @throws Exception\InvalidArgumentException
+     * @return string|null
+     */
+    public static function parseScheme($uriString)
+    {
+        if (! is_string($uriString)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Expecting a string, got %s',
+                is_object($uriString) ? get_class($uriString) : gettype($uriString)
+            ));
+        }
+
+        if (preg_match('/^([A-Za-z][A-Za-z0-9\.\+\-]*):/', $uriString, $match)) {
+            return $match[1];
+        }
+    }
+
+    /**
+     * Remove any extra dot segments (/../, /./) from a path
+     *
+     * Algorithm is adapted from RFC-3986 section 5.2.4
+     * (@link http://tools.ietf.org/html/rfc3986#section-5.2.4)
+     *
+     * @todo   consider optimizing
+     * @param  string $path
+     * @return string
+     */
+    public static function removePathDotSegments($path)
+    {
+        $output = '';
+
+        while ($path) {
+            if ($path === '..' || $path === '.') {
+                break;
+            }
+
+            switch (true) {
+                case $path === '/.':
+                    $path = '/';
+                    break;
+                case $path === '/..':
+                    $path         = '/';
+                    $lastSlashPos = strrpos($output, '/', -1);
+                    if (false === $lastSlashPos) {
+                        break;
+                    }
+                    $output = substr($output, 0, $lastSlashPos);
+                    break;
+                case 0 === strpos($path, '/../'):
+                    $path         = '/' . substr($path, 4);
+                    $lastSlashPos = false;
+                    if ($output !== '') {
+                        $lastSlashPos = strrpos($output, '/', -1);
+                    }
+                    if (false === $lastSlashPos) {
+                        break;
+                    }
+                    $output = substr($output, 0, $lastSlashPos);
+                    break;
+                case 0 === strpos($path, '/./'):
+                    $path = substr($path, 2);
+                    break;
+                case 0 === strpos($path, './'):
+                    $path = substr($path, 2);
+                    break;
+                case 0 === strpos($path, '../'):
+                    $path = substr($path, 3);
+                    break;
+                default:
+                    $slash = strpos($path, '/', 1);
+                    if ($slash === false) {
+                        $seg = $path;
+                    } else {
+                        $seg = substr($path, 0, $slash);
+                    }
+
+                    $output .= $seg;
+                    $path    = substr($path, strlen($seg));
+                    break;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Merge a base URI and a relative URI into a new URI object
+     *
+     * This convenience method wraps ::resolve() to allow users to quickly
+     * create new absolute URLs without the need to instantiate and clone
+     * URI objects.
+     *
+     * If objects are passed in, none of the passed objects will be modified.
+     *
+     * @param  Uri|string $baseUri
+     * @param  Uri|string $relativeUri
+     * @return Uri
+     */
+    public static function merge($baseUri, $relativeUri)
+    {
+        $uri = new static($relativeUri);
+        return $uri->resolve($baseUri);
+    }
+
+    /**
+     * Check if a host name is a valid IP address, depending on allowed IP address types
+     *
+     * @param  string  $host
+     * @param  int $allowed allowed address types
+     * @return bool
+     */
+    protected static function isValidIpAddress($host, $allowed)
+    {
+        $validatorParams = [
+            'allowipv4'      => (bool) ($allowed & self::HOST_IPV4),
+            'allowipv6'      => false,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ];
+
+        // Test only IPv4
+        $validator = new Validator\Ip($validatorParams);
+        $return    = $validator->isValid($host);
+        if ($return) {
+            return true;
+        }
+
+        // IPv6 & IPvLiteral must be in literal format
+        $validatorParams = [
+            'allowipv4'      => false,
+            'allowipv6'      => (bool) ($allowed & self::HOST_IPV6),
+            'allowipvfuture' => (bool) ($allowed & self::HOST_IPVFUTURE),
+            'allowliteral'   => true,
+        ];
+        static $regex    = '/^\[.*\]$/';
+        $validator->setOptions($validatorParams);
+        return preg_match($regex, $host) && $validator->isValid($host);
+    }
+
+    /**
+     * Check if an address is a valid DNS hostname
+     *
+     * @param  string $host
+     * @return bool
+     */
+    protected static function isValidDnsHostname($host)
+    {
+        $validator = new Validator\Hostname([
+            'allow' => Validator\Hostname::ALLOW_DNS | Validator\Hostname::ALLOW_LOCAL,
+        ]);
+
+        return $validator->isValid($host);
+    }
+
+    /**
+     * Check if an address is a valid registered name (as defined by RFC-3986) address
+     *
+     * @param  string $host
+     * @return bool
+     */
+    protected static function isValidRegName($host)
+    {
+        $regex = '/^(?:[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ':@\/\?]+|%[A-Fa-f0-9]{2})+$/';
+        return (bool) preg_match($regex, $host);
+    }
+
+    /**
+     * Part normalization methods
+     *
+     * These are called by normalize() using static::_normalize*() so they may
+     * be extended or overridden by extending classes to implement additional
+     * scheme specific normalization rules
+     */
+
+    /**
+     * Normalize the scheme
+     *
+     * Usually this means simply converting the scheme to lower case
+     *
+     * @param  string $scheme
+     * @return string
+     */
+    protected static function normalizeScheme($scheme)
+    {
+        return strtolower($scheme);
+    }
+
+    /**
+     * Normalize the host part
+     *
+     * By default this converts host names to lower case
+     *
+     * @param  string $host
+     * @return string
+     */
+    protected static function normalizeHost($host)
+    {
+        return strtolower($host);
+    }
+
+    /**
+     * Normalize the port
+     *
+     * If the class defines a default port for the current scheme, and the
+     * current port is default, it will be unset.
+     *
+     * @param  int $port
+     * @param  string  $scheme
+     * @return int|null
+     */
+    protected static function normalizePort($port, $scheme = null)
+    {
+        if (
+            $scheme
+            && isset(static::$defaultPorts[$scheme])
+            && ($port === static::$defaultPorts[$scheme])
+        ) {
+            return;
+        }
+
+        return $port;
+    }
+
+    /**
+     * Normalize the path
+     *
+     * This involves removing redundant dot segments, decoding any over-encoded
+     * characters and encoding everything that needs to be encoded and is not
+     *
+     * @param  string $path
+     * @return string
+     */
+    protected static function normalizePath($path)
+    {
+        $path = self::encodePath(
+            self::decodeUrlEncodedChars(
+                self::removePathDotSegments($path),
+                '/[' . self::CHAR_UNRESERVED . ':@&=\+\$,\/;%]/'
+            )
+        );
+
+        return $path;
+    }
+
+    /**
+     * Normalize the query part
+     *
+     * This involves decoding everything that doesn't need to be encoded, and
+     * encoding everything else
+     *
+     * @param  string $query
+     * @return string
+     */
+    protected static function normalizeQuery($query)
+    {
+        $query = self::encodeQueryFragment(
+            self::decodeUrlEncodedChars(
+                $query,
+                '/[' . self::CHAR_UNRESERVED . self::CHAR_QUERY_DELIMS . ':@\/\?]/'
+            )
+        );
+
+        return $query;
+    }
+
+    /**
+     * Normalize the fragment part
+     *
+     * Currently this is exactly the same as normalizeQuery().
+     *
+     * @param  string $fragment
+     * @return string
+     */
+    protected static function normalizeFragment($fragment)
+    {
+        $fragment = self::encodeQueryFragment(
+            self::decodeUrlEncodedChars(
+                $fragment,
+                '/[' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]/'
+            )
+        );
+
+        return $fragment;
+    }
+
+    /**
+     * Decode all percent encoded characters which are allowed to be represented literally
+     *
+     * Will not decode any characters which are not listed in the 'allowed' list
+     *
+     * @param string $input
+     * @param string $allowed Pattern of allowed characters
+     * @return mixed
+     */
+    protected static function decodeUrlEncodedChars($input, $allowed = '')
+    {
+        $decodeCb = function ($match) use ($allowed) {
+            $char = rawurldecode($match[0]);
+            if (preg_match($allowed, $char)) {
+                return $char;
+            }
+            return strtoupper($match[0]);
+        };
+
+        return preg_replace_callback('/%[A-Fa-f0-9]{2}/', $decodeCb, $input);
+    }
+}

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,11 @@
+<?php
+
+if (PHP_VERSION_ID >= 80100) {
+    require __DIR__ . '/TestAsset/Db/AbstractResultSet.php';
+    require __DIR__ . '/TestAsset/Db/Join.php';
+    require __DIR__ . '/TestAsset/Db/ParameterContainer.php';
+    require __DIR__ . '/TestAsset/Db/PredicateSet.php';
+    require __DIR__ . '/TestAsset/Db/ResultSet.php';
+    require __DIR__ . '/TestAsset/Session/ArrayStorage.php';
+    require __DIR__ . '/TestAsset/Uri/Uri.php';
+}


### PR DESCRIPTION
This patch provides support for PHP 8.1.

Changes affecting users:

- The PHP requirement now adds `~8.1.0` to the list of allowed constraints.
- As a replacement for zend-validator:
  - The "replace" section of the package was renamed to "conflict", and the "zend-validator" entry constraint set to "*".
  - The dependency on laminas-zendframework-bridge was removed.
- The laminas-stdlib requirement was bumped to 3.6, to pick up fixes that affect PHP 8.1.
- `ValidatorChain::count()` adds a `#[ReturnTypeWillChange]` attribute to allow it to work under PHP 8.1.
- A change to `Csrf::getTokenFromHash()` to detect a `null` `$hash` argument, and return `null` immediately, avoiding passing it to `explode()` (as PHP 8.1 deprecates `null` arguments to `explode()`).
- A change to `File\Extension::getExtension()` to detect a null "extension" option, and return null early before attempting to parse it.

Changes that do not affect users:

- Since the baseline is now run against PHP 7.3, a number of new Psalm "errors" were found before any code changes occured that were all in the category of "MixedAssignment" or similar; these were added to the Psalm baseline.
- The development dependency for laminas-config was removed, as the tests that consumed it could use vanilla `Traversable` objects instead.
- A number of development dependencies are not yet updated for PHP 8.1, and required importing shims so that tests would run. Each is inlined into the test assets, and updated to work under PHP 8.1; an autoloader that checks for a PHP 8.1 runtime conditionally loads them under that version. Shims include:
  - From laminas-db:
    - `Laminas\Db\Adapter\ParameterContainer`
    - `Laminas\Db\ResultSet\AbstractResultSet`
    - `Laminas\Db\ResultSet\ResultSet`
    - `Laminas\Db\Sql\Join`
    - `Laminas\Db\Sql\PredicateSet`
  - From laminas-session:
    - `Laminas\Session\Storage\ArrayStorage`
  - From laminas-uri
    - `Laminas\Uri\Uri`
- Conditional branching in the `File\IsImageTest` and `File\IsCompressedTest` when testing constructor option population, due to a regression found in the finfo extension under PHP 8.1.
