### PR TITLE
add handling for enum as haystack

### DIFF
--- a/src/InArray.php
+++ b/src/InArray.php
@@ -86,7 +86,7 @@ class InArray extends AbstractValidator
     /**
      * Sets the haystack option
      *
-     * @param array|UnitEnum|BackedEnum $haystack
+     * @param array|class-string<UnitEnum> $haystack
      * @return $this Provides a fluent interface
      */
     public function setHaystack($haystack)

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -6,6 +6,9 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\InArray;
+use LaminasTest\Validator\TestAsset\Enum\TestBackedIntEnum;
+use LaminasTest\Validator\TestAsset\Enum\TestBackedStringEnum;
+use LaminasTest\Validator\TestAsset\Enum\TestUnitEnum;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
@@ -471,5 +474,40 @@ final class InArrayTest extends TestCase
 
         self::assertTrue($validator->isValid($valid));
         self::assertFalse($validator->isValid($invalid));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumValidation(): void
+    {
+        $validator = new InArray([
+            'haystack' => TestUnitEnum::class,
+        ]);
+
+        self::assertTrue($validator->isValid('foo'));
+        self::assertFalse($validator->isValid('baz'));
+
+        $validator = new InArray([
+            'haystack' => TestBackedStringEnum::class,
+        ]);
+
+        self::assertTrue($validator->isValid('foo'));
+        self::assertFalse($validator->isValid('baz'));
+
+        $validator = new InArray([
+            'haystack' => TestBackedIntEnum::class,
+        ]);
+
+        self::assertTrue($validator->isValid(1));
+        self::assertFalse($validator->isValid(3));
+
+        $validator = new InArray([
+            'haystack' => TestBackedIntEnum::class,
+            'strict'   => true,
+        ]);
+
+        self::assertTrue($validator->isValid(1));
+        self::assertFalse($validator->isValid('2'));
     }
 }

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\InArray;
+use LaminasTest\Validator\TestAsset\CustomTraversable;
 use LaminasTest\Validator\TestAsset\Enum\TestBackedIntEnum;
 use LaminasTest\Validator\TestAsset\Enum\TestBackedStringEnum;
 use LaminasTest\Validator\TestAsset\Enum\TestUnitEnum;
@@ -482,32 +483,45 @@ final class InArrayTest extends TestCase
     public function testEnumValidation(): void
     {
         $validator = new InArray([
-            'haystack' => TestUnitEnum::class,
+            'enum' => TestUnitEnum::class,
         ]);
 
         self::assertTrue($validator->isValid('foo'));
         self::assertFalse($validator->isValid('baz'));
 
         $validator = new InArray([
-            'haystack' => TestBackedStringEnum::class,
+            'enum' => TestBackedStringEnum::class,
         ]);
 
         self::assertTrue($validator->isValid('foo'));
         self::assertFalse($validator->isValid('baz'));
 
         $validator = new InArray([
-            'haystack' => TestBackedIntEnum::class,
+            'enum' => TestBackedIntEnum::class,
         ]);
 
         self::assertTrue($validator->isValid(1));
         self::assertFalse($validator->isValid(3));
 
         $validator = new InArray([
-            'haystack' => TestBackedIntEnum::class,
-            'strict'   => true,
+            'enum'   => TestBackedIntEnum::class,
+            'strict' => true,
         ]);
 
         self::assertTrue($validator->isValid(1));
         self::assertFalse($validator->isValid('2'));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnumOptionException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('enum has invalid type');
+
+        $validator = new InArray([
+            'enum' => CustomTraversable::class,
+        ]);
     }
 }

--- a/test/TestAsset/Enum/TestBackedIntEnum.php
+++ b/test/TestAsset/Enum/TestBackedIntEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\TestAsset\Enum;
+
+enum TestBackedIntEnum: int
+{
+    case Foo = 1;
+    case Bar = 2;
+}

--- a/test/TestAsset/Enum/TestBackedStringEnum.php
+++ b/test/TestAsset/Enum/TestBackedStringEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\TestAsset\Enum;
+
+enum TestBackedStringEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}

--- a/test/TestAsset/Enum/TestUnitEnum.php
+++ b/test/TestAsset/Enum/TestUnitEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\TestAsset\Enum;
+
+enum TestUnitEnum
+{
+    case foo;
+    case bar;
+}


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

See issue #167.

Suggestion was to allow the haystack to be an enum. Otherwise a new validator for just the case of enums would be suitable.

I am a bit unsure about the testcase and I hope it would work with the build pipeline, but I will see it afterwards. 

And psalm is not working because it misses the classes on PHP 8.0.

Happy to hear your feedback.
