### PR TITLE
Remove documented requirement for `Laminas\Math`

### DIFF
--- a/docs/book/validators/csrf.md
+++ b/docs/book/validators/csrf.md
@@ -9,17 +9,6 @@ The typical mitigation is to create a one-time token that is transmitted as part
 This token expires after first submission or after a short amount of time, preventing replays or further submissions.
 If the token provided does not match what was originally sent, an error should be returned.
 
-<!-- markdownlint-disable-next-line MD001 -->
-> ### Installation Requirements
->
-> The CSRF validator depends on [laminas-math](https://docs.laminas.dev/laminas-math/) to generate the hash and on [laminas-session](https://docs.laminas.dev/laminas-session/) to persist the generated token between requests.
-> Consequently, both components must be installed before the validator can be used.
-> To install both components, run the following command.
->
-> ```bash
-> composer require laminas/laminas-math laminas/laminas-session
-> ```
-
 ## Supported Options
 
 The following options are supported for `Laminas\Validator\Csrf`.


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Pull #133 did not update the documentation for the CSRF validator