### PR TITLE
Mark the ValidatorChain as iterable and final

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-servicemanager": "^3.12.0",
-        "laminas/laminas-stdlib": "^3.10"
+        "laminas/laminas-stdlib": "^3.13"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "692419bd211c070dc48def1f401530d0",
+    "content-hash": "85c2b13ee36a9a4429eca67b43f03d0a",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1205,21 +1205,21 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.18.0",
+            "version": "2.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "8d352d8d031af69a366ba5eb5b812a5d33e97c3c"
+                "reference": "06322d90fad3c18dc4646f26d92c8b5557ee195e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/8d352d8d031af69a366ba5eb5b812a5d33e97c3c",
-                "reference": "8d352d8d031af69a366ba5eb5b812a5d33e97c3c",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/06322d90fad3c18dc4646f26d92c8b5557ee195e",
+                "reference": "06322d90fad3c18dc4646f26d92c8b5557ee195e",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-servicemanager": "^3.14.0",
-                "laminas/laminas-stdlib": "^3.6.1",
+                "laminas/laminas-stdlib": "^3.13.0",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
@@ -1227,15 +1227,15 @@
                 "zendframework/zend-filter": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.3.0",
+                "laminas/laminas-coding-standard": "~2.4.0",
                 "laminas/laminas-crypt": "^3.5.1",
                 "laminas/laminas-uri": "^2.9.1",
                 "pear/archive_tar": "^1.4.14",
                 "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^9.5.10",
+                "phpunit/phpunit": "^9.5.24",
                 "psalm/plugin-phpunit": "^0.17.0",
                 "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.27.0"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -1279,7 +1279,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-09T05:08:45+00:00"
+            "time": "2022-09-20T11:05:37+00:00"
         },
         {
             "name": "laminas/laminas-http",

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -3,9 +3,11 @@
 namespace Laminas\Validator;
 
 use Countable;
+use IteratorAggregate;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\PriorityQueue;
 use ReturnTypeWillChange;
+use Traversable;
 
 use function array_replace;
 use function assert;
@@ -16,10 +18,10 @@ use const SORT_NUMERIC;
 
 /**
  * @psalm-type QueueElement = array{instance: ValidatorInterface, breakChainOnFailure: bool}
+ * @implements IteratorAggregate<array-key, QueueElement>
+ * @final
  */
-class ValidatorChain implements
-    Countable,
-    ValidatorInterface
+class ValidatorChain implements Countable, IteratorAggregate, ValidatorInterface
 {
     /**
      * Default priority at which validators are added
@@ -248,7 +250,7 @@ class ValidatorChain implements
     {
         $this->messages = [];
         $result         = true;
-        foreach ($this->validators as $element) {
+        foreach ($this as $element) {
             $validator = $element['instance'];
             assert($validator instanceof ValidatorInterface);
             if ($validator->isValid($value, $context)) {
@@ -330,5 +332,11 @@ class ValidatorChain implements
     public function __sleep()
     {
         return ['validators', 'messages'];
+    }
+
+    /** @return Traversable<array-key, QueueElement> */
+    public function getIterator(): Traversable
+    {
+        return clone $this->validators;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes

### Description

This patch has less value than https://github.com/laminas/laminas-filter/pull/64 - initial investigation shows that other components consistently call `getValidators()` when they wish to iterate over the list of validators - the reason for this is that each element the chain returns is an array of a specific shape: `{instance: ValidatorInterface, break_chain_on_failure: bool}`

Feel free to close if it is simply not a worthwhile change :)