### PR TITLE
Fix value annotation in isValid method for Regex validator.

### DIFF
--- a/src/Regex.php
+++ b/src/Regex.php
@@ -107,7 +107,7 @@ class Regex extends AbstractValidator
     /**
      * Returns true if and only if $value matches against the pattern option
      *
-     * @param  string $value
+     * @param  string|numeric $value
      * @return bool
      */
     public function isValid($value)
@@ -120,6 +120,7 @@ class Regex extends AbstractValidator
         $this->setValue($value);
 
         ErrorHandler::start();
+        /** @psalm-suppress PossiblyInvalidArgument */
         $status = preg_match($this->pattern, $value);
         ErrorHandler::stop();
         if (false === $status) {

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -117,10 +117,13 @@ class Regex extends AbstractValidator
             return false;
         }
 
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
         $this->setValue($value);
 
         ErrorHandler::start();
-        /** @psalm-suppress PossiblyInvalidArgument */
         $status = preg_match($this->pattern, $value);
         ErrorHandler::stop();
         if (false === $status) {

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -213,24 +213,27 @@ final class RegexTest extends TestCase
     /**
      * @dataProvider numericDataProvider
      */
-    public function testNumbers(int|float $input, bool $expected): void
+    public function testNumbers(string $pattern, int|float $input, bool $expected): void
     {
-        $validator = new Regex('/^(-?\d+(?:\.\d+)?+)$/');
+        $validator = new Regex($pattern);
 
         self::assertSame($expected, $validator->isValid($input));
     }
 
     /**
-     * @psalm-return array<array-key, array{0: int|float, 1: bool}>
+     * @psalm-return array<array-key, array{0: string, 1: int|float, 2: bool}>
      */
-    public function numericDataProvider(): array
+    public static function numericDataProvider(): array
     {
         return [
-            [12345, true],
-            [PHP_INT_MAX, true],
-            [-123, true],
-            [0.0099, true],
-            [-100.50, true],
+            ['/^(-?\d+(?:\.\d+)?+)$/', 12345, true],
+            ['/^(-?\d+(?:\.\d+)?+)$/', PHP_INT_MAX, true],
+            ['/^(-?\d+(?:\.\d+)?+)$/', -123, true],
+            ['/^(-?\d+(?:\.\d+)?+)$/', 0.0099, true],
+            ['/^(-?\d+(?:\.\d+)?+)$/', -100.50, true],
+            ['/^\d+$/', 100, true],
+            ['/^\d+$/', -100, false],
+            ['/^\d+$/', 123.45, false],
         ];
     }
 }

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -12,6 +12,8 @@ use ReflectionProperty;
 use function array_keys;
 use function implode;
 
+use const PHP_INT_MAX;
+
 /**
  * @group Laminas_Validator
  * @covers \Laminas\Validator\Regex
@@ -206,5 +208,29 @@ final class RegexTest extends TestCase
         $r->setValue($validator, $pattern);
 
         self::assertFalse($validator->isValid('test'));
+    }
+
+    /**
+     * @dataProvider numericDataProvider
+     */
+    public function testNumbers(int|float $input, bool $expected): void
+    {
+        $validator = new Regex('/^(-?\d+(?:\.\d+)?+)$/');
+
+        self::assertSame($expected, $validator->isValid($input));
+    }
+
+    /**
+     * @psalm-return array<array-key, array{0: int|float, 1: bool}>
+     */
+    public function numericDataProvider(): array
+    {
+        return [
+            [12345, true],
+            [PHP_INT_MAX, true],
+            [-123, true],
+            [0.0099, true],
+            [-100.50, true],
+        ];
     }
 }


### PR DESCRIPTION
Changed annotation for parameter value in isValid method for Regex validator, from string to string|numerical as long as this method accepts also integer and float parameters.