### PR TITLE
Fix some 8.2 compatibility issues in `Date` validator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.26.0@6998fabb2bf528b65777bf9941920888d23c03ac">
   <file src="bin/update_hostname_validator.php">
     <MissingClosureParamType occurrences="2">
       <code>$domain</code>
@@ -579,6 +579,9 @@
     <PossiblyUndefinedVariable occurrences="1">
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$errors === false</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/DateStep.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1431,7 +1434,7 @@
     </PossiblyNullArgument>
     <RedundantConditionGivenDocblockType occurrences="3">
       <code>$file !== null</code>
-      <code>is_array($files)</code>
+      <code>is_countable($files)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/UploadFile.php">
@@ -2045,9 +2048,6 @@
       <code>[$this, 'errorHandlerIgnore']</code>
       <code>[$this, 'errorHandlerIgnore']</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="1">
-      <code>1</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$options</code>
@@ -2059,9 +2059,6 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
-    <PossiblyNullArgument occurrences="1">
-      <code>var_export($messages, 1)</code>
-    </PossiblyNullArgument>
   </file>
   <file src="test/BarcodeTest.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -2167,9 +2164,6 @@
       <code>'users'</code>
       <code>'users'</code>
     </InvalidArgument>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$mockHasResultRow-&gt;one</code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="test/Db/RecordExistsTest.php">
     <DeprecatedMethod occurrences="2">
@@ -2188,9 +2182,6 @@
     <PossiblyNullReference occurrences="1">
       <code>$parameters</code>
     </PossiblyNullReference>
-    <UndefinedPropertyAssignment occurrences="1">
-      <code>$mockHasResultRow-&gt;one</code>
-    </UndefinedPropertyAssignment>
   </file>
   <file src="test/Db/TestAsset/ConcreteDbValidator.php">
     <PropertyNotSetInConstructor occurrences="2">
@@ -2684,31 +2675,11 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$classOrInstance</code>
     </ArgumentTypeCoercion>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
     <MixedArgument occurrences="2"/>
     <MixedInferredReturnType occurrences="2">
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="6">
-      <code>will</code>
-      <code>will</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturnCallback</code>
-      <code>willReturnCallback</code>
-    </MixedMethodCall>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <UndefinedInterfaceMethod occurrences="6">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="test/UriTest.php">
     <InvalidArgument occurrences="4">

--- a/src/Date.php
+++ b/src/Date.php
@@ -207,6 +207,10 @@ class Date extends AbstractValidator
         // Invalid dates can show up as warnings (ie. "2007-02-99")
         // and still return a DateTime object.
         $errors = DateTime::getLastErrors();
+        if ($errors === false) {
+            return $date;
+        }
+
         if ($errors['warning_count'] > 0) {
             if ($addErrors) {
                 $this->error(self::FALSEFORMAT);

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -39,7 +39,7 @@ class DateTest extends TestCase
     /**
      * @return array[]
      * @psalm-return array<array{
-     *     0: string|numeric|DateTime|object|array,
+     *     0: string|numeric|DateTime|object|array|null,
      *     1: null|string,
      *     2: bool,
      *     3: bool
@@ -97,6 +97,10 @@ class DateTest extends TestCase
             [new DateTime(),            null,              true,     false],
             // invalid obj
             [new stdClass(),            null,              false,    false],
+            // Empty Values
+            [[], null, false, false],
+            ['',                        null,              false,    false],
+            [null,                      null,              false,    false],
         ];
     }
 
@@ -104,24 +108,24 @@ class DateTest extends TestCase
      * Ensures that the validator follows expected behavior
      *
      * @dataProvider datesDataProvider
-     * @param string|numeric|DateTime|object|array $input
+     * @param string|numeric|DateTime|object|array|null $input
      */
     public function testBasic($input, ?string $format, bool $result, bool $resultStrict): void
     {
         $this->validator->setFormat($format);
-        /** @psalm-suppress ArgumentTypeCoercion */
+        /** @psalm-suppress ArgumentTypeCoercion, PossiblyNullArgument */
         $this->assertEquals($result, $this->validator->isValid($input));
     }
 
     /**
      * @dataProvider datesDataProvider
-     * @param string|numeric|DateTime|object|array $input
+     * @param string|numeric|DateTime|object|array|null $input
      */
     public function testBasicStrictMode($input, ?string $format, bool $result, bool $resultStrict): void
     {
         $this->validator->setStrict(true);
         $this->validator->setFormat($format);
-        /** @psalm-suppress ArgumentTypeCoercion */
+        /** @psalm-suppress ArgumentTypeCoercion, PossiblyNullArgument */
         $this->assertSame($resultStrict, $this->validator->isValid($input));
     }
 

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -31,7 +31,7 @@ class NoRecordExistsTest extends TestCase
         $mockConnection = $this->createMock(ConnectionInterface::class);
 
         // Mock has result
-        $mockHasResultRow      = new class extends ArrayObject {
+        $mockHasResultRow = new class extends ArrayObject {
             public ?string $one = null;
         };
 

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -31,7 +31,10 @@ class NoRecordExistsTest extends TestCase
         $mockConnection = $this->createMock(ConnectionInterface::class);
 
         // Mock has result
-        $mockHasResultRow      = new ArrayObject();
+        $mockHasResultRow      = new class extends ArrayObject {
+            public ?string $one = null;
+        };
+
         $mockHasResultRow->one = 'one';
 
         $mockHasResult = $this->createMock(ResultInterface::class);

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -35,7 +35,7 @@ class RecordExistsTest extends TestCase
         $mockConnection = $this->createMock(ConnectionInterface::class);
 
         // Mock has result
-        $mockHasResultRow      = new class extends ArrayObject {
+        $mockHasResultRow = new class extends ArrayObject {
             public ?string $one = null;
         };
 

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -35,7 +35,10 @@ class RecordExistsTest extends TestCase
         $mockConnection = $this->createMock(ConnectionInterface::class);
 
         // Mock has result
-        $mockHasResultRow      = new ArrayObject();
+        $mockHasResultRow      = new class extends ArrayObject {
+            public ?string $one = null;
+        };
+
         $mockHasResultRow->one = 'one';
 
         $mockHasResult = $this->createMock(ResultInterface::class);

--- a/test/File/Crc32Test.php
+++ b/test/File/Crc32Test.php
@@ -98,14 +98,14 @@ class Crc32Test extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Crc32($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\Crc32($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/Crc32Test.php
+++ b/test/File/Crc32Test.php
@@ -104,6 +104,8 @@ class Crc32Test extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/ExcludeExtensionTest.php
+++ b/test/File/ExcludeExtensionTest.php
@@ -94,14 +94,14 @@ class ExcludeExtensionTest extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\ExcludeExtension($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\ExcludeExtension($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/ExcludeExtensionTest.php
+++ b/test/File/ExcludeExtensionTest.php
@@ -100,6 +100,8 @@ class ExcludeExtensionTest extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/ExistsTest.php
+++ b/test/File/ExistsTest.php
@@ -75,12 +75,12 @@ class ExistsTest extends TestCase
      */
     public function testLegacy(string $options, $isValidParam, bool $expected): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Exists($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
         }
+
+        $validator = new File\Exists($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
     }
 
     /**

--- a/test/File/ExistsTest.php
+++ b/test/File/ExistsTest.php
@@ -78,6 +78,8 @@ class ExistsTest extends TestCase
         if (is_array($isValidParam)) {
             $validator = new File\Exists($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/ExtensionTest.php
+++ b/test/File/ExtensionTest.php
@@ -95,14 +95,14 @@ class ExtensionTest extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Extension($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\Extension($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/ExtensionTest.php
+++ b/test/File/ExtensionTest.php
@@ -101,6 +101,8 @@ class ExtensionTest extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/HashTest.php
+++ b/test/File/HashTest.php
@@ -126,14 +126,14 @@ class HashTest extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Hash($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\Hash($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/HashTest.php
+++ b/test/File/HashTest.php
@@ -132,6 +132,8 @@ class HashTest extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/ImageSizeTest.php
+++ b/test/File/ImageSizeTest.php
@@ -156,20 +156,19 @@ class ImageSizeTest extends TestCase
      */
     public function testLegacy(array $options, $isValidParam, bool $expected, $messageKeys): void
     {
-        // Test legacy Laminas\Transfer API
-        if (is_array($isValidParam)) {
-            $validator = new File\ImageSize($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                if (! is_array($messageKeys)) {
-                    $messageKeys = [$messageKeys];
-                }
-                foreach ($messageKeys as $messageKey) {
-                    $this->assertArrayHasKey($messageKey, $validator->getMessages());
-                }
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\ImageSize($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            if (! is_array($messageKeys)) {
+                $messageKeys = [$messageKeys];
             }
-        } else {
-            $this->expectNotToPerformAssertions();
+            foreach ($messageKeys as $messageKey) {
+                $this->assertArrayHasKey($messageKey, $validator->getMessages());
+            }
         }
     }
 

--- a/test/File/ImageSizeTest.php
+++ b/test/File/ImageSizeTest.php
@@ -168,6 +168,8 @@ class ImageSizeTest extends TestCase
                     $this->assertArrayHasKey($messageKey, $validator->getMessages());
                 }
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/Md5Test.php
+++ b/test/File/Md5Test.php
@@ -126,6 +126,8 @@ class Md5Test extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/Md5Test.php
+++ b/test/File/Md5Test.php
@@ -120,14 +120,14 @@ class Md5Test extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Md5($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\Md5($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/NotExistsTest.php
+++ b/test/File/NotExistsTest.php
@@ -79,6 +79,8 @@ class NotExistsTest extends TestCase
         if (is_array($isValidParam)) {
             $validator = new File\NotExists($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/NotExistsTest.php
+++ b/test/File/NotExistsTest.php
@@ -76,12 +76,12 @@ class NotExistsTest extends TestCase
      */
     public function testLegacy(string $options, $isValidParam, bool $expected): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\NotExists($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
         }
+
+        $validator = new File\NotExists($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
     }
 
     /**

--- a/test/File/Sha1Test.php
+++ b/test/File/Sha1Test.php
@@ -109,6 +109,8 @@ class Sha1Test extends TestCase
             if (! $expected) {
                 $this->assertArrayHasKey($messageKey, $validator->getMessages());
             }
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/Sha1Test.php
+++ b/test/File/Sha1Test.php
@@ -103,14 +103,14 @@ class Sha1Test extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Sha1($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-            if (! $expected) {
-                $this->assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
+        }
+
+        $validator = new File\Sha1($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        if (! $expected) {
+            $this->assertArrayHasKey($messageKey, $validator->getMessages());
         }
     }
 

--- a/test/File/SizeTest.php
+++ b/test/File/SizeTest.php
@@ -87,6 +87,8 @@ class SizeTest extends TestCase
         if (is_array($isValidParam)) {
             $validator = new File\Size($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 

--- a/test/File/SizeTest.php
+++ b/test/File/SizeTest.php
@@ -84,12 +84,12 @@ class SizeTest extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\Size($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
         }
+
+        $validator = new File\Size($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
     }
 
     /**

--- a/test/File/WordCountTest.php
+++ b/test/File/WordCountTest.php
@@ -79,12 +79,12 @@ class WordCountTest extends TestCase
      */
     public function testLegacy($options, $isValidParam, bool $expected): void
     {
-        if (is_array($isValidParam)) {
-            $validator = new File\WordCount($options);
-            $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-        } else {
-            $this->expectNotToPerformAssertions();
+        if (! is_array($isValidParam)) {
+            $this->markTestSkipped('An array is expected for legacy compat tests');
         }
+
+        $validator = new File\WordCount($options);
+        $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
     }
 
     /**

--- a/test/File/WordCountTest.php
+++ b/test/File/WordCountTest.php
@@ -82,6 +82,8 @@ class WordCountTest extends TestCase
         if (is_array($isValidParam)) {
             $validator = new File\WordCount($options);
             $this->assertEquals($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
+        } else {
+            $this->expectNotToPerformAssertions();
         }
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

### Description

Testing a local project under 8.2-RC reveals a problem specific to the Date validator, where `DateTime::getLastErrors()` is potentially false. Even given https://3v4l.org/HBq0q - I can't get a test to actually return false from this method because it's 8.2 specific, so verifying the fix is a tough one.

Looking at https://3v4l.org/3QsKY - Only 8.2 returns false *after* a date operation that causes no errors.

A couple of other tests had complaints about dynamic properties and I've silenced a number of tests that don't perform any assertions depending on the data providers.


 