### PR TITLE
QA: Bumps Dependencies and Improves Static Analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
-        "container-interop/container-interop": "^1.1",
+        "laminas/laminas-servicemanager": "^3.12.0",
         "laminas/laminas-stdlib": "^3.10"
     },
     "require-dev": {
@@ -43,7 +43,6 @@
         "laminas/laminas-http": "^2.14.2",
         "laminas/laminas-i18n": "^2.15.0",
         "laminas/laminas-math": "^2.7.1",
-        "laminas/laminas-servicemanager": "^3.12.0",
         "laminas/laminas-session": "^2.12.1",
         "laminas/laminas-uri": "^2.9.1",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.3.99"
+            "php": "7.4.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "container-interop/container-interop": "^1.1",
         "laminas/laminas-stdlib": "^3.10"
     },
@@ -39,20 +39,20 @@
         "laminas/laminas-cache": "^2.6.1",
         "laminas/laminas-coding-standard": "~2.2.1",
         "laminas/laminas-db": "^2.7",
-        "laminas/laminas-filter": "^2.6",
+        "laminas/laminas-filter": "^2.14.0",
         "laminas/laminas-http": "^2.14.2",
-        "laminas/laminas-i18n": "^2.6",
-        "laminas/laminas-math": "^2.6",
-        "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-        "laminas/laminas-session": "^2.8",
-        "laminas/laminas-uri": "^2.7",
+        "laminas/laminas-i18n": "^2.15.0",
+        "laminas/laminas-math": "^2.7.1",
+        "laminas/laminas-servicemanager": "^3.12.0",
+        "laminas/laminas-session": "^2.12.1",
+        "laminas/laminas-uri": "^2.9.1",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.15.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "vimeo/psalm": "^4.3"
+        "vimeo/psalm": "^4.23"
     },
     "suggest": {
         "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,56 +4,111 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cfab05d9913bbc9e4ac25184c989da7",
+    "content-hash": "9c648cb7391ef85eac6ec4b3dfc37651",
     "packages": [
         {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/05ac4b1fb1fe9333313eeafced9b6c7946589487",
+                "reference": "05ac4b1fb1fe9333313eeafced9b6c7946589487",
                 "shasum": ""
             },
             "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
+                    "Laminas\\ServiceManager\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
             "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
             },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-06-13T16:20:56+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "449c0405e182bfe77702604a474668fbb63e9907"
+                "reference": "0d669074845fc80a99add0f64025192f143ef836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/449c0405e182bfe77702604a474668fbb63e9907",
-                "reference": "449c0405e182bfe77702604a474668fbb63e9907",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/0d669074845fc80a99add0f64025192f143ef836",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836",
                 "shasum": ""
             },
             "require": {
@@ -99,24 +154,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-09T08:43:49+00:00"
+            "time": "2022-06-10T14:49:09+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -145,9 +200,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "packages-dev": [
@@ -392,20 +447,20 @@
         },
         {
             "name": "composer/pcre",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "c8e9d27cfc5ed22643c19c160455b473ffd8aabe"
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/c8e9d27cfc5ed22643c19c160455b473ffd8aabe",
-                "reference": "c8e9d27cfc5ed22643c19c160455b473ffd8aabe",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
@@ -415,7 +470,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -443,7 +498,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/2.0.0"
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
             },
             "funding": [
                 {
@@ -459,7 +514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T20:05:29+00:00"
+            "time": "2022-02-25T20:21:48+00:00"
         },
         {
             "name": "composer/semver",
@@ -2056,33 +2111,33 @@
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
+                "reference": "58af67282db37d24e584a837a94ee55b9c7552be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/58af67282db37d24e584a837a94ee55b9c7552be",
+                "reference": "58af67282db37d24e584a837a94ee55b9c7552be",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "ext-ctype": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
+                "infection/infection": "^0.26.6",
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.12.2",
-                "vimeo/psalm": "^3.16"
-            },
-            "suggest": {
-                "ext-iconv": "*",
-                "ext-mbstring": "*"
+                "maglnet/composer-require-checker": "^3.8.0",
+                "phpunit/phpunit": "^9.5.18",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.22.0"
             },
             "type": "library",
             "autoload": {
@@ -2114,39 +2169,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-02T17:10:53+00:00"
+            "time": "2022-03-08T20:15:36+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "container-interop/container-interop": "^1.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-stdlib": "^3.6",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5"
+                "phpunit/phpunit": "^9.5.5",
+                "psr/container": "^1.1.2 || ^2.0.2"
             },
             "suggest": {
-                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
             },
             "type": "library",
             "autoload": {
@@ -2180,44 +2236,41 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-07T22:35:32+00:00"
+            "time": "2022-04-06T21:05:17+00:00"
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.12.0",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "0fc5dcd27dc22dba1a2544123684c67768fc5f88"
+                "reference": "98a126b8cd069a446054680c9be5f37a61f6dc17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/0fc5dcd27dc22dba1a2544123684c67768fc5f88",
-                "reference": "0fc5dcd27dc22dba1a2544123684c67768fc5f88",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/98a126b8cd069a446054680c9be5f37a61f6dc17",
+                "reference": "98a126b8cd069a446054680c9be5f37a61f6dc17",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-stdlib": "^3.6.1",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
-                "laminas/laminas-validator": "<2.10.1"
-            },
-            "replace": {
-                "zendframework/zend-filter": "^2.9.2"
+                "laminas/laminas-validator": "<2.10.1",
+                "zendframework/zend-filter": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-crypt": "^3.2.1",
-                "laminas/laminas-servicemanager": "^3.3",
-                "laminas/laminas-uri": "^2.6",
-                "pear/archive_tar": "^1.4.3",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "psr/http-factory": "^1.0",
-                "vimeo/psalm": "^4.6"
+                "laminas/laminas-coding-standard": "^2.3.0",
+                "laminas/laminas-crypt": "^3.5.1",
+                "laminas/laminas-servicemanager": "^3.7.0",
+                "laminas/laminas-uri": "^2.9.1",
+                "pear/archive_tar": "^1.4.14",
+                "phpspec/prophecy-phpunit": "^2.0.1",
+                "phpunit/phpunit": "^9.5.10",
+                "psalm/plugin-phpunit": "^0.15.2",
+                "psr/http-factory": "^1.0.1",
+                "vimeo/psalm": "^4.13.1"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -2262,7 +2315,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-10-24T21:01:15+00:00"
+            "time": "2022-02-22T23:09:15+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -2331,24 +2384,25 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.13.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "b3a55d05818ed37ed18e76c103727e95e32cf591"
+                "reference": "1654fcd6cd27c01a902b47fe71fa583ad227268c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/b3a55d05818ed37ed18e76c103727e95e32cf591",
-                "reference": "b3a55d05818ed37ed18e76c103727e95e32cf591",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/1654fcd6cd27c01a902b47fe71fa583ad227268c",
+                "reference": "1654fcd6cd27c01a902b47fe71fa583ad227268c",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "laminas/laminas-stdlib": "^2.7 || ^3.0",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "laminas/laminas-view": "<2.20.0",
                 "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-i18n": "*"
             },
@@ -2356,14 +2410,17 @@
                 "laminas/laminas-cache": "^3.1.2",
                 "laminas/laminas-cache-storage-adapter-memory": "^2.0.0",
                 "laminas/laminas-cache-storage-deprecated-factory": "^1.0.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "laminas/laminas-config": "^3.4.0",
                 "laminas/laminas-eventmanager": "^3.4.0",
                 "laminas/laminas-filter": "^2.10.0",
                 "laminas/laminas-servicemanager": "^3.7.0",
                 "laminas/laminas-validator": "^2.14.0",
-                "laminas/laminas-view": "^2.12.0",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-view": "^2.20.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.21"
             },
             "suggest": {
                 "laminas/laminas-cache": "You should install this package to cache the translations",
@@ -2411,7 +2468,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-06T00:44:40+00:00"
+            "time": "2022-04-01T10:47:19+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -2530,95 +2587,6 @@
                 "source": "https://github.com/laminas/laminas-math"
             },
             "time": "2019-12-31T17:24:15+00:00"
-        },
-        {
-            "name": "laminas/laminas-servicemanager",
-            "version": "3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
-            },
-            "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
-            },
-            "require-dev": {
-                "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.0",
-                "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1.2",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.4",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.8"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Factory-Driven Dependency Injection Container",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "PSR-11",
-                "dependency-injection",
-                "di",
-                "dic",
-                "laminas",
-                "service-manager",
-                "servicemanager"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-07-24T19:33:07+00:00"
         },
         {
             "name": "laminas/laminas-session",
@@ -2762,26 +2730,26 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
+                "reference": "7f049390b756d34ba5940a8fb47634fbb51f79ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/7f049390b756d34ba5940a8fb47634fbb51f79ab",
+                "reference": "7f049390b756d34ba5940a8fb47634fbb51f79ab",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": ">=7.4, <8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
+                "phpunit/phpunit": "^9.5.14",
+                "psalm/plugin-phpunit": "^0.15.2",
+                "squizlabs/php_codesniffer": "^3.6.2",
+                "vimeo/psalm": "^4.21.0"
             },
             "type": "library",
             "extra": {
@@ -2820,7 +2788,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-21T14:34:37+00:00"
+            "time": "2022-02-22T22:17:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5302,16 +5270,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
                 "shasum": ""
             },
             "require": {
@@ -5354,7 +5322,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-13T06:31:38+00:00"
         },
         {
             "name": "symfony/console",
@@ -6511,11 +6479,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0"
+        "php": "^7.4 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.99"
+        "php": "7.4.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c648cb7391ef85eac6ec4b3dfc37651",
+    "content-hash": "0eb1f1c3bae821da3c13e1e504414c93",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -779,32 +779,15 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Explode.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>! $validator</code>
-      <code>$validator</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>[$value]</code>
     </DocblockTypeContradiction>
-    <InvalidNullableReturnType occurrences="1">
-      <code>ValidatorPluginManager</code>
-    </InvalidNullableReturnType>
-    <MixedArgument occurrences="2">
-      <code>$name</code>
-      <code>$options</code>
-    </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;abstractOptions['messages'][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
-      <code>$name</code>
-      <code>$options</code>
+    <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;pluginManager</code>
-    </NullableReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$validator</code>
-    </PropertyNotSetInConstructor>
     <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;abstractOptions</code>
     </PropertyTypeCoercion>
@@ -1840,9 +1823,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/StaticValidator.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === static::$plugins</code>
-    </DocblockTypeContradiction>
     <RedundantCondition occurrences="1">
       <code>method_exists($plugins, 'configure')</code>
     </RedundantCondition>
@@ -2035,19 +2015,15 @@
       <code>getServiceLocator</code>
       <code>getServiceLocator</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="1">
-      <code>gettype($instance)</code>
-    </DocblockTypeContradiction>
     <MethodSignatureMismatch occurrences="1">
       <code>ValidatorPluginManager</code>
     </MethodSignatureMismatch>
     <MissingParamType occurrences="1">
       <code>$configOrContainerInstance</code>
     </MissingParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$configOrContainerInstance</code>
       <code>$container-&gt;get('MvcTranslator')</code>
-      <code>$plugin</code>
     </MixedArgument>
     <MixedMethodCall occurrences="2">
       <code>get</code>
@@ -2059,11 +2035,10 @@
     <RedundantCondition occurrences="1">
       <code>$container === $this &amp;&amp; method_exists($container, 'getServiceLocator')</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="3">
       <code>$container</code>
       <code>$container</code>
       <code>$container-&gt;getServiceLocator()</code>
-      <code>is_object($instance)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/ValidatorPluginManagerAwareInterface.php">
@@ -2075,11 +2050,6 @@
     <DeprecatedInterface occurrences="1">
       <code>ValidatorPluginManagerFactory</code>
     </DeprecatedInterface>
-    <MissingParamType occurrences="3">
-      <code>$name</code>
-      <code>$name</code>
-      <code>$requestedName</code>
-    </MissingParamType>
     <MixedArgument occurrences="1">
       <code>$config['validators']</code>
     </MixedArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2822,21 +2822,9 @@
     <MixedAssignment occurrences="1">
       <code>$validator</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
-      <code>get</code>
-      <code>get</code>
+    <MixedMethodCall occurrences="1">
       <code>getValidatorPluginManager</code>
-      <code>setInvokableClass</code>
-      <code>setService</code>
     </MixedMethodCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;validators</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="3">
-      <code>$this-&gt;validators</code>
-      <code>$this-&gt;validators</code>
-      <code>$this-&gt;validators</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="test/_files/MyBarcode1.php">
     <UndefinedFunction occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2818,14 +2818,6 @@
       <code>$container</code>
     </UnusedClosureParam>
   </file>
-  <file src="test/ValidatorPluginManagerTest.php">
-    <MixedAssignment occurrences="1">
-      <code>$validator</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>getValidatorPluginManager</code>
-    </MixedMethodCall>
-  </file>
   <file src="test/_files/MyBarcode1.php">
     <UndefinedFunction occurrences="1">
       <code>'invalid'</code>

--- a/src/Explode.php
+++ b/src/Explode.php
@@ -11,6 +11,9 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
+/**
+ * @psalm-import-type ValidatorSpecification from ValidatorInterface
+ */
 class Explode extends AbstractValidator implements ValidatorPluginManagerAwareInterface
 {
     public const INVALID = 'explodeInvalid';
@@ -29,7 +32,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     /** @var string */
     protected $valueDelimiter = ',';
 
-    /** @var ValidatorInterface */
+    /** @var ValidatorInterface|null */
     protected $validator;
 
     /** @var bool */
@@ -75,7 +78,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     public function getValidatorPluginManager()
     {
         if (! $this->pluginManager) {
-            $this->setValidatorPluginManager(new ValidatorPluginManager(new ServiceManager()));
+            $this->pluginManager = new ValidatorPluginManager(new ServiceManager());
         }
 
         return $this->pluginManager;
@@ -84,7 +87,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     /**
      * Sets the Validator for validating each value
      *
-     * @param ValidatorInterface|array $validator
+     * @param ValidatorInterface|ValidatorSpecification $validator
      * @throws Exception\RuntimeException
      * @return $this
      */
@@ -96,8 +99,9 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
                     'Invalid validator specification provided; does not include "name" key'
                 );
             }
-            $name      = $validator['name'];
-            $options   = $validator['options'] ?? [];
+            $name    = $validator['name'];
+            $options = $validator['options'] ?? [];
+            /** @psalm-suppress MixedAssignment $validator */
             $validator = $this->getValidatorPluginManager()->get($name, $options);
         }
 
@@ -114,7 +118,7 @@ class Explode extends AbstractValidator implements ValidatorPluginManagerAwareIn
     /**
      * Gets the Validator for validating each value
      *
-     * @return ValidatorInterface
+     * @return ValidatorInterface|null
      */
     public function getValidator()
     {

--- a/src/StaticValidator.php
+++ b/src/StaticValidator.php
@@ -9,7 +9,7 @@ use function method_exists;
 
 class StaticValidator
 {
-    /** @var ValidatorPluginManager */
+    /** @var ValidatorPluginManager|null */
     protected static $plugins;
 
     /**
@@ -38,17 +38,20 @@ class StaticValidator
      */
     public static function getPluginManager()
     {
-        if (null === static::$plugins) {
-            static::setPluginManager(new ValidatorPluginManager(new ServiceManager()));
+        if (! static::$plugins instanceof ValidatorPluginManager) {
+            $plugins = new ValidatorPluginManager(new ServiceManager());
+            static::setPluginManager($plugins);
+
+            return $plugins;
         }
         return static::$plugins;
     }
 
     /**
-     * @param  mixed    $value
-     * @param  string   $classBaseName
-     * @param  array    $options OPTIONAL associative array of options to pass as
-     *     the sole argument to the validator constructor.
+     * @param  mixed                            $value
+     * @param  class-string<ValidatorInterface> $classBaseName
+     * @param  array                            $options OPTIONAL associative array of options to pass as
+     *                                                   the sole argument to the validator constructor.
      * @return bool
      * @throws Exception\InvalidArgumentException For an invalid $options argument.
      */

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -26,7 +26,7 @@ class ValidatorChain implements
      */
     public const DEFAULT_PRIORITY = 1;
 
-    /** @var ValidatorPluginManager|null */
+    /** @var ValidatorPluginManager<ValidatorInterface>|null */
     protected $plugins;
 
     /**
@@ -66,7 +66,7 @@ class ValidatorChain implements
     /**
      * Get plugin manager instance
      *
-     * @return ValidatorPluginManager
+     * @return ValidatorPluginManager<ValidatorInterface>
      */
     public function getPluginManager()
     {
@@ -98,7 +98,7 @@ class ValidatorChain implements
      * @return ValidatorInterface
      * @template T of ValidatorInterface
      * @psalm-param string|class-string<T> $name
-     * @psalm-return ($name is class-string ? T : ValidatorInterface)
+     * @psalm-return ValidatorInterface
      */
     public function plugin($name, ?array $options = null)
     {

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -2,6 +2,14 @@
 
 namespace Laminas\Validator;
 
+/**
+ * @psalm-type ValidatorSpecification = array{
+ *     name: string|class-string<ValidatorInterface>,
+ *     priority?: int,
+ *     break_chain_on_failure?: bool,
+ *     options?: array<string, mixed>,
+ * }
+ */
 interface ValidatorInterface
 {
     /**

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -248,7 +248,7 @@ class ValidatorPluginManager extends AbstractPluginManager
         \Zend\Validator\Bitwise::class      => Bitwise::class,
         \Zend\Validator\Callback::class     => Callback::class,
         \Zend\Validator\CreditCard::class   => CreditCard::class,
-        \zend\validator\csrf::class         => Csrf::class,
+        \Zend\Validator\Csrf::class         => Csrf::class,
         \Zend\Validator\DateStep::class     => DateStep::class,
         \Zend\Validator\Date::class         => Date::class,
         DateTime::class                     => I18nValidator\DateTime::class,

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -2,11 +2,13 @@
 
 namespace Laminas\Validator;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\ServiceManager;
 use Zend\I18n\Validator\Alnum;
 use Zend\I18n\Validator\Alpha;
 use Zend\I18n\Validator\DateTime;
@@ -47,7 +49,13 @@ use function method_exists;
 use function sprintf;
 
 /**
- * @method ValidatorInterface get(string $name, ?array $options = null)
+ * @link ConfigInterface
+ * @link ServiceManager
+ *
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ * @psalm-import-type FactoriesConfigurationType from ConfigInterface
+ * @template InstanceType of ValidatorInterface
+ * @extends AbstractPluginManager<InstanceType>
  */
 class ValidatorPluginManager extends AbstractPluginManager
 {
@@ -55,6 +63,7 @@ class ValidatorPluginManager extends AbstractPluginManager
      * Default set of aliases
      *
      * @var array<array-key, string>
+     * @psalm-suppress UndefinedClass
      */
     protected $aliases = [
         'alnum'                  => I18nValidator\Alnum::class,
@@ -239,7 +248,7 @@ class ValidatorPluginManager extends AbstractPluginManager
         \Zend\Validator\Bitwise::class      => Bitwise::class,
         \Zend\Validator\Callback::class     => Callback::class,
         \Zend\Validator\CreditCard::class   => CreditCard::class,
-        \Zend\Validator\Csrf::class         => Csrf::class,
+        \zend\validator\csrf::class         => Csrf::class,
         \Zend\Validator\DateStep::class     => DateStep::class,
         \Zend\Validator\Date::class         => Date::class,
         DateTime::class                     => I18nValidator\DateTime::class,
@@ -361,7 +370,7 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Default set of factories
      *
-     * @var array<array-key, callable|string>
+     * @var FactoriesConfigurationType
      */
     protected $factories = [
         I18nValidator\Alnum::class       => InvokableFactory::class,
@@ -548,6 +557,8 @@ class ValidatorPluginManager extends AbstractPluginManager
      * attached translator, if any, to the currently requested helper.
      *
      * {@inheritDoc}
+     *
+     * @param ServiceManagerConfiguration $v3config
      */
     public function __construct($configOrContainerInstance = null, array $v3config = [])
     {

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -2,13 +2,13 @@
 
 namespace Laminas\Validator;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
 use Zend\I18n\Validator\Alnum;
 use Zend\I18n\Validator\Alpha;
 use Zend\I18n\Validator\DateTime;

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -2,11 +2,11 @@
 
 namespace Laminas\Validator;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
 
 use function is_array;
 

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -2,26 +2,35 @@
 
 namespace Laminas\Validator;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceManager;
 
 use function is_array;
 
+/**
+ * @link ServiceManager
+ *
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ */
 class ValidatorPluginManagerFactory implements FactoryInterface
 {
     /**
      * laminas-servicemanager v2 support for invocation options.
      *
-     * @var null|array
+     * @var null|ServiceManagerConfiguration
      */
     protected $creationOptions;
 
     /**
      * {@inheritDoc}
      *
+     * @param string $name
+     * @param ServiceManagerConfiguration|null $options
      * @return ValidatorPluginManager
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function __invoke(ContainerInterface $container, $name, ?array $options = null)
     {
@@ -54,6 +63,8 @@ class ValidatorPluginManagerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @param string|null $name
+     * @param string|null $requestedName
      * @return ValidatorPluginManager
      */
     public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
@@ -64,7 +75,7 @@ class ValidatorPluginManagerFactory implements FactoryInterface
     /**
      * laminas-servicemanager v2 support for invocation options.
      *
-     * @param array $options
+     * @param ServiceManagerConfiguration $options
      * @return void
      */
     public function setCreationOptions(array $options)

--- a/test/ExplodeTest.php
+++ b/test/ExplodeTest.php
@@ -142,6 +142,7 @@ class ExplodeTest extends TestCase
     {
         $validator = new Explode();
         $this->expectException(RuntimeException::class);
+        /** @psalm-suppress InvalidArgument */
         $validator->setValidator([
             'options' => [],
         ]);

--- a/test/StaticValidatorTest.php
+++ b/test/StaticValidatorTest.php
@@ -9,6 +9,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Between;
 use Laminas\Validator\StaticValidator;
+use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 
@@ -130,7 +131,7 @@ class StaticValidatorTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     0: int,
-     *     1: string,
+     *     1: class-string<ValidatorInterface>,
      *     2: array<string, int>,
      *     3: bool
      * }>
@@ -138,15 +139,16 @@ class StaticValidatorTest extends TestCase
     public function parameterizedData(): array
     {
         return [
-            'valid-positive-range'   => [5, 'between', ['min' => 1, 'max' => 10], true],
-            'valid-negative-range'   => [-5, 'between', ['min' => -10, 'max' => -1], true],
-            'invalid-positive-range' => [-5, 'between', ['min' => 1, 'max' => 10], false],
-            'invalid-negative-range' => [5, 'between', ['min' => -10, 'max' => -1], false],
+            'valid-positive-range'   => [5, Between::class, ['min' => 1, 'max' => 10], true],
+            'valid-negative-range'   => [-5, Between::class, ['min' => -10, 'max' => -1], true],
+            'invalid-positive-range' => [-5, Between::class, ['min' => 1, 'max' => 10], false],
+            'invalid-negative-range' => [5, Between::class, ['min' => -10, 'max' => -1], false],
         ];
     }
 
     /**
      * @dataProvider parameterizedData
+     * @param class-string<ValidatorInterface> $validator
      */
     public function testExecuteValidWithParameters(
         int $value,
@@ -158,18 +160,19 @@ class StaticValidatorTest extends TestCase
     }
 
     /**
-     * @psalm-return array<string, array{0: int, 1: string, 2: int[]}>
+     * @psalm-return array<string, array{0: int, 1: class-string<ValidatorInterface>, 2: int[]}>
      */
     public function invalidParameterizedData(): array
     {
         return [
-            'positive-range' => [5, 'between', [1, 10]],
-            'negative-range' => [-5, 'between', [-10, -1]],
+            'positive-range' => [5, Between::class, [1, 10]],
+            'negative-range' => [-5, Between::class, [-10, -1]],
         ];
     }
 
     /**
      * @dataProvider invalidParameterizedData
+     * @param class-string<ValidatorInterface> $validator
      */
     public function testExecuteRaisesExceptionForIndexedOptionsArray(
         int $value,
@@ -193,6 +196,7 @@ class StaticValidatorTest extends TestCase
     public function testStaticFactoryClassNotFound()
     {
         $this->expectException(ServiceNotFoundException::class);
+        /** @psalm-suppress ArgumentTypeCoercion, UndefinedClass */
         StaticValidator::execute('1234', 'UnknownValidator');
     }
 }

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace LaminasTest\Validator;
 
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Validator\Digits;
 use Laminas\Validator\ValidatorInterface;

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace LaminasTest\Validator;
 
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Validator\Digits;
 use Laminas\Validator\ValidatorInterface;
@@ -10,6 +9,7 @@ use Laminas\Validator\ValidatorPluginManager;
 use Laminas\Validator\ValidatorPluginManagerFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 class ValidatorPluginManagerFactoryTest extends TestCase
 {

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -3,7 +3,7 @@
 namespace LaminasTest\Validator;
 
 use Exception;
-use Interop\Container\ContainerInterface;
+use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -3,7 +3,6 @@
 namespace LaminasTest\Validator;
 
 use Exception;
-use Interop\Container\ContainerInterface; // phpcs:ignore
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;
@@ -13,6 +12,7 @@ use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Container\ContainerInterface;
 
 use function get_class;
 use function sprintf;
@@ -23,6 +23,8 @@ use function sprintf;
 class ValidatorPluginManagerTest extends TestCase
 {
     use ProphecyTrait;
+
+    private ValidatorPluginManager $validators;
 
     protected function setUp(): void
     {
@@ -59,6 +61,7 @@ class ValidatorPluginManagerTest extends TestCase
     public function testRegisteringInvalidValidatorRaisesException(): void
     {
         try {
+            /** @psalm-suppress InvalidArgument */
             $this->validators->setService('test', $this);
         } catch (InvalidServiceException $e) {
             $this->assertStringContainsString(ValidatorInterface::class, $e->getMessage());

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -7,6 +7,7 @@ use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\RuntimeException;
+use Laminas\Validator\Explode;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
@@ -14,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
+use function assert;
 use function get_class;
 use function sprintf;
 
@@ -94,7 +96,8 @@ class ValidatorPluginManagerTest extends TestCase
 
     public function testInjectedValidatorPluginManager(): void
     {
-        $validator = $this->validators->get('explode');
+        $validator = $this->validators->get(Explode::class);
+        assert($validator instanceof Explode);
         $this->assertSame($this->validators, $validator->getValidatorPluginManager());
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Drops PHP 7.3
- Drops Service Manager v2
- Updates latest dev dependencies
- Adds template types for plugin manager
- Fixes newly surfaced type errors
- Drops Interop\Container
- Moves Service Manager from dev deps to required deps

