### PR TITLE
Add installation requirements for use of the default handler

### DIFF
--- a/docs/book/validators/uri.md
+++ b/docs/book/validators/uri.md
@@ -5,6 +5,16 @@ handler to parse the URI. The validator allows for both validation of absolute
 and/or relative URIs. There is the possibility to exchange the handler for
 another one in case the parsing of the uri should be done differently.
 
+<!-- markdownlint-disable-next-line MD001 -->
+> ### Installation Requirements
+>
+> The default handler depends on [laminas-uri](https://docs.laminas.dev/laminas-uri/) to validate the URI.
+> To install the component, run the following command.
+>
+> ```bash
+> composer require laminas/laminas-uri
+> ```
+
 ## Supported options
 
 The following options are supported for `Laminas\Validator\Uri`:


### PR DESCRIPTION
The default handler, which is used in the example, depends on
laminas-uri, however it is not installed automatically. Adding a brief
note about this and instructions on how to install will help users who
are otherwise confronted with a 'class not found' exception when running
the example (including myself this afternoon - hence the PR).

Installation requirements block copied from csrf.md and modified to
match the URI validator.

Signed-off-by: Paul Waring <paul@phpdeveloper.org.uk>

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

