### PR TITLE
Supported PSR-7 in File\Count validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "laminas/laminas-servicemanager": "^3.12.0",
-        "laminas/laminas-stdlib": "^3.13"
+        "laminas/laminas-stdlib": "^3.13",
+        "psr/http-message": "^1.0.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.4.0",
@@ -47,7 +48,6 @@
         "psalm/plugin-phpunit": "^0.17.0",
         "psr/http-client": "^1.0.1",
         "psr/http-factory": "^1.0.1",
-        "psr/http-message": "^1.0.1",
         "vimeo/psalm": "^4.28"
     },
     "suggest": {

--- a/src/File/Count.php
+++ b/src/File/Count.php
@@ -13,7 +13,6 @@ use function count;
 use function dirname;
 use function func_get_args;
 use function func_num_args;
-use function interface_exists;
 use function is_array;
 use function is_numeric;
 use function is_string;
@@ -268,14 +267,13 @@ class Count extends AbstractValidator
 
     /**
      * Checks if the type of uploaded file is UploadedFileInterface.
-     * (backward compatible)
      *
      * @param  string|array|UploadedFileInterface $value Filenames to check for count
      * @return bool
      */
     private function isUploadedFilterInterface($value)
     {
-        if (interface_exists(UploadedFileInterface::class) && $value instanceof UploadedFileInterface) {
+        if ($value instanceof UploadedFileInterface) {
             return true;
         }
 

--- a/test/File/CountTest.php
+++ b/test/File/CountTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 use ReflectionClass;
 
+use function basename;
+
 /**
  * @group Laminas_Validator
  * @covers \Laminas\Validator\File\Count

--- a/test/File/CountTest.php
+++ b/test/File/CountTest.php
@@ -254,13 +254,13 @@ final class CountTest extends TestCase
 
         $validValidator = new Count(['min' => 1]);
 
-        $this->assertSame(true, $validValidator->isValid($upload));
-        $this->assertSame(true, $validValidator->isValid($upload, []));
+        $this->assertTrue($validValidator->isValid($upload));
+        $this->assertTrue($validValidator->isValid($upload, []));
 
         $invalidMinValidator = new Count(['min' => 2]);
         $invalidMaxValidator = new Count(['max' => 0]);
 
-        $this->assertSame(false, $invalidMinValidator->isValid($upload));
-        $this->assertSame(false, $invalidMaxValidator->isValid($upload));
+        $this->assertFalse($invalidMinValidator->isValid($upload));
+        $this->assertFalse($invalidMaxValidator->isValid($upload));
     }
 }

--- a/test/File/CountTest.php
+++ b/test/File/CountTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Validator\File;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Count;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UploadedFileInterface;
 use ReflectionClass;
 
 /**
@@ -240,5 +241,24 @@ final class CountTest extends TestCase
 
         self::assertSame($min, $validator->getMin());
         self::assertSame($max, $validator->getMax());
+    }
+
+    public function testPsr7FileTypes(): void
+    {
+        $testFile = __DIR__ . '/_files/testsize.mo';
+
+        $upload = $this->createMock(UploadedFileInterface::class);
+        $upload->method('getClientFilename')->willReturn(basename($testFile));
+
+        $validValidator = new Count(['min' => 1]);
+
+        $this->assertSame(true, $validValidator->isValid($upload));
+        $this->assertSame(true, $validValidator->isValid($upload, []));
+
+        $invalidMinValidator = new Count(['min' => 2]);
+        $invalidMaxValidator = new Count(['max' => 0]);
+
+        $this->assertSame(false, $invalidMinValidator->isValid($upload));
+        $this->assertSame(false, $invalidMaxValidator->isValid($upload));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR complements previous PR https://github.com/zendframework/zend-validator/pull/251. Recommendation PSR-7 UploadedFileInterface has not been implemented in File / Count validation. At the same time, it improves the https://github.com/laminas/laminas-validator/issues/24 issue.

This PR is same https://github.com/laminas/laminas-validator/pull/109, but upgrade Count path for Actions workflow tests. 