### PR TITLE
Domains with bad MX configurations should not print warnings to page

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
          bootstrap="./vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
+         failOnWarning="true"
          colors="true">
     <testsuites>
         <testsuite name="laminas-validator Test Suite">

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -449,13 +449,13 @@ class EmailAddress extends AbstractValidator
         $validAddress = false;
         $reserved     = true;
         foreach (array_keys($this->mxRecord) as $hostname) {
-            if (! trim($hostname)) {
-                continue;
-            }
-
             $res = $this->isReserved($hostname);
             if (! $res) {
                 $reserved = false;
+            }
+
+            if (! is_string($hostname) || ! trim($hostname)) {
+                continue;
             }
 
             if (

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -24,6 +24,7 @@ use function is_string;
 use function preg_match;
 use function strlen;
 use function strpos;
+use function trim;
 
 use const INTL_IDNA_VARIANT_UTS46;
 
@@ -448,6 +449,10 @@ class EmailAddress extends AbstractValidator
         $validAddress = false;
         $reserved     = true;
         foreach (array_keys($this->mxRecord) as $hostname) {
+            if (! trim($hostname)) {
+                continue;
+            }
+
             $res = $this->isReserved($hostname);
             if (! $res) {
                 $reserved = false;

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -18,14 +18,12 @@ use function getenv;
 use function implode;
 use function next;
 use function preg_replace;
-use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
 use function str_repeat;
 use function strstr;
 
 use const E_USER_NOTICE;
-use const E_WARNING;
 
 /**
  * @group      Laminas_Validator
@@ -934,15 +932,6 @@ class EmailAddressTest extends TestCase
             'useDeepMxCheck' => true,
         ]);
 
-        $called = false;
-        /** @psalm-suppress InvalidArgument **/
-        set_error_handler(static function () use (&$called) {
-            $called = true;
-        }, E_WARNING);
-
-        $validator->isValid('jon@example.com');
-
-        restore_error_handler();
-        $this->assertFalse($called);
+        $this->assertFalse($validator->isValid('jon@example.com'));
     }
 }

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -935,7 +935,8 @@ class EmailAddressTest extends TestCase
         ]);
 
         $called = false;
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$called) {
+        /** @psalm-suppress InvalidArgument **/
+        set_error_handler(static function () use (&$called) {
             $called = true;
         }, E_WARNING);
 

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -18,12 +18,14 @@ use function getenv;
 use function implode;
 use function next;
 use function preg_replace;
+use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
 use function str_repeat;
 use function strstr;
 
 use const E_USER_NOTICE;
+use const E_WARNING;
 
 /**
  * @group      Laminas_Validator
@@ -923,5 +925,23 @@ class EmailAddressTest extends TestCase
         $validator = new EmailAddress();
         $validator->useDomainCheck(false);
         $this->assertFalse($validator->getDomainCheck());
+    }
+
+    public function testWillNotCheckEmptyDeepMxChecks(): void
+    {
+        $validator = new EmailAddress([
+            'useMxCheck'     => true,
+            'useDeepMxCheck' => true,
+        ]);
+
+        $called = false;
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$called) {
+            $called = true;
+        }, E_WARNING);
+
+        $validator->isValid('jon@example.com');
+
+        restore_error_handler();
+        $this->assertFalse($called);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This change is necessary to prevent the EmailAddress validator, with deep MX checks enabled, from printing warnings to page when domain configurations are not valid.

It is possible that mx records return empty servers, which is where the validator currently prints unsightly errors to page (e.g., `host example.com`).

For example, attempting to validate jon@example.com (which is a common black-box scanner test), yields:
<img width="1138" alt="Screen Shot 2022-03-07 at 10 47 36 PM" src="https://user-images.githubusercontent.com/887224/157162554-174f0330-0b55-41ba-af0e-50cf4265d100.png">

Validation should be silent, the warnings otherwise yield useful information to attackers (path structure, etc.).

A test is added to validate the correction (test fails when the fix is not implemented) by trapping (and then restoring) the error handler.

Cheers.
Alex