### PR TITLE
Apply the `#[\SensitiveParameter]` PHP 8.2 attribute to prevent leaking passwords in stack traces when verifying passwords against known leaks

### DIFF
--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -356,6 +356,9 @@ class CreditCard extends AbstractValidator
         return $this;
     }
 
+    // The following rule is buggy for parameters attributes
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
+
     /**
      * Returns true if and only if $value follows the Luhn algorithm (mod-10 checksum)
      *
@@ -436,4 +439,6 @@ class CreditCard extends AbstractValidator
 
         return true;
     }
+
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
 }

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -5,6 +5,7 @@ namespace Laminas\Validator;
 use Exception;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Validator\Exception\InvalidArgumentException;
+use SensitiveParameter;
 use Traversable;
 
 use function array_key_exists;
@@ -361,8 +362,10 @@ class CreditCard extends AbstractValidator
      * @param  string $value
      * @return bool
      */
-    public function isValid($value)
-    {
+    public function isValid(
+        #[SensitiveParameter]
+        $value
+    ) {
         $this->setValue($value);
 
         if (! is_string($value)) {

--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -46,6 +46,9 @@ final class UndisclosedPassword extends AbstractValidator
         parent::__construct();
     }
 
+    // The following rule is buggy for parameters attributes
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
+
     /** {@inheritDoc} */
     public function isValid(
         #[SensitiveParameter]
@@ -63,6 +66,8 @@ final class UndisclosedPassword extends AbstractValidator
 
         return true;
     }
+
+    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
 
     private function isPwnedPassword(
         #[SensitiveParameter]

--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -5,6 +5,7 @@ namespace Laminas\Validator;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use SensitiveParameter;
 
 use function array_filter;
 use function explode;
@@ -46,8 +47,10 @@ final class UndisclosedPassword extends AbstractValidator
     }
 
     /** {@inheritDoc} */
-    public function isValid($value): bool
-    {
+    public function isValid(
+        #[SensitiveParameter]
+        $value
+    ): bool {
         if (! is_string($value)) {
             $this->error(self::NOT_A_STRING);
             return false;
@@ -61,8 +64,10 @@ final class UndisclosedPassword extends AbstractValidator
         return true;
     }
 
-    private function isPwnedPassword(string $password): bool
-    {
+    private function isPwnedPassword(
+        #[SensitiveParameter]
+        string $password
+    ): bool {
         $sha1Hash  = $this->hashPassword($password);
         $rangeHash = $this->getRangeHash($sha1Hash);
         $hashList  = $this->retrieveHashList($rangeHash);
@@ -74,8 +79,10 @@ final class UndisclosedPassword extends AbstractValidator
      * We use a SHA1 hashed password for checking it against
      * the breached data set of HIBP.
      */
-    private function hashPassword(string $password): string
-    {
+    private function hashPassword(
+        #[SensitiveParameter]
+        string $password
+    ): string {
         $hashedPassword = sha1($password);
 
         return strtoupper($hashedPassword);
@@ -87,8 +94,10 @@ final class UndisclosedPassword extends AbstractValidator
      *
      * @see https://www.troyhunt.com/enhancing-pwned-passwords-privacy-by-exclusively-supporting-anonymity/
      */
-    private function getRangeHash(string $passwordHash): string
-    {
+    private function getRangeHash(
+        #[SensitiveParameter]
+        string $passwordHash
+    ): string {
         return substr($passwordHash, self::HIBP_K_ANONYMITY_HASH_RANGE_BASE, self::HIBP_K_ANONYMITY_HASH_RANGE_LENGTH);
     }
 
@@ -99,8 +108,10 @@ final class UndisclosedPassword extends AbstractValidator
      *
      * @throws ClientExceptionInterface
      */
-    private function retrieveHashList(string $passwordRange): string
-    {
+    private function retrieveHashList(
+        #[SensitiveParameter]
+        string $passwordRange
+    ): string {
         $request = $this->makeHttpRequest->createRequest(
             'GET',
             self::HIBP_API_URI . '/range/' . $passwordRange
@@ -113,8 +124,12 @@ final class UndisclosedPassword extends AbstractValidator
     /**
      * Checks if the password is in the response from HIBP
      */
-    private function hashInResponse(string $sha1Hash, string $resultStream): bool
-    {
+    private function hashInResponse(
+        #[SensitiveParameter]
+        string $sha1Hash,
+        #[SensitiveParameter]
+        string $resultStream
+    ): bool {
         $data   = explode("\r\n", $resultStream);
         $hashes = array_filter($data, static function ($value) use ($sha1Hash): bool {
             [$hash] = explode(':', $value);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This applies the PHP 8.2 `#[\SensitiveParameter]` attribute to prevent sensitive information from ending up in stack traces. This is especially important for the UndisclosedPassword validator which performs outgoing network requests that have a real chance of failing and thus disclosing (duh) the password in the stack trace [1].

I've also applied the attribute to CreditCard for good measure, but I don't believe that validator can actually fail.

[1] Example with a misconfigured Guzzle client:

Before:

```
#13 /pwd/src/UndisclosedPassword.php(109): GuzzleHttp\Client->sendRequest(Object(GuzzleHttp\Psr7\Request))
#14 /pwd/src/UndisclosedPassword.php(68): Laminas\Validator\UndisclosedPassword->retrieveHashList('A94A8')
#15 /pwd/src/UndisclosedPassword.php(56): Laminas\Validator\UndisclosedPassword->isPwnedPassword('test')
#16 /pwd/test.php(14): Laminas\Validator\UndisclosedPassword->isValid('test')
#17 {main}
  thrown in /pwd/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 211
```

After:

```
#13 /pwd/src/UndisclosedPassword.php(120): GuzzleHttp\Client->sendRequest(Object(GuzzleHttp\Psr7\Request))
#14 /pwd/src/UndisclosedPassword.php(73): Laminas\Validator\UndisclosedPassword->retrieveHashList(Object(SensitiveParameterValue))
#15 /pwd/src/UndisclosedPassword.php(59): Laminas\Validator\UndisclosedPassword->isPwnedPassword(Object(SensitiveParameterValue))
#16 /pwd/test.php(14): Laminas\Validator\UndisclosedPassword->isValid(Object(SensitiveParameterValue))
#17 {main}
  thrown in /pwd/vendor/guzzlehttp/guzzle/src/Handler/CurlFactory.php on line 211
```