### PR TITLE
Remove support for PHP 8.0, Upgrade PHPUnit to 10.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.phpcs-cache
-/.phpunit.result.cache
+/.phpunit.cache
 /clover.xml
 /docs/html/
 /laminas-mkdoc-theme.tgz

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,2 @@
 {
-    "ignore_php_platform_requirements": {
-        "8.2": true
-    }
 }

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -18,6 +18,6 @@ namespace Psr\Container {
          * @psalm-param string|class-string<T> $id
          * @psalm-return ($id is class-string ? T : mixed)
          */
-        public function get(string $id): object;
+        public function get(string $id): mixed;
     }
 }

--- a/bin/update_hostname_validator.php
+++ b/bin/update_hostname_validator.php
@@ -185,7 +185,6 @@ function getPunycodeDecoder()
     $hostnameValidator = new Hostname();
     $reflection        = new ReflectionClass(get_class($hostnameValidator));
     $decodePunyCode    = $reflection->getMethod('decodePunycode');
-    $decodePunyCode->setAccessible(true);
 
     return function ($encode) use ($hostnameValidator, $decodePunyCode) {
         if (strpos($encode, 'xn--') === 0) {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "laminas/laminas-servicemanager": "^3.12.0",
+        "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-stdlib": "^3.13",
         "psr/http-message": "^1.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "laminas/laminas-i18n": "^2.23",
         "laminas/laminas-session": "^2.16",
         "laminas/laminas-uri": "^2.10.0",
-        "phpunit/phpunit": "^9.6.8",
+        "phpunit/phpunit": "^10.1.3",
         "psalm/plugin-phpunit": "^0.18.4",
         "psr/http-client": "^1.0.2",
         "psr/http-factory": "^1.0.2",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -31,24 +31,24 @@
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-servicemanager": "^3.12.0",
         "laminas/laminas-stdlib": "^3.13",
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "^2.4.0",
-        "laminas/laminas-db": "^2.16",
-        "laminas/laminas-filter": "^2.28.1",
+        "laminas/laminas-coding-standard": "^2.5",
+        "laminas/laminas-db": "^2.18",
+        "laminas/laminas-filter": "^2.32",
         "laminas/laminas-http": "^2.18",
-        "laminas/laminas-i18n": "^2.19",
-        "laminas/laminas-session": "^2.15",
+        "laminas/laminas-i18n": "^2.23",
+        "laminas/laminas-session": "^2.16",
         "laminas/laminas-uri": "^2.10.0",
-        "phpunit/phpunit": "^9.5.26",
-        "psalm/plugin-phpunit": "^0.18.3",
-        "psr/http-client": "^1.0.1",
-        "psr/http-factory": "^1.0.1",
-        "vimeo/psalm": "^5.0"
+        "phpunit/phpunit": "^9.6.8",
+        "psalm/plugin-phpunit": "^0.18.4",
+        "psr/http-client": "^1.0.2",
+        "psr/http-factory": "^1.0.2",
+        "vimeo/psalm": "^5.11"
     },
     "suggest": {
         "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "941b562f2d854c1e00142d7ec7e7d02e",
+    "content-hash": "7ce836b9c58ae4004b0284a94c77dc2d",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/625f2aa3bc6dd02688b2da5155b3a69870812bda",
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -39,18 +39,19 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.17",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -94,34 +95,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-05-14T12:24:54+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -153,7 +154,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "psr/container",
@@ -205,25 +206,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -252,9 +253,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         }
     ],
     "packages-dev": [
@@ -829,30 +830,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -879,7 +880,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -895,7 +896,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1000,16 +1001,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1049,7 +1050,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1057,7 +1058,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1117,16 +1118,16 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.17.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "9020ba27ffa4966c03cac743144bfd6716fdab60"
+                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/9020ba27ffa4966c03cac743144bfd6716fdab60",
-                "reference": "9020ba27ffa4966c03cac743144bfd6716fdab60",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/4df7a3f7ffe268e8683306fcec125c269408b295",
+                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295",
                 "shasum": ""
             },
             "require": {
@@ -1184,7 +1185,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-31T12:09:24+00:00"
+            "time": "2023-05-05T16:22:28+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -1318,23 +1319,23 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.31.0",
+            "version": "2.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8"
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
-                "reference": "548a6597d357b0b0b139cc7bffea4dfbc50eb5a8",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/2b7e6b2b26a92412c38336ee3089251164edf141",
+                "reference": "2b7e6b2b26a92412c38336ee3089251164edf141",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "laminas/laminas-validator": "<2.10.1",
@@ -1342,13 +1343,13 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.9",
+                "laminas/laminas-crypt": "^3.10",
                 "laminas/laminas-uri": "^2.10",
                 "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^9.5.27",
+                "phpunit/phpunit": "^10.1.3",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.3"
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
@@ -1392,7 +1393,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-12T06:17:48+00:00"
+            "time": "2023-05-16T23:25:05+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -1461,42 +1462,41 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.21.0",
+            "version": "2.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "fbd2d0373aaced4769cba2bf3d1425d55f68abb1"
+                "reference": "bb844a1141bb6e65d8889f5a08383f761a8270b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/fbd2d0373aaced4769cba2bf3d1425d55f68abb1",
-                "reference": "fbd2d0373aaced4769cba2bf3d1425d55f68abb1",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/bb844a1141bb6e65d8889f5a08383f761a8270b2",
+                "reference": "bb844a1141bb6e65d8889f5a08383f761a8270b2",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^3.14.0",
-                "laminas/laminas-stdlib": "^2.7 || ^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "laminas/laminas-view": "<2.20.0",
-                "phpspec/prophecy": "<1.9.0",
                 "zendframework/zend-i18n": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^3.8",
+                "laminas/laminas-cache": "^3.10.1",
                 "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
-                "laminas/laminas-cache-storage-deprecated-factory": "^1.0.1",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-cache-storage-deprecated-factory": "^1.1",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-config": "^3.8.0",
-                "laminas/laminas-eventmanager": "^3.7",
-                "laminas/laminas-filter": "^2.28.1",
-                "laminas/laminas-validator": "^2.28",
-                "laminas/laminas-view": "^2.25",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-eventmanager": "^3.10",
+                "laminas/laminas-filter": "^2.31",
+                "laminas/laminas-validator": "^2.30.1",
+                "laminas/laminas-view": "^2.27",
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.11"
             },
             "suggest": {
                 "laminas/laminas-cache": "You should install this package to cache the translations",
@@ -1543,7 +1543,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-02T17:15:52+00:00"
+            "time": "2023-05-16T23:22:24+00:00"
         },
         {
             "name": "laminas/laminas-loader",
@@ -1742,16 +1742,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1789,7 +1789,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1797,20 +1797,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -1846,22 +1846,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -1902,9 +1902,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2228,23 +2228,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2259,8 +2259,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -2293,7 +2293,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -2301,7 +2301,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2546,16 +2546,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -2588,8 +2588,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -2597,7 +2597,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -2628,7 +2628,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -2644,7 +2645,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2708,21 +2709,21 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -2742,7 +2743,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -2754,27 +2755,27 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-04-10T20:12:12+00:00"
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -2794,7 +2795,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -2809,9 +2810,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/log",
@@ -3163,16 +3164,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -3217,7 +3218,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3225,20 +3226,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -3280,7 +3281,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -3288,7 +3289,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3602,16 +3603,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -3650,10 +3651,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3661,7 +3662,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3720,16 +3721,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3764,7 +3765,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3772,7 +3773,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3890,26 +3891,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "e210b98957987c755372465be105d32113f339a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/e210b98957987c755372465be105d32113f339a4",
+                "reference": "e210b98957987c755372465be105d32113f339a4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -3938,7 +3938,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.6"
             },
             "funding": [
                 {
@@ -3950,20 +3950,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2023-05-11T14:04:07+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -3999,31 +3999,33 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/12288d9f4500f84a4d02254d4aa968b15488476f",
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -4080,12 +4082,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -4101,29 +4103,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-04-28T13:37:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4152,7 +4154,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4168,24 +4170,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fd588debf7d1bc16a2c84b4b3b71145d9946b894",
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -4215,7 +4217,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -4231,7 +4233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-04-18T13:46:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4648,20 +4650,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4673,6 +4675,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -4713,7 +4716,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -4729,7 +4732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4783,22 +4786,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/c9b192ab8400fdaf04b2b13d110575adc879aa90",
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4811,12 +4814,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -4824,14 +4827,15 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -4877,34 +4881,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.11.0"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-05-04T21:35:44+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4930,7 +4935,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -4938,7 +4943,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5005,11 +5010,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ce836b9c58ae4004b0284a94c77dc2d",
+    "content-hash": "f76a1b4cc662ecb01777f6c2c5aca934",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f76a1b4cc662ecb01777f6c2c5aca934",
+    "content-hash": "671699eed93da1cc140c6748469431c6",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -827,76 +827,6 @@
                 "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
             },
             "time": "2019-12-04T15:06:13+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -2228,16 +2158,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "10.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/884a0da7f9f46f28b2cb69134217fd810b793974",
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974",
                 "shasum": ""
             },
             "require": {
@@ -2245,18 +2175,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2265,7 +2195,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2293,7 +2223,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.1"
             },
             "funding": [
                 {
@@ -2301,32 +2232,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-04-17T12:15:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "5647d65443818959172645e7ed999217360654b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
+                "reference": "5647d65443818959172645e7ed999217360654b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2353,7 +2284,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
             },
             "funding": [
                 {
@@ -2361,28 +2293,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-05-07T09:13:23+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2390,7 +2322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2416,7 +2348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2424,32 +2356,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2475,7 +2407,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2483,32 +2415,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2534,7 +2466,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2542,24 +2474,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "10.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2379ebafc1737e71cdc84f402acb6b7f04198b9d",
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2569,27 +2500,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2597,7 +2527,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2629,7 +2559,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.3"
             },
             "funding": [
                 {
@@ -2645,7 +2575,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-05-11T05:16:22+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2866,28 +2796,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2910,7 +2840,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2918,32 +2848,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2966,7 +2896,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2974,32 +2904,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3021,7 +2951,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3029,34 +2959,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3095,7 +3027,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3103,33 +3035,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3152,7 +3084,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3160,33 +3092,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3218,7 +3150,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3226,27 +3159,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3254,7 +3187,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3273,7 +3206,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3281,7 +3214,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3289,34 +3223,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3358,7 +3292,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3366,38 +3300,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3422,7 +3353,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3430,33 +3361,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3479,7 +3410,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3487,34 +3418,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3536,7 +3467,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3544,32 +3475,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3591,7 +3522,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3599,32 +3530,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3654,7 +3585,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3662,87 +3593,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3765,7 +3641,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3773,29 +3649,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3818,7 +3694,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3826,7 +3702,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,29 +4,31 @@
          bootstrap="./vendor/autoload.php"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          failOnWarning="true"
-         colors="true">
+         failOnDeprecation="true"
+         failOnNotice="true"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+>
     <testsuites>
         <testsuite name="laminas-validator Test Suite">
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
-
-    <groups>
-        <exclude>
-            <group>disable</group>
-        </exclude>
-    </groups>
-
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
-
     <php>
         <ini name="date.timezone" value="UTC"/>
         <ini name="xdebug.max_nesting_level" value="3000"/>
-        <env name="TESTS_LAMINAS_VALIDATOR_ONLINE_ENABLED" value="true" />
+        <env name="TESTS_LAMINAS_VALIDATOR_ONLINE_ENABLED" value="true"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,13 +27,6 @@
     <php>
         <ini name="date.timezone" value="UTC"/>
         <ini name="xdebug.max_nesting_level" value="3000"/>
-
-        <!-- OB_ENABLED should be enabled for some tests to check if all
-             functionality works as expected. Such tests include those for
-             Laminas\Soap and Laminas\Session, which require that headers not be sent
-             in order to work. -->
-        <env name="TESTS_LAMINAS_OB_ENABLED" value="false" />
-
-        <env name="TESTS_LAMINAS_VALIDATOR_ONLINE_ENABLED" value="false" />
+        <env name="TESTS_LAMINAS_VALIDATOR_ONLINE_ENABLED" value="true" />
     </php>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2657,9 +2657,6 @@
       <code>get</code>
       <code>has</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType>
-      <code>$instanceOf</code>
-    </NonInvariantDocblockPropertyType>
     <PossiblyUnusedMethod>
       <code>validatePlugin</code>
     </PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
   <file src="bin/update_hostname_validator.php">
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$domain</code>
       <code>$encode</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>function ($encode) use ($hostnameValidator, $decodePunyCode) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$decodePunycode(strtolower($line))</code>
       <code>$domain</code>
       <code>$encode</code>
@@ -16,118 +16,118 @@
     </MixedArgument>
   </file>
   <file src="src/AbstractValidator.php">
-    <LessSpecificReturnStatement occurrences="5">
+    <LessSpecificReturnStatement>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
     </LessSpecificReturnStatement>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$this-&gt;{key($property)}[current($property)]</code>
-      <code>$this-&gt;{key($result)}[current($result)]</code>
-      <code>$this-&gt;{key($result)}[current($result)]</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$this->{key($property)}[current($property)]]]></code>
+      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
+      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;abstractOptions['messages'][$messageKey]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->abstractOptions['messages'][$messageKey]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="3">
-      <code>$this-&gt;{key($property)}[current($property)]</code>
-      <code>$this-&gt;{key($result)}[current($result)]</code>
-      <code>$this-&gt;{key($result)}[current($result)]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->{key($property)}[current($property)]]]></code>
+      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
+      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$property</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;abstractOptions</code>
-    </PropertyTypeCoercion>
-    <UndefinedThisPropertyAssignment occurrences="31">
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
-      <code>$this-&gt;options</code>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->abstractOptions]]></code>
+    </MixedPropertyTypeCoercion>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>$options instanceof Traversable</code>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$options['options']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$options['options']]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$options['options']</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$options['options']]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$length</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>Barcode\AbstractAdapter</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>new $adapter($options)</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$length</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['adapter']</code>
-      <code>$this-&gt;options['adapter']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['adapter']]]></code>
+      <code><![CDATA[$this->options['adapter']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Barcode/AbstractAdapter.php">
-    <DocblockTypeContradiction occurrences="6">
-      <code>$length === 'even'</code>
-      <code>$length === 'even'</code>
-      <code>$length === 'odd'</code>
-      <code>$length === 'odd'</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$length === 'even']]></code>
+      <code><![CDATA[$length === 'even']]></code>
+      <code><![CDATA[$length === 'odd']]></code>
+      <code><![CDATA[$length === 'odd']]></code>
       <code>is_string($value)</code>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <InvalidOperand occurrences="7">
+    <InvalidOperand>
       <code>$barcode[$i]</code>
       <code>$barcode[$i]</code>
       <code>$barcode[$length - $i]</code>
@@ -136,50 +136,380 @@
       <code>$barcode[$length - $i]</code>
       <code>$row</code>
     </InvalidOperand>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType>
       <code>AbstractAdapter|bool</code>
       <code>bool</code>
       <code>int|array</code>
       <code>int|string|array</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="5">
-      <code>$this-&gt;$checksum($value)</code>
-      <code>$this-&gt;options['characters']</code>
-      <code>$this-&gt;options['checksum']</code>
-      <code>$this-&gt;options['length']</code>
-      <code>$this-&gt;options['useChecksum']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->$checksum($value)]]></code>
+      <code><![CDATA[$this->options['characters']]]></code>
+      <code><![CDATA[$this->options['checksum']]]></code>
+      <code><![CDATA[$this->options['length']]]></code>
+      <code><![CDATA[$this->options['useChecksum']]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$characters</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$characters</code>
     </PossiblyInvalidCast>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $check</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Barcode/Codabar.php">
-    <InvalidArgument occurrences="2">
-      <code>'0123456789-$:/.+'</code>
-      <code>'0123456789-$:/.+ABCDTN*E'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789-$:/.+']]></code>
+      <code><![CDATA['0123456789-$:/.+ABCDTN*E']]></code>
     </InvalidArgument>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$chars</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Barcode/Code128.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>! $this-&gt;utf8StringWrapper</code>
-      <code>$this-&gt;utf8StringWrapper</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! $this->utf8StringWrapper]]></code>
+      <code><![CDATA[$this->utf8StringWrapper]]></code>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1"/>
-    <PossiblyFalseArgument occurrences="12">
+    <InvalidArgument>
+      <code><![CDATA[[
+            'A' => [
+                0   => ' ',
+                1   => '!',
+                2   => '"',
+                3   => '#',
+                4   => '$',
+                5   => '%',
+                6   => '&',
+                7   => "'",
+                8   => '(',
+                9   => ')',
+                10  => '*',
+                11  => '+',
+                12  => ',',
+                13  => '-',
+                14  => '.',
+                15  => '/',
+                16  => '0',
+                17  => '1',
+                18  => '2',
+                19  => '3',
+                20  => '4',
+                21  => '5',
+                22  => '6',
+                23  => '7',
+                24  => '8',
+                25  => '9',
+                26  => ':',
+                27  => ';',
+                28  => '<',
+                29  => '=',
+                30  => '>',
+                31  => '?',
+                32  => '@',
+                33  => 'A',
+                34  => 'B',
+                35  => 'C',
+                36  => 'D',
+                37  => 'E',
+                38  => 'F',
+                39  => 'G',
+                40  => 'H',
+                41  => 'I',
+                42  => 'J',
+                43  => 'K',
+                44  => 'L',
+                45  => 'M',
+                46  => 'N',
+                47  => 'O',
+                48  => 'P',
+                49  => 'Q',
+                50  => 'R',
+                51  => 'S',
+                52  => 'T',
+                53  => 'U',
+                54  => 'V',
+                55  => 'W',
+                56  => 'X',
+                57  => 'Y',
+                58  => 'Z',
+                59  => '[',
+                60  => '\\',
+                61  => ']',
+                62  => '^',
+                63  => '_',
+                64  => 0x00,
+                65  => 0x01,
+                66  => 0x02,
+                67  => 0x03,
+                68  => 0x04,
+                69  => 0x05,
+                70  => 0x06,
+                71  => 0x07,
+                72  => 0x08,
+                73  => 0x09,
+                74  => 0x0A,
+                75  => 0x0B,
+                76  => 0x0C,
+                77  => 0x0D,
+                78  => 0x0E,
+                79  => 0x0F,
+                80  => 0x10,
+                81  => 0x11,
+                82  => 0x12,
+                83  => 0x13,
+                84  => 0x14,
+                85  => 0x15,
+                86  => 0x16,
+                87  => 0x17,
+                88  => 0x18,
+                89  => 0x19,
+                90  => 0x1A,
+                91  => 0x1B,
+                92  => 0x1C,
+                93  => 0x1D,
+                94  => 0x1E,
+                95  => 0x1F,
+                96  => 'Ç',
+                97  => 'ü',
+                98  => 'é',
+                99  => 'â',
+                100 => 'ä',
+                101 => 'à',
+                102 => 'å',
+                103 => '‡',
+                104 => 'ˆ',
+                105 => '‰',
+                106 => 'Š',
+            ],
+            'B' => [
+                0   => ' ',
+                1   => '!',
+                2   => '"',
+                3   => '#',
+                4   => '$',
+                5   => '%',
+                6   => '&',
+                7   => "'",
+                8   => '(',
+                9   => ')',
+                10  => '*',
+                11  => '+',
+                12  => ',',
+                13  => '-',
+                14  => '.',
+                15  => '/',
+                16  => '0',
+                17  => '1',
+                18  => '2',
+                19  => '3',
+                20  => '4',
+                21  => '5',
+                22  => '6',
+                23  => '7',
+                24  => '8',
+                25  => '9',
+                26  => ':',
+                27  => ';',
+                28  => '<',
+                29  => '=',
+                30  => '>',
+                31  => '?',
+                32  => '@',
+                33  => 'A',
+                34  => 'B',
+                35  => 'C',
+                36  => 'D',
+                37  => 'E',
+                38  => 'F',
+                39  => 'G',
+                40  => 'H',
+                41  => 'I',
+                42  => 'J',
+                43  => 'K',
+                44  => 'L',
+                45  => 'M',
+                46  => 'N',
+                47  => 'O',
+                48  => 'P',
+                49  => 'Q',
+                50  => 'R',
+                51  => 'S',
+                52  => 'T',
+                53  => 'U',
+                54  => 'V',
+                55  => 'W',
+                56  => 'X',
+                57  => 'Y',
+                58  => 'Z',
+                59  => '[',
+                60  => '\\',
+                61  => ']',
+                62  => '^',
+                63  => '_',
+                64  => '`',
+                65  => 'a',
+                66  => 'b',
+                67  => 'c',
+                68  => 'd',
+                69  => 'e',
+                70  => 'f',
+                71  => 'g',
+                72  => 'h',
+                73  => 'i',
+                74  => 'j',
+                75  => 'k',
+                76  => 'l',
+                77  => 'm',
+                78  => 'n',
+                79  => 'o',
+                80  => 'p',
+                81  => 'q',
+                82  => 'r',
+                83  => 's',
+                84  => 't',
+                85  => 'u',
+                86  => 'v',
+                87  => 'w',
+                88  => 'x',
+                89  => 'y',
+                90  => 'z',
+                91  => '{',
+                92  => '|',
+                93  => '}',
+                94  => '~',
+                95  => 0x7F,
+                96  => 'Ç',
+                97  => 'ü',
+                98  => 'é',
+                99  => 'â',
+                100 => 'ä',
+                101 => 'à',
+                102 => 'å',
+                103 => '‡',
+                104 => 'ˆ',
+                105 => '‰',
+                106 => 'Š',
+            ],
+            'C' => [
+                0   => '00',
+                1   => '01',
+                2   => '02',
+                3   => '03',
+                4   => '04',
+                5   => '05',
+                6   => '06',
+                7   => '07',
+                8   => '08',
+                9   => '09',
+                10  => '10',
+                11  => '11',
+                12  => '12',
+                13  => '13',
+                14  => '14',
+                15  => '15',
+                16  => '16',
+                17  => '17',
+                18  => '18',
+                19  => '19',
+                20  => '20',
+                21  => '21',
+                22  => '22',
+                23  => '23',
+                24  => '24',
+                25  => '25',
+                26  => '26',
+                27  => '27',
+                28  => '28',
+                29  => '29',
+                30  => '30',
+                31  => '31',
+                32  => '32',
+                33  => '33',
+                34  => '34',
+                35  => '35',
+                36  => '36',
+                37  => '37',
+                38  => '38',
+                39  => '39',
+                40  => '40',
+                41  => '41',
+                42  => '42',
+                43  => '43',
+                44  => '44',
+                45  => '45',
+                46  => '46',
+                47  => '47',
+                48  => '48',
+                49  => '49',
+                50  => '50',
+                51  => '51',
+                52  => '52',
+                53  => '53',
+                54  => '54',
+                55  => '55',
+                56  => '56',
+                57  => '57',
+                58  => '58',
+                59  => '59',
+                60  => '60',
+                61  => '61',
+                62  => '62',
+                63  => '63',
+                64  => '64',
+                65  => '65',
+                66  => '66',
+                67  => '67',
+                68  => '68',
+                69  => '69',
+                70  => '70',
+                71  => '71',
+                72  => '72',
+                73  => '73',
+                74  => '74',
+                75  => '75',
+                76  => '76',
+                77  => '77',
+                78  => '78',
+                79  => '79',
+                80  => '80',
+                81  => '81',
+                82  => '82',
+                83  => '83',
+                84  => '84',
+                85  => '85',
+                86  => '86',
+                87  => '87',
+                88  => '88',
+                89  => '89',
+                90  => '90',
+                91  => '91',
+                92  => '92',
+                93  => '93',
+                94  => '94',
+                95  => '95',
+                96  => '96',
+                97  => '97',
+                98  => '98',
+                99  => '99',
+                100 => 'ä',
+                101 => 'à',
+                102 => 'å',
+                103 => '‡',
+                104 => 'ˆ',
+                105 => '‰',
+                106 => 'Š',
+            ],
+        ]]]></code>
+    </InvalidArgument>
+    <PossiblyFalseArgument>
       <code>$char</code>
       <code>$char</code>
       <code>$char</code>
@@ -193,13 +523,13 @@
       <code>$value</code>
       <code>$value</code>
     </PossiblyFalseArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$utf8StringWrapper</code>
     </PropertyNotSetInConstructor>
-    <UndefinedFunction occurrences="1">
-      <code>'code128'</code>
+    <UndefinedFunction>
+      <code><![CDATA['code128']]></code>
     </UndefinedFunction>
-    <UnusedVariable occurrences="10">
+    <UnusedVariable>
       <code>$read</code>
       <code>$read</code>
       <code>$read</code>
@@ -213,463 +543,465 @@
     </UnusedVariable>
   </file>
   <file src="src/Barcode/Code25.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'code25'</code>
+    <UndefinedFunction>
+      <code><![CDATA['code25']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Code25interleaved.php">
-    <InvalidArgument occurrences="2">
-      <code>'0123456789'</code>
-      <code>'even'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
+      <code><![CDATA['even']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'code25'</code>
+    <UndefinedFunction>
+      <code><![CDATA['code25']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Code39.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -.$/+%'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -.$/+%']]></code>
     </InvalidArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$count</code>
       <code>$mod</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$count</code>
-      <code>$this-&gt;check[$char]</code>
+      <code><![CDATA[$this->check[$char]]]></code>
     </MixedOperand>
-    <UndefinedFunction occurrences="1">
-      <code>'code39'</code>
+    <UndefinedFunction>
+      <code><![CDATA['code39']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Code93.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -.$/+%'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ -.$/+%']]></code>
     </InvalidArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$count</code>
       <code>$count</code>
     </MixedAssignment>
-    <MixedOperand occurrences="6">
+    <MixedOperand>
       <code>$count</code>
       <code>$count</code>
-      <code>$this-&gt;check[$char]</code>
-      <code>$this-&gt;check[$char]</code>
-      <code>$this-&gt;check[$char] * $length</code>
-      <code>$this-&gt;check[$char] * $length</code>
+      <code><![CDATA[$this->check[$char]]]></code>
+      <code><![CDATA[$this->check[$char]]]></code>
+      <code><![CDATA[$this->check[$char] * $length]]></code>
+      <code><![CDATA[$this->check[$char] * $length]]></code>
     </MixedOperand>
-    <PossiblyFalseOperand occurrences="2">
+    <PossiblyFalseOperand>
       <code>$check</code>
-      <code>array_search($count % 47, $this-&gt;check)</code>
+      <code><![CDATA[array_search($count % 47, $this->check)]]></code>
     </PossiblyFalseOperand>
-    <UndefinedFunction occurrences="1">
-      <code>'code93'</code>
+    <UndefinedFunction>
+      <code><![CDATA['code93']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Ean12.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Ean13.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Ean14.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Ean18.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Ean2.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
   </file>
   <file src="src/Barcode/Ean5.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
   </file>
   <file src="src/Barcode/Ean8.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Gtin12.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Gtin13.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Gtin14.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Identcode.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'identcode'</code>
+    <UndefinedFunction>
+      <code><![CDATA['identcode']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Intelligentmail.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
   </file>
   <file src="src/Barcode/Issn.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789X'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789X']]></code>
     </InvalidArgument>
-    <PossiblyInvalidOperand occurrences="1">
+    <PossiblyInvalidOperand>
       <code>$token</code>
     </PossiblyInvalidOperand>
-    <UndefinedFunction occurrences="3">
-      <code>'gtin'</code>
-      <code>'gtin'</code>
-      <code>'issn'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
+      <code><![CDATA['gtin']]></code>
+      <code><![CDATA['issn']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Itf14.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Leitcode.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'identcode'</code>
+    <UndefinedFunction>
+      <code><![CDATA['identcode']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Planet.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'postnet'</code>
+    <UndefinedFunction>
+      <code><![CDATA['postnet']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Postnet.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'postnet'</code>
+    <UndefinedFunction>
+      <code><![CDATA['postnet']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Royalmail.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ']]></code>
     </InvalidArgument>
-    <InvalidPropertyAssignmentValue occurrences="2"/>
-    <UndefinedFunction occurrences="1">
-      <code>'royalmail'</code>
+    <UndefinedFunction>
+      <code><![CDATA['royalmail']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Sscc.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Upca.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Barcode/Upce.php">
-    <InvalidArgument occurrences="1">
-      <code>'0123456789'</code>
+    <InvalidArgument>
+      <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'gtin'</code>
+    <UndefinedFunction>
+      <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
   </file>
   <file src="src/Between.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;options['inclusive']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['inclusive']]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Bitwise.php">
-    <DocblockTypeContradiction occurrences="4">
-      <code>self::OP_AND === $this-&gt;operator</code>
-      <code>self::OP_AND === $this-&gt;operator</code>
-      <code>self::OP_XOR === $this-&gt;operator</code>
-      <code>self::OP_XOR === $this-&gt;operator</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[self::OP_AND === $this->operator]]></code>
+      <code><![CDATA[self::OP_AND === $this->operator]]></code>
+      <code><![CDATA[self::OP_XOR === $this->operator]]></code>
+      <code><![CDATA[self::OP_XOR === $this->operator]]></code>
     </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>$operator</code>
     </InvalidPropertyAssignmentValue>
-    <MixedAssignment occurrences="3">
-      <code>$temp['control']</code>
-      <code>$temp['operator']</code>
-      <code>$temp['strict']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['control']]]></code>
+      <code><![CDATA[$temp['operator']]]></code>
+      <code><![CDATA[$temp['strict']]]></code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$control</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $strict</code>
       <code>(int) $control</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Callback.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$options</code>
       <code>$options</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$args[]</code>
       <code>$args[]</code>
       <code>$callback</code>
       <code>$options</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
+    <MixedFunctionCall>
       <code>call_user_func_array($callback, $args)</code>
     </MixedFunctionCall>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/CreditCard.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <InvalidOperand occurrences="1">
+    <InvalidOperand>
       <code>$value[$i]</code>
     </InvalidOperand>
-    <MixedArgument occurrences="7">
-      <code>$options['service']</code>
-      <code>$options['type']</code>
-      <code>$this-&gt;cardLength[$type]</code>
-      <code>$this-&gt;options['type']</code>
-      <code>$this-&gt;options['type']</code>
+    <MixedArgument>
+      <code><![CDATA[$options['service']]]></code>
+      <code><![CDATA[$options['type']]]></code>
+      <code><![CDATA[$this->cardLength[$type]]]></code>
+      <code><![CDATA[$this->options['type']]]></code>
+      <code><![CDATA[$this->options['type']]]></code>
       <code>$typ</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;options['type'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->options['type'][]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="2">
-      <code>$this-&gt;cardLength[$type]</code>
-      <code>$this-&gt;cardType[$type]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->cardLength[$type]]]></code>
+      <code><![CDATA[$this->cardType[$type]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$prefix</code>
-      <code>$temp['service']</code>
-      <code>$temp['type']</code>
+      <code><![CDATA[$temp['service']]]></code>
+      <code><![CDATA[$temp['type']]]></code>
       <code>$typ</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>callable</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['service']</code>
-      <code>$this-&gt;options['type']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['service']]]></code>
+      <code><![CDATA[$this->options['type']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$options</code>
-      <code>$this-&gt;getType()</code>
+      <code><![CDATA[$this->getType()]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <UndefinedAttributeClass>
+      <code>SensitiveParameter</code>
+    </UndefinedAttributeClass>
   </file>
   <file src="src/Csrf.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>is_array($options)</code>
       <code>is_string($value)</code>
-      <code>null === $this-&gt;session</code>
+      <code><![CDATA[null === $this->session]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$key</code>
-      <code>$session-&gt;tokenList[$tokenId]</code>
+      <code><![CDATA[$session->tokenList[$tokenId]]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="1">
-      <code>$session-&gt;tokenList[$tokenId]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$session->tokenList[$tokenId]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$key</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>null|string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$session-&gt;hash</code>
-      <code>$this-&gt;hash</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$session->hash]]></code>
+      <code><![CDATA[$this->hash]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$session-&gt;tokenList</code>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$session->tokenList]]></code>
     </PossiblyNullArrayOffset>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$session</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(int) $ttl</code>
       <code>(string) $name</code>
       <code>(string) $salt</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Date.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$temp['format']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['format']]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
   </file>
   <file src="src/DateStep.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$intervalParts</code>
     </ArgumentTypeCoercion>
-    <MixedAssignment occurrences="4">
-      <code>$temp['baseValue']</code>
-      <code>$temp['format']</code>
-      <code>$temp['step']</code>
-      <code>$temp['timezone']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['baseValue']]]></code>
+      <code><![CDATA[$temp['format']]]></code>
+      <code><![CDATA[$temp['step']]]></code>
+      <code><![CDATA[$temp['timezone']]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$step</code>
       <code>$timezone</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>$baseDate instanceof DateTimeImmutable</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Db/AbstractDb.php">
-    <LessSpecificReturnStatement occurrences="5">
+    <LessSpecificReturnStatement>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="8">
-      <code>$options['adapter']</code>
-      <code>$options['exclude']</code>
-      <code>$options['field']</code>
-      <code>$options['schema']</code>
-      <code>$options['table']</code>
-      <code>$this-&gt;exclude</code>
-      <code>$this-&gt;exclude['field']</code>
-      <code>$this-&gt;exclude['value']</code>
+    <MixedArgument>
+      <code><![CDATA[$options['adapter']]]></code>
+      <code><![CDATA[$options['exclude']]]></code>
+      <code><![CDATA[$options['field']]]></code>
+      <code><![CDATA[$options['schema']]]></code>
+      <code><![CDATA[$options['table']]]></code>
+      <code><![CDATA[$this->exclude]]></code>
+      <code><![CDATA[$this->exclude['field']]]></code>
+      <code><![CDATA[$this->exclude['value']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$firstArgument</code>
-      <code>$temp['adapter']</code>
-      <code>$temp['exclude']</code>
-      <code>$temp['field']</code>
-      <code>$temp['table']</code>
+      <code><![CDATA[$temp['adapter']]]></code>
+      <code><![CDATA[$temp['exclude']]]></code>
+      <code><![CDATA[$temp['field']]]></code>
+      <code><![CDATA[$temp['table']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>string|array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$result-&gt;current()</code>
-      <code>$this-&gt;exclude</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$result->current()]]></code>
+      <code><![CDATA[$this->exclude]]></code>
     </MixedReturnStatement>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <PossiblyNullArgument occurrences="12">
+    <PossiblyNullArgument>
       <code>$options</code>
       <code>$options</code>
       <code>$options</code>
@@ -677,391 +1009,396 @@
       <code>$options</code>
       <code>$options</code>
       <code>$options</code>
-      <code>$options['adapter']</code>
-      <code>$options['exclude']</code>
-      <code>$options['field']</code>
-      <code>$options['schema']</code>
-      <code>$options['table']</code>
+      <code><![CDATA[$options['adapter']]]></code>
+      <code><![CDATA[$options['exclude']]]></code>
+      <code><![CDATA[$options['field']]]></code>
+      <code><![CDATA[$options['schema']]]></code>
+      <code><![CDATA[$options['table']]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="4">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
       <code>null</code>
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>$parameters</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$schema</code>
       <code>AbstractDb</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(string) $field</code>
       <code>(string) $table</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;select instanceof Select</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->select instanceof Select]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Db/NoRecordExists.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;adapter</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[null === $this->adapter]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>NoRecordExists</code>
       <code>NoRecordExists</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Db/RecordExists.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;adapter</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[null === $this->adapter]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>RecordExists</code>
       <code>RecordExists</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Digits.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! is_string($value)</code>
       <code>null === static::$filter</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/EmailAddress.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>''</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA['']]></code>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;getAllow()</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->getAllow()]]></code>
     </InvalidArgument>
-    <LessSpecificImplementedReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
       <code>AbstractValidator</code>
     </LessSpecificImplementedReturnType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;getValue()</code>
+    <MixedArgument>
+      <code><![CDATA[$this->getValue()]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$hostname</code>
       <code>$mxHosts</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;abstractOptions['messages'][$code]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->abstractOptions['messages'][$code]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
-      <code>$temp['allow']</code>
-      <code>$temp['hostnameValidator']</code>
-      <code>$temp['useMxCheck']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['allow']]]></code>
+      <code><![CDATA[$temp['hostnameValidator']]]></code>
+      <code><![CDATA[$temp['useMxCheck']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType>
       <code>Hostname</code>
       <code>bool</code>
       <code>bool</code>
       <code>bool</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setAllow</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="6">
-      <code>$this-&gt;options['allow']</code>
-      <code>$this-&gt;options['hostnameValidator']</code>
-      <code>$this-&gt;options['hostnameValidator']</code>
-      <code>$this-&gt;options['useDeepMxCheck']</code>
-      <code>$this-&gt;options['useDomainCheck']</code>
-      <code>$this-&gt;options['useMxCheck']</code>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->abstractOptions]]></code>
+    </MixedPropertyTypeCoercion>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['allow']]]></code>
+      <code><![CDATA[$this->options['hostnameValidator']]]></code>
+      <code><![CDATA[$this->options['hostnameValidator']]]></code>
+      <code><![CDATA[$this->options['useDeepMxCheck']]]></code>
+      <code><![CDATA[$this->options['useDomainCheck']]]></code>
+      <code><![CDATA[$this->options['useMxCheck']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$hostname</code>
       <code>$localPart</code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;abstractOptions</code>
-    </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $deep</code>
       <code>(bool) $domain</code>
       <code>(bool) $mx</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>array_combine($mxHosts, $weight)</code>
       <code>is_string($value)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')</code>
+    <TypeDoesNotContainType>
+      <code><![CDATA[false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Explode.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>[$value]</code>
     </DocblockTypeContradiction>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;abstractOptions['messages'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->abstractOptions['messages'][]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <PropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;abstractOptions</code>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->abstractOptions]]></code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $break</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>null !== $delimiter</code>
     </RedundantConditionGivenDocblockType>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>isValid</code>
     </TooManyArguments>
   </file>
   <file src="src/File/Count.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>is_array($file)</code>
       <code>is_string($options)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$file</code>
       <code>$file</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$file</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
-      <code>$file['name']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$file['name']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="2">
-      <code>$this-&gt;files[$name]</code>
-      <code>$this-&gt;files[$name]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->files[$name]]]></code>
+      <code><![CDATA[$this->files[$name]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$max</code>
       <code>$min</code>
       <code>$name</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>int</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
-      <code>$file['destination']</code>
-      <code>$file['name']</code>
+    <MixedOperand>
+      <code><![CDATA[$file['destination']]]></code>
+      <code><![CDATA[$file['name']]]></code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['max']</code>
-      <code>$this-&gt;options['min']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['max']]]></code>
+      <code><![CDATA[$this->options['min']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="3">
+    <PossiblyInvalidCast>
       <code>$file</code>
       <code>$file</code>
       <code>$value</code>
     </PossiblyInvalidCast>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$count</code>
       <code>$files</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="6">
+    <RedundantConditionGivenDocblockType>
       <code>$file !== null</code>
-      <code>$this-&gt;getMax() !== null</code>
-      <code>$this-&gt;getMax() !== null</code>
-      <code>$this-&gt;getMin() !== null</code>
-      <code>$this-&gt;getMin() !== null</code>
+      <code><![CDATA[$this->getMax() !== null]]></code>
+      <code><![CDATA[$this->getMax() !== null]]></code>
+      <code><![CDATA[$this->getMin() !== null]]></code>
+      <code><![CDATA[$this->getMin() !== null]]></code>
       <code>is_string($file)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Crc32.php">
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>DOES_NOT_MATCH</code>
       <code>NOT_DETECTED</code>
       <code>NOT_FOUND</code>
     </InvalidClassConstantType>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
-    <MixedArgument occurrences="2">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[[
+        'algorithm' => 'crc32',
+        'hash'      => null,
+    ]]]></code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/File/ExcludeExtension.php">
-    <InvalidClassConstantType occurrences="2">
+    <InvalidClassConstantType>
       <code>FALSE_EXTENSION</code>
       <code>NOT_FOUND</code>
     </InvalidClassConstantType>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$ext</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['filename']</code>
-      <code>$fileInfo['filename']</code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$ext</code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$messageTemplates</code>
     </NonInvariantDocblockPropertyType>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strrpos($fileInfo['filename'], '.')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
   </file>
   <file src="src/File/ExcludeMimeType.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! $this-&gt;isMagicFileDisabled() &amp;&amp; (! empty($mimefile) &amp;&amp; empty($this-&gt;finfo))</code>
-    </DocblockTypeContradiction>
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>FALSE_TYPE</code>
       <code>NOT_DETECTED</code>
       <code>NOT_READABLE</code>
     </InvalidClassConstantType>
-    <MixedArgument occurrences="5">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;type</code>
+    <MixedAssignment>
+      <code><![CDATA[$this->type]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>ExcludeMimeType</code>
+    <PropertyNotSetInConstructor>
       <code>ExcludeMimeType</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/File/Exists.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($directory)</code>
     </DocblockTypeContradiction>
-    <InvalidIterator occurrences="1">
+    <InvalidIterator>
       <code>$directories</code>
     </InvalidIterator>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$directory</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="1">
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedArgumentTypeCoercion>
+      <code>$directories</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment>
+      <code>$dir</code>
       <code>$directory</code>
       <code>$directory</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string|null</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$directory</code>
-      <code>$fileInfo['basename']</code>
+      <code><![CDATA[$fileInfo['basename']]]></code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$directory</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$directories</code>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $asArray</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/File/Extension.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$ext</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['filename']</code>
-      <code>$fileInfo['filename']</code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$extensions</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$case</code>
       <code>$case</code>
       <code>$ext</code>
       <code>$ext</code>
-      <code>$options['case']</code>
+      <code><![CDATA[$options['case']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['allowNonExistentFile']</code>
-      <code>$this-&gt;options['case']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['allowNonExistentFile']]]></code>
+      <code><![CDATA[$this->options['case']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strrpos($fileInfo['filename'], '.')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $case</code>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/File/FileInformationTrait.php">
-    <MixedArgument occurrences="3">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['filename']</code>
-      <code>$fileInfo['filename']</code>
-      <code>$fileInfo['filetype']</code>
-      <code>$fileInfo['filetype']</code>
+    <MixedAssignment>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
+      <code><![CDATA[$fileInfo['filename']]]></code>
+      <code><![CDATA[$fileInfo['filetype']]]></code>
+      <code><![CDATA[$fileInfo['filetype']]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="15">
-      <code>$fileInfo['file']</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -1077,66 +1414,66 @@
       <code>$value</code>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="2">
-      <code>$fileInfo['file']</code>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$fileInfo['file']]]></code>
       <code>$value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="src/File/FilesSize.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($file)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="5">
+    <InvalidArgument>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
     </InvalidArgument>
-    <InvalidClassConstantType occurrences="2">
+    <InvalidClassConstantType>
       <code>TOO_BIG</code>
       <code>TOO_SMALL</code>
     </InvalidClassConstantType>
-    <InvalidPropertyAssignmentValue occurrences="2">
-      <code>$this-&gt;toByteString($size)</code>
-      <code>$this-&gt;toByteString($size)</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->toByteString($size)]]></code>
+      <code><![CDATA[$this->toByteString($size)]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$file</code>
       <code>$files</code>
       <code>$files</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$file['name']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$file['name']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="2">
-      <code>$this-&gt;files[$files]</code>
-      <code>$this-&gt;files[$files]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->files[$files]]]></code>
+      <code><![CDATA[$this->files[$files]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$files</code>
       <code>$files</code>
-      <code>$options['max']</code>
-      <code>$options['useByteString']</code>
+      <code><![CDATA[$options['max']]]></code>
+      <code><![CDATA[$options['useByteString']]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$max</code>
       <code>$min</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="5">
+    <PossiblyInvalidCast>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
     </PossiblyInvalidCast>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>FilesSize</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType>
       <code>$file !== null</code>
       <code>$max !== null</code>
       <code>$min !== null</code>
@@ -1145,245 +1482,262 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Hash.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
-    <MixedArgument occurrences="3">
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[[
+        'algorithm' => 'crc32',
+        'hash'      => null,
+    ]]]></code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument>
       <code>$algorithm</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;options['hash'][$value]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->options['hash'][$value]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$algorithm</code>
       <code>$algorithm</code>
       <code>$algorithm</code>
-      <code>$options['algorithm']</code>
+      <code><![CDATA[$options['algorithm']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;options['hash']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['hash']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/File/ImageSize.php">
-    <MixedArgument occurrences="2">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
-      <code>$options['maxHeight']</code>
-      <code>$options['maxWidth']</code>
-      <code>$options['minHeight']</code>
-      <code>$this-&gt;height</code>
-      <code>$this-&gt;width</code>
+    <MixedAssignment>
+      <code><![CDATA[$options['maxHeight']]]></code>
+      <code><![CDATA[$options['maxWidth']]]></code>
+      <code><![CDATA[$options['minHeight']]]></code>
+      <code><![CDATA[$this->height]]></code>
+      <code><![CDATA[$this->width]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType>
       <code>int</code>
       <code>int</code>
       <code>int</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="4">
-      <code>$this-&gt;options['maxHeight']</code>
-      <code>$this-&gt;options['maxWidth']</code>
-      <code>$this-&gt;options['minHeight']</code>
-      <code>$this-&gt;options['minWidth']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['maxHeight']]]></code>
+      <code><![CDATA[$this->options['maxWidth']]]></code>
+      <code><![CDATA[$this->options['minHeight']]]></code>
+      <code><![CDATA[$this->options['minWidth']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$options</code>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$height</code>
       <code>$width</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="4">
+    <RedundantCastGivenDocblockType>
       <code>(int) $maxHeight</code>
       <code>(int) $maxWidth</code>
       <code>(int) $minHeight</code>
       <code>(int) $minWidth</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="6">
-      <code>$this-&gt;getMaxHeight() !== null</code>
-      <code>$this-&gt;getMaxHeight() !== null</code>
-      <code>$this-&gt;getMaxWidth() !== null</code>
-      <code>$this-&gt;getMaxWidth() !== null</code>
-      <code>$this-&gt;getMinHeight() !== null</code>
-      <code>$this-&gt;getMinWidth() !== null</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->getMaxHeight() !== null]]></code>
+      <code><![CDATA[$this->getMaxHeight() !== null]]></code>
+      <code><![CDATA[$this->getMaxWidth() !== null]]></code>
+      <code><![CDATA[$this->getMaxWidth() !== null]]></code>
+      <code><![CDATA[$this->getMinHeight() !== null]]></code>
+      <code><![CDATA[$this->getMinWidth() !== null]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/IsCompressed.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>$options === null</code>
     </DocblockTypeContradiction>
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>FALSE_TYPE</code>
       <code>NOT_DETECTED</code>
       <code>NOT_READABLE</code>
     </InvalidClassConstantType>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>IsCompressed</code>
+    <PropertyNotSetInConstructor>
       <code>IsCompressed</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/File/IsImage.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>$options === null</code>
     </DocblockTypeContradiction>
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>FALSE_TYPE</code>
       <code>NOT_DETECTED</code>
       <code>NOT_READABLE</code>
     </InvalidClassConstantType>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>IsImage</code>
+    <PropertyNotSetInConstructor>
       <code>IsImage</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/File/Md5.php">
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>DOES_NOT_MATCH</code>
       <code>NOT_DETECTED</code>
       <code>NOT_FOUND</code>
     </InvalidClassConstantType>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
-    <MixedArgument occurrences="2">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[[
+        'algorithm' => 'md5',
+        'hash'      => null,
+    ]]]></code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/File/MimeType.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>! $this-&gt;isMagicFileDisabled() &amp;&amp; (! empty($mimefile) &amp;&amp; empty($this-&gt;finfo))</code>
+    <DocblockTypeContradiction>
       <code>$file === false</code>
       <code>is_array($mimetype)</code>
     </DocblockTypeContradiction>
-    <FalsableReturnStatement occurrences="1">
-      <code>$this-&gt;options['magicFile']</code>
+    <FalsableReturnStatement>
+      <code><![CDATA[$this->options['magicFile']]]></code>
     </FalsableReturnStatement>
-    <InvalidCatch occurrences="1"/>
-    <MixedArgument occurrences="13">
+    <InvalidCatch>
+      <code><![CDATA[try {
+                    $this->setMagicFile($file);
+                } catch (Exception\ExceptionInterface) {
+                    // suppressing errors which are thrown due to open_basedir restrictions
+                    continue;
+                }]]></code>
+    </InvalidCatch>
+    <MixedArgument>
       <code>$file</code>
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
       <code>$options[$key]</code>
-      <code>$options['enableHeaderCheck']</code>
-      <code>$options['magicFile']</code>
-      <code>$options['mimeType']</code>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
-      <code>$this-&gt;type</code>
+      <code><![CDATA[$options['enableHeaderCheck']]]></code>
+      <code><![CDATA[$options['magicFile']]]></code>
+      <code><![CDATA[$options['mimeType']]]></code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
+      <code><![CDATA[$this->type]]></code>
       <code>static::FALSE_TYPE</code>
       <code>static::NOT_DETECTED</code>
       <code>static::NOT_READABLE</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$file</code>
-      <code>$this-&gt;type</code>
+      <code><![CDATA[$this->type]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>bool</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
-      <code>$this-&gt;options['disableMagicFile']</code>
-      <code>$this-&gt;options['enableHeaderCheck']</code>
-      <code>$this-&gt;options['magicFile']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['disableMagicFile']]]></code>
+      <code><![CDATA[$this->options['enableHeaderCheck']]]></code>
+      <code><![CDATA[$this->options['magicFile']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <NoValue occurrences="1">
-      <code>return $this-&gt;options['magicFile'];</code>
+    <NoValue>
+      <code><![CDATA[return $this->options['magicFile'];]]></code>
     </NoValue>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$finfo</code>
+    <PropertyNotSetInConstructor>
       <code>$type</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $disable</code>
       <code>(bool) $headerCheck</code>
     </RedundantCastGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$this-&gt;options['magicFile'] !== null</code>
+    <TypeDoesNotContainType>
+      <code><![CDATA[$this->options['magicFile'] !== null]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/File/NotExists.php">
-    <InvalidIterator occurrences="1">
+    <InvalidIterator>
       <code>$directories</code>
     </InvalidIterator>
-    <MixedArgument occurrences="1">
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$directory</code>
     </MixedAssignment>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$directory</code>
-      <code>$fileInfo['basename']</code>
+      <code><![CDATA[$fileInfo['basename']]]></code>
     </MixedOperand>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/File/Sha1.php">
-    <InvalidClassConstantType occurrences="3">
+    <InvalidClassConstantType>
       <code>DOES_NOT_MATCH</code>
       <code>NOT_DETECTED</code>
       <code>NOT_FOUND</code>
     </InvalidClassConstantType>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
-    <MixedArgument occurrences="2">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[[
+        'algorithm' => 'sha1',
+        'hash'      => null,
+    ]]]></code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MoreSpecificImplementedParamType occurrences="2">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/File/Size.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>! is_string($max) &amp;&amp; ! is_numeric($max)</code>
-      <code>! is_string($min) &amp;&amp; ! is_numeric($min)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_string($max) && ! is_numeric($max)]]></code>
+      <code><![CDATA[! is_string($min) && ! is_numeric($min)]]></code>
       <code>is_string($options)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$size</code>
       <code>$size</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$sizes[$i]</code>
     </InvalidArrayOffset>
-    <InvalidOperand occurrences="8">
+    <InvalidOperand>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -1393,63 +1747,63 @@
       <code>$value</code>
       <code>$value</code>
     </InvalidOperand>
-    <InvalidPropertyAssignmentValue occurrences="5">
+    <InvalidPropertyAssignmentValue>
       <code>$size</code>
       <code>$size</code>
       <code>$size</code>
-      <code>$this-&gt;toByteString($size)</code>
-      <code>$this-&gt;toByteString($size)</code>
+      <code><![CDATA[$this->toByteString($size)]]></code>
+      <code><![CDATA[$this->toByteString($size)]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument occurrences="4">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
       <code>$max</code>
       <code>$min</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$max</code>
       <code>$min</code>
-      <code>$options['max']</code>
-      <code>$options['useByteString']</code>
+      <code><![CDATA[$options['max']]]></code>
+      <code><![CDATA[$options['useByteString']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>int|string</code>
       <code>int|string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$sizes[$i]</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="5">
+    <MixedReturnStatement>
       <code>$max</code>
       <code>$max</code>
       <code>$min</code>
       <code>$min</code>
-      <code>$this-&gt;options['useByteString']</code>
+      <code><![CDATA[$this->options['useByteString']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="4">
+    <PossiblyInvalidArgument>
       <code>$max</code>
       <code>$max</code>
       <code>$min</code>
       <code>$min</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidArrayAssignment occurrences="2">
-      <code>$options['max']</code>
-      <code>$options['useByteString']</code>
+    <PossiblyInvalidArrayAssignment>
+      <code><![CDATA[$options['max']]]></code>
+      <code><![CDATA[$options['useByteString']]]></code>
     </PossiblyInvalidArrayAssignment>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$size</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $byteString</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType>
       <code>$max !== null</code>
       <code>$max !== null</code>
       <code>$min !== null</code>
@@ -1457,11 +1811,10 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Upload.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>$this-&gt;options['files'] === null</code>
+    <DocblockTypeContradiction>
       <code>null === $files</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="11">
+    <MixedArgument>
       <code>$content</code>
       <code>$content</code>
       <code>$content</code>
@@ -1471,31 +1824,30 @@
       <code>$content</code>
       <code>$content</code>
       <code>$content</code>
-      <code>$content['tmp_name']</code>
+      <code><![CDATA[$content['tmp_name']]]></code>
       <code>$file</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="4">
+    <MixedArgumentTypeCoercion>
       <code>$file</code>
       <code>$file</code>
       <code>$file</code>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="6">
-      <code>$content['error']</code>
-      <code>$content['name']</code>
-      <code>$content['tmp_name']</code>
-      <code>$this-&gt;options['files'][$name]</code>
-      <code>$this-&gt;options['files'][$name]</code>
-      <code>$this-&gt;options['files'][$name]</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$content['error']]]></code>
+      <code><![CDATA[$content['name']]]></code>
+      <code><![CDATA[$content['tmp_name']]]></code>
+      <code><![CDATA[$this->options['files'][$name]]]></code>
+      <code><![CDATA[$this->options['files'][$name]]]></code>
+      <code><![CDATA[$this->options['files'][$name]]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="4">
+    <MixedArrayOffset>
       <code>$return[$name]</code>
       <code>$return[$name]</code>
-      <code>$this-&gt;options['files'][$name]</code>
-      <code>$this-&gt;options['files'][$name]</code>
+      <code><![CDATA[$this->options['files'][$name]]]></code>
+      <code><![CDATA[$this->options['files'][$name]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="9">
-      <code>$content</code>
+    <MixedAssignment>
       <code>$content</code>
       <code>$content</code>
       <code>$content</code>
@@ -1505,652 +1857,697 @@
       <code>$return[$name]</code>
       <code>$return[$name]</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;options['files']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['files']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$file</code>
     </PossiblyNullArgument>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType>
       <code>$file !== null</code>
+      <code><![CDATA[(is_countable($files))
+                && count($files) === 0]]></code>
       <code>is_countable($files)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainNull>
+      <code><![CDATA[$this->options['files'] === null]]></code>
+    </TypeDoesNotContainNull>
   </file>
   <file src="src/File/UploadFile.php">
-    <MixedArgument occurrences="3">
-      <code>$value['error']</code>
-      <code>$value['name']</code>
-      <code>$value['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$value['error']]]></code>
+      <code><![CDATA[$value['name']]]></code>
+      <code><![CDATA[$value['tmp_name']]]></code>
     </MixedArgument>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($value)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/WordCount.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($options)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
-      <code>$fileInfo['file']</code>
-      <code>$fileInfo['file']</code>
+    <MixedArgument>
+      <code><![CDATA[$fileInfo['file']]]></code>
+      <code><![CDATA[$fileInfo['file']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$max</code>
       <code>$min</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>int</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['max']</code>
-      <code>$this-&gt;options['min']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['max']]]></code>
+      <code><![CDATA[$this->options['min']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$count</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="4">
-      <code>$this-&gt;getMax() !== null</code>
-      <code>$this-&gt;getMax() !== null</code>
-      <code>$this-&gt;getMin() !== null</code>
-      <code>$this-&gt;getMin() !== null</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->getMax() !== null]]></code>
+      <code><![CDATA[$this->getMax() !== null]]></code>
+      <code><![CDATA[$this->getMin() !== null]]></code>
+      <code><![CDATA[$this->getMin() !== null]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/GpsPoint.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>$value === false || $value === null</code>
       <code>$value === null</code>
     </DocblockTypeContradiction>
-    <InvalidOperand occurrences="2">
+    <InvalidOperand>
       <code>$matches[1][0]</code>
       <code>$matches[2][0]</code>
     </InvalidOperand>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
   </file>
   <file src="src/GreaterThan.php">
-    <MixedArgument occurrences="1">
-      <code>$options['inclusive']</code>
+    <MixedArgument>
+      <code><![CDATA[$options['inclusive']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$temp['inclusive']</code>
-      <code>$temp['min']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['inclusive']]]></code>
+      <code><![CDATA[$temp['min']]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$inclusive</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Hex.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_string($value)</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Hostname.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>is_array($options)</code>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$regexChar</code>
       <code>$regexKey</code>
     </MixedArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$partRegexChars</code>
       <code>$regexChar</code>
       <code>$regexChars</code>
       <code>$regexKey</code>
-      <code>$temp['allow']</code>
-      <code>$temp['ipValidator']</code>
-      <code>$temp['useIdnCheck']</code>
-      <code>$temp['useTldCheck']</code>
+      <code><![CDATA[$temp['allow']]]></code>
+      <code><![CDATA[$temp['ipValidator']]]></code>
+      <code><![CDATA[$temp['useIdnCheck']]]></code>
+      <code><![CDATA[$temp['useTldCheck']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType>
       <code>Ip</code>
       <code>bool</code>
       <code>bool</code>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$regexChars</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="4">
-      <code>$this-&gt;options['allow']</code>
-      <code>$this-&gt;options['ipValidator']</code>
-      <code>$this-&gt;options['useIdnCheck']</code>
-      <code>$this-&gt;options['useTldCheck']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['allow']]]></code>
+      <code><![CDATA[$this->options['ipValidator']]]></code>
+      <code><![CDATA[$this->options['useIdnCheck']]]></code>
+      <code><![CDATA[$this->options['useTldCheck']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $useIdnCheck</code>
       <code>(bool) $useTldCheck</code>
     </RedundantCastGivenDocblockType>
-    <UnresolvableInclude occurrences="1">
-      <code>include __DIR__ . '/' . $this-&gt;validIdns[$this-&gt;tld]</code>
+    <UnresolvableInclude>
+      <code><![CDATA[include __DIR__ . '/' . $this->validIdns[$this->tld]]]></code>
     </UnresolvableInclude>
   </file>
   <file src="src/Iban.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
-      <code>$options['allow_non_sepa']</code>
-      <code>$options['country_code']</code>
+    <MixedArgument>
+      <code><![CDATA[$options['allow_non_sepa']]]></code>
+      <code><![CDATA[$options['country_code']]]></code>
     </MixedArgument>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>static::$ibanRegex[$countryCode]</code>
     </MixedOperand>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $allowNonSepa</code>
       <code>(string) $countryCode</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Identical.php">
-    <MixedArgument occurrences="2">
-      <code>$token['literal']</code>
-      <code>$token['strict']</code>
+    <MixedArgument>
+      <code><![CDATA[$token['literal']]]></code>
+      <code><![CDATA[$token['strict']]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$context[$key]</code>
       <code>$context[$token]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$context</code>
-      <code>$this-&gt;token</code>
+      <code><![CDATA[$this->token]]></code>
       <code>$token</code>
       <code>$token</code>
       <code>$token</code>
       <code>$token</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>is_array($token) ? $token : null</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $literal</code>
       <code>(bool) $strict</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/InArray.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$this-&gt;haystack === null</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$this->haystack === null]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$haystack</code>
       <code>$haystack</code>
       <code>$haystack</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$el</code>
       <code>$element</code>
       <code>$h</code>
       <code>$haystack</code>
-      <code>$this-&gt;haystack</code>
+      <code><![CDATA[$this->haystack]]></code>
     </MixedAssignment>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$haystack</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $recursive</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Ip.php">
-    <LessSpecificImplementedReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
       <code>AbstractValidator</code>
     </LessSpecificImplementedReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$regex</code>
       <code>$regex</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/IsCountable.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$options</code>
     </MixedArgumentTypeCoercion>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/IsInstanceOf.php">
-    <MixedAssignment occurrences="1">
-      <code>$tmpOptions['className']</code>
+    <MixedAssignment>
+      <code><![CDATA[$tmpOptions['className']]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$className</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/IsJsonString.php">
+    <InvalidArgument>
+      <code><![CDATA[$this->maxDepth]]></code>
+    </InvalidArgument>
+  </file>
   <file src="src/Isbn.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
-      <code>$this-&gt;getValue()</code>
-      <code>$this-&gt;getValue()</code>
-      <code>$this-&gt;getValue()</code>
+    <MixedArgument>
+      <code><![CDATA[$this->getValue()]]></code>
+      <code><![CDATA[$this->getValue()]]></code>
+      <code><![CDATA[$this->getValue()]]></code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;options['separator']</code>
-      <code>$this-&gt;options['type']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['separator']]]></code>
+      <code><![CDATA[$this->options['type']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/LessThan.php">
-    <MixedArgument occurrences="1">
-      <code>$options['inclusive']</code>
+    <MixedArgument>
+      <code><![CDATA[$options['inclusive']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$temp['inclusive']</code>
-      <code>$temp['max']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['inclusive']]]></code>
+      <code><![CDATA[$temp['max']]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$inclusive</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Module.php">
-    <UndefinedDocblockClass occurrences="1">
+    <UndefinedDocblockClass>
       <code>ModuleManager</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/NotEmpty.php">
-    <MixedAssignment occurrences="2">
-      <code>$temp['type']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['type']]]></code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;options['type']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['type']]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$type</code>
     </PossiblyNullArgument>
+    <RedundantCondition>
+      <code><![CDATA[is_object($value) && method_exists($value, '__toString')]]></code>
+    </RedundantCondition>
   </file>
   <file src="src/Regex.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! is_string($value)</code>
       <code>is_array($pattern)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
-      <code>$pattern['pattern']</code>
+    <MixedArgument>
+      <code><![CDATA[$pattern['pattern']]]></code>
       <code>$value</code>
     </MixedArgument>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$pattern</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $pattern</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Sitemap/Changefreq.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Sitemap/Lastmod.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Sitemap/Loc.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/Sitemap/Priority.php">
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="src/StaticValidator.php">
-    <RedundantCondition occurrences="1">
-      <code>method_exists($plugins, 'configure')</code>
+    <RedundantCondition>
+      <code><![CDATA[method_exists($plugins, 'configure')]]></code>
     </RedundantCondition>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>setShareByDefault</code>
     </UndefinedMethod>
   </file>
   <file src="src/Step.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>$options instanceof Traversable</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$float</code>
       <code>$value</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument>
       <code>$float</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$options</code>
-      <code>$this-&gt;baseValue</code>
-      <code>$this-&gt;step</code>
+      <code><![CDATA[$this->baseValue]]></code>
+      <code><![CDATA[$this->step]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$temp['baseValue']</code>
-      <code>$temp['step']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['baseValue']]]></code>
+      <code><![CDATA[$temp['step']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;baseValue</code>
-      <code>$this-&gt;step</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->baseValue]]></code>
+      <code><![CDATA[$this->step]]></code>
     </MixedReturnStatement>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strpos($float, '.')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strpos($float, '.')]]></code>
     </PossiblyFalseOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
   </file>
   <file src="src/StringLength.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="3">
-      <code>$temp['encoding']</code>
-      <code>$temp['max']</code>
-      <code>$temp['min']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['encoding']]]></code>
+      <code><![CDATA[$temp['max']]]></code>
+      <code><![CDATA[$temp['min']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType>
       <code>int</code>
       <code>int</code>
       <code>int|null</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="4">
-      <code>$this-&gt;options['encoding']</code>
-      <code>$this-&gt;options['length']</code>
-      <code>$this-&gt;options['max']</code>
-      <code>$this-&gt;options['min']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['encoding']]]></code>
+      <code><![CDATA[$this->options['length']]]></code>
+      <code><![CDATA[$this->options['max']]]></code>
+      <code><![CDATA[$this->options['min']]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$this-&gt;getStringWrapper()-&gt;strlen($value)</code>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->getStringWrapper()->strlen($value)]]></code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(int) $length</code>
       <code>(int) $max</code>
       <code>(int) $min</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Timezone.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($type)</code>
     </DocblockTypeContradiction>
-    <InvalidOperand occurrences="1">
-      <code>array_search($value, $this-&gt;constants)</code>
+    <InvalidOperand>
+      <code><![CDATA[array_search($value, $this->constants)]]></code>
     </InvalidOperand>
-    <MixedArgument occurrences="1"/>
-    <MixedAssignment occurrences="3">
-      <code>$opts['type']</code>
+    <MixedArgument>
+      <code>is_string($type) || is_int($type)
+                    ? $type : gettype($type)</code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$opts['type']]]></code>
       <code>$type</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
       <code>$type</code>
       <code>$type</code>
       <code>$type</code>
       <code>$type</code>
     </MixedOperand>
-    <PossiblyFalseOperand occurrences="1">
-      <code>array_search($value, $this-&gt;constants)</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[array_search($value, $this->constants)]]></code>
     </PossiblyFalseOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$opts</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument>
       <code>$type</code>
       <code>$value</code>
       <code>$value</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$opts</code>
     </PossiblyUndefinedVariable>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>gettype($type)</code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="src/UndisclosedPassword.php">
+    <UndefinedAttributeClass>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+      <code>SensitiveParameter</code>
+    </UndefinedAttributeClass>
+  </file>
   <file src="src/Uri.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction>
       <code>is_array($options)</code>
-      <code>is_string($this-&gt;uriHandler)</code>
+      <code><![CDATA[is_string($this->uriHandler)]]></code>
       <code>is_string($value)</code>
-      <code>null === $this-&gt;uriHandler</code>
+      <code><![CDATA[null === $this->uriHandler]]></code>
     </DocblockTypeContradiction>
-    <InvalidCatch occurrences="1"/>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;uriHandler</code>
+    <InvalidCatch>
+      <code><![CDATA[try {
+            $uriHandler->parse($value);
+            if ($uriHandler->isValid()) {
+                // It will either be a valid absolute or relative URI
+                if (
+                    ($this->allowRelative && $this->allowAbsolute)
+                    || ($this->allowAbsolute && $uriHandler->isAbsolute())
+                    || ($this->allowRelative && $uriHandler->isValidRelative())
+                ) {
+                    return true;
+                }
+            }
+        } catch (UriException) {
+            // Error parsing URI, it must be invalid
+        }]]></code>
+    </InvalidCatch>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->uriHandler]]></code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="4">
-      <code>$options['allowAbsolute']</code>
-      <code>$options['allowRelative']</code>
-      <code>$options['uriHandler']</code>
-      <code>$this-&gt;uriHandler</code>
+    <MixedArgument>
+      <code><![CDATA[$options['allowAbsolute']]]></code>
+      <code><![CDATA[$options['allowRelative']]]></code>
+      <code><![CDATA[$options['uriHandler']]]></code>
+      <code><![CDATA[$this->uriHandler]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$temp['allowAbsolute']</code>
-      <code>$temp['allowRelative']</code>
-      <code>$temp['uriHandler']</code>
+    <MixedAssignment>
+      <code><![CDATA[$temp['allowAbsolute']]]></code>
+      <code><![CDATA[$temp['allowRelative']]]></code>
+      <code><![CDATA[$temp['uriHandler']]]></code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>new $this-&gt;uriHandler()</code>
+    <MixedMethodCall>
+      <code><![CDATA[new $this->uriHandler()]]></code>
     </MixedMethodCall>
-    <MoreSpecificImplementedParamType occurrences="1">
+    <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>UriHandler</code>
     </MoreSpecificReturnType>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+    <PossiblyInvalidPropertyAssignmentValue>
       <code>$uriHandler</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyUndefinedVariable occurrences="1">
+    <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$uriHandler</code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="1">
-      <code>new $this-&gt;uriHandler()</code>
+    <PropertyTypeCoercion>
+      <code><![CDATA[new $this->uriHandler()]]></code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $allowAbsolute</code>
       <code>(bool) $allowRelative</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/ValidatorChain.php">
-    <MixedPropertyTypeCoercion occurrences="1">
+    <MixedPropertyTypeCoercion>
       <code>new PriorityQueue()</code>
     </MixedPropertyTypeCoercion>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>isValid</code>
     </TooManyArguments>
   </file>
   <file src="src/ValidatorPluginManager.php">
-    <DeprecatedMethod occurrences="2">
+    <DeprecatedMethod>
       <code>getServiceLocator</code>
       <code>getServiceLocator</code>
     </DeprecatedMethod>
-    <MethodSignatureMismatch occurrences="2">
-      <code>ValidatorPluginManager</code>
+    <MethodSignatureMismatch>
       <code>ValidatorPluginManager</code>
     </MethodSignatureMismatch>
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$configOrContainerInstance</code>
     </MissingParamType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$configOrContainerInstance</code>
-      <code>$container-&gt;get('MvcTranslator')</code>
+      <code><![CDATA[$container->get('MvcTranslator')]]></code>
     </MixedArgument>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>get</code>
       <code>has</code>
     </MixedMethodCall>
-    <NonInvariantDocblockPropertyType occurrences="1">
+    <NonInvariantDocblockPropertyType>
       <code>$instanceOf</code>
     </NonInvariantDocblockPropertyType>
-    <RedundantCondition occurrences="1">
-      <code>$container === $this &amp;&amp; method_exists($container, 'getServiceLocator')</code>
+    <RedundantCondition>
+      <code><![CDATA[$container === $this && method_exists($container, 'getServiceLocator')]]></code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>$container</code>
-      <code>$container-&gt;getServiceLocator()</code>
+      <code><![CDATA[$container->getServiceLocator()]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/ValidatorPluginManagerAwareInterface.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>setValidatorPluginManager</code>
     </MissingReturnType>
   </file>
   <file src="src/ValidatorPluginManagerFactory.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedClass>
+      <code><![CDATA[new Config($config['validators'])]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
       <code>ValidatorPluginManagerFactory</code>
     </DeprecatedInterface>
-    <MixedArgument occurrences="1">
-      <code>$config['validators']</code>
+    <MixedArgument>
+      <code><![CDATA[$config['validators']]]></code>
     </MixedArgument>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$container</code>
     </ParamNameMismatch>
   </file>
   <file src="test/AbstractValidatorTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$options</code>
-      <code>[$this, 'errorHandlerIgnore']</code>
-      <code>[$this, 'errorHandlerIgnore']</code>
-      <code>[$this, 'errorHandlerIgnore']</code>
+      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
+      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
+      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$message</code>
     </MixedAssignment>
-    <NullArgument occurrences="2">
+    <NullArgument>
       <code>null</code>
       <code>null</code>
     </NullArgument>
   </file>
   <file src="test/BarcodeTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$expectedInstance</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="6">
+    <InvalidArgument>
       <code>123</code>
       <code>123</code>
       <code>06510000.4327</code>
       <code>106510000.4327</code>
-      <code>['065100004327']</code>
-      <code>['065100004327']</code>
+      <code><![CDATA[['065100004327']]]></code>
+      <code><![CDATA[['065100004327']]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="2">
-      <code>['065100004327']</code>
-      <code>['065100004327']</code>
+    <InvalidCast>
+      <code><![CDATA[['065100004327']]]></code>
+      <code><![CDATA[['065100004327']]]></code>
     </InvalidCast>
   </file>
   <file src="test/BetweenTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>1</code>
     </InvalidArgument>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$args</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/BitwiseTest.php">
-    <InvalidArgument occurrences="7">
+    <InvalidArgument>
       <code>$control</code>
       <code>$control</code>
       <code>0x1</code>
@@ -2161,300 +2558,313 @@
     </InvalidArgument>
   </file>
   <file src="test/CallbackTest.php">
-    <MissingClosureParamType occurrences="5">
+    <MissingClosureParamType>
       <code>$baz</code>
       <code>$c</code>
       <code>$c</code>
       <code>$v</code>
       <code>$v</code>
     </MissingClosureParamType>
-    <MixedArrayAssignment occurrences="1">
-      <code>$options['callback']</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$options['callback']]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
   </file>
   <file src="test/CreditCardTest.php">
-    <InvalidArgument occurrences="2">
-      <code>['something']</code>
-      <code>[self::class, 'nocallback']</code>
+    <InvalidArgument>
+      <code><![CDATA[['something']]]></code>
+      <code><![CDATA[[self::class, 'nocallback']]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>['something']</code>
+    <InvalidCast>
+      <code><![CDATA[['something']]]></code>
     </InvalidCast>
   </file>
   <file src="test/CsrfTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>[]</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>[]</code>
     </InvalidCast>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$bareToken</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$bareToken</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$timeout</code>
     </PossiblyInvalidArgument>
-    <PossiblyUndefinedArrayOffset occurrences="1">
-      <code>$_SERVER['REQUEST_TIME']</code>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
-    <InvalidArgument occurrences="8">
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
+    <InvalidArgument>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
     </InvalidArgument>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>class extends ArrayObject {</code>
     </MissingTemplateParam>
   </file>
   <file src="test/Db/RecordExistsTest.php">
-    <InvalidArgument occurrences="4">
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
-      <code>'users'</code>
+    <InvalidArgument>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
+      <code><![CDATA['users']]></code>
     </InvalidArgument>
-    <MissingTemplateParam occurrences="1">
+    <MissingTemplateParam>
       <code>class extends ArrayObject {</code>
     </MissingTemplateParam>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$parameters['where1']</code>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$parameters['where1']]]></code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>$parameters</code>
     </PossiblyNullReference>
   </file>
   <file src="test/Db/TestAsset/ConcreteDbValidator.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>ConcreteDbValidator</code>
       <code>ConcreteDbValidator</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/DigitsTest.php">
-    <InvalidArgument occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidArgument>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
   </file>
   <file src="test/EmailAddressTest.php">
-    <InvalidArgument occurrences="10">
+    <InvalidArgument>
       <code>Hostname::ALLOW_ALL</code>
       <code>Hostname::ALLOW_ALL</code>
       <code>Hostname::ALLOW_ALL</code>
       <code>Hostname::ALLOW_ALL</code>
       <code>Hostname::ALLOW_ALL</code>
-      <code>Hostname::ALLOW_DNS</code>
-      <code>Hostname::ALLOW_DNS</code>
       <code>Hostname::ALLOW_DNS | Hostname::ALLOW_IP</code>
-      <code>[$this, 'errorHandler']</code>
-      <code>[1 =&gt; 1]</code>
+      <code><![CDATA[[$this, 'errorHandler']]]></code>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <NullArgument occurrences="2">
-      <code>null</code>
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedDocblockClass occurrences="1">
-      <code>PHPUnit_Framework_SkippedTestError</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="test/ExplodeTest.php">
-    <InvalidArgument occurrences="1">
-      <code>'inarray'</code>
+    <InvalidArgument>
+      <code><![CDATA['inarray']]></code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$c</code>
       <code>$v</code>
     </MissingClosureParamType>
-    <UnusedClosureParam occurrences="1">
-      <code>$v</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/File/CountTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$max</code>
       <code>$min</code>
     </MixedArgument>
   </file>
   <file src="test/File/Crc32Test.php">
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/ExcludeExtensionTest.php">
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$testData</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1"/>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <InvalidReturnType>
+      <code><![CDATA[array<array-key, array{
+     *     0: string|string[],
+     *     1: string|array{
+     *         tmp_name: string,
+     *         name: string,
+     *         size: int,
+     *         error: int,
+     *         type: string
+     *     },
+     *     2: bool,
+     *     3: string
+     * }>]]></code>
+    </InvalidReturnType>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/ExcludeMimeTypeTest.php">
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/ExistsTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$value</code>
     </ArgumentTypeCoercion>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$value</code>
     </PossiblyNullArgument>
   </file>
   <file src="test/File/ExtensionTest.php">
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
       <code>$testData</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1"/>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <InvalidReturnType>
+      <code><![CDATA[array<array-key, array{
+     *     0: string|string[],
+     *     1: string|array{
+     *         tmp_name: string,
+     *         name: string,
+     *         size: int,
+     *         error: int,
+     *         type: string
+     *     },
+     *     2: bool,
+     *     3: string
+     * }>]]></code>
+    </InvalidReturnType>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/FilesSizeTest.php">
-    <InvalidDocblock occurrences="1">
-      <code>public function basicDataProvider(): array</code>
-    </InvalidDocblock>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1"/>
   </file>
   <file src="test/File/HashTest.php">
-    <MixedArgument occurrences="2">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$options['algorithm']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$options['algorithm']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
   </file>
   <file src="test/File/ImageSizeTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$minWidth</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/IsCompressedTest.php">
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument>
       <code>$options</code>
       <code>$options</code>
     </PossiblyNullArgument>
   </file>
   <file src="test/File/IsImageTest.php">
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument>
       <code>$options</code>
       <code>$options</code>
     </PossiblyNullArgument>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>is_array($isValidParam)</code>
     </RedundantCondition>
   </file>
   <file src="test/File/Md5Test.php">
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
   </file>
   <file src="test/File/MimeTypeTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$type</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>[]</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>[]</code>
     </InvalidCast>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$options['magicFile']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$options['magicFile']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$type</code>
     </PossiblyNullArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_array($isValidParam)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/File/NotExistsTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$value</code>
     </ArgumentTypeCoercion>
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$value</code>
     </PossiblyNullArgument>
   </file>
   <file src="test/File/Sha1Test.php">
-    <MixedArgument occurrences="1">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$isValidParam</code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="test/File/SizeTest.php">
-    <MixedArgument occurrences="3">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
   </file>
   <file src="test/File/UploadTest.php">
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
   </file>
   <file src="test/File/WordCountTest.php">
-    <MixedArgument occurrences="3">
-      <code>$isValidParam['tmp_name']</code>
+    <MixedArgument>
+      <code><![CDATA[$isValidParam['tmp_name']]]></code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
   </file>
   <file src="test/GreaterThanTest.php">
-    <InvalidArgument occurrences="7">
+    <InvalidArgument>
       <code>1</code>
       <code>1</code>
       <code>10</code>
@@ -2463,26 +2873,26 @@
       <code>10</code>
       <code>10</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>testBasic</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/HexTest.php">
-    <InvalidArgument occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidArgument>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$input</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/HostnameTest.php">
-    <InvalidArgument occurrences="14">
+    <InvalidArgument>
       <code>$option</code>
       <code>$option</code>
       <code>$option</code>
@@ -2496,46 +2906,46 @@
       <code>Hostname::ALLOW_DNS</code>
       <code>Hostname::ALLOW_DNS</code>
       <code>Hostname::ALLOW_URI</code>
-      <code>[1 =&gt; 1]</code>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset>
       <code>$translations[$code]</code>
     </MixedArrayOffset>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <PossiblyUndefinedVariable occurrences="2">
+    <PossiblyUndefinedVariable>
       <code>$code</code>
       <code>$message</code>
     </PossiblyUndefinedVariable>
   </file>
   <file src="test/IbanTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>[]</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>[]</code>
     </InvalidCast>
   </file>
   <file src="test/IdenticalTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$context</code>
     </MixedArgument>
   </file>
   <file src="test/IsCountableTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$options</code>
       <code>$originalOptions</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/IsInstanceOfTest.php">
-    <InvalidArgument occurrences="7">
+    <InvalidArgument>
       <code>DateTime::class</code>
       <code>DateTime::class</code>
       <code>DateTime::class</code>
@@ -2546,19 +2956,19 @@
     </InvalidArgument>
   </file>
   <file src="test/IsbnTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>(float) 1.2345</code>
-      <code>(object) 'Test'</code>
+      <code><![CDATA[(object) 'Test']]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>(object) 'Test'</code>
+    <InvalidCast>
+      <code><![CDATA[(object) 'Test']]></code>
     </InvalidCast>
-    <RedundantCast occurrences="1">
+    <RedundantCast>
       <code>(float) 1.2345</code>
     </RedundantCast>
   </file>
   <file src="test/LessThanTest.php">
-    <InvalidArgument occurrences="6">
+    <InvalidArgument>
       <code>10</code>
       <code>10</code>
       <code>10</code>
@@ -2566,197 +2976,163 @@
       <code>10</code>
       <code>10</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>testBasic</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="test/MessageTest.php">
-    <InaccessibleProperty occurrences="1">
-      <code>$this-&gt;validator-&gt;value</code>
+    <InaccessibleProperty>
+      <code><![CDATA[$this->validator->value]]></code>
     </InaccessibleProperty>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedMagicPropertyFetch occurrences="3">
-      <code>$this-&gt;validator-&gt;max</code>
-      <code>$this-&gt;validator-&gt;min</code>
-      <code>$this-&gt;validator-&gt;unknownProperty</code>
+    <UndefinedMagicPropertyFetch>
+      <code><![CDATA[$this->validator->max]]></code>
+      <code><![CDATA[$this->validator->min]]></code>
+      <code><![CDATA[$this->validator->unknownProperty]]></code>
     </UndefinedMagicPropertyFetch>
   </file>
   <file src="test/NotEmptyTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$type</code>
-      <code>'boolean'</code>
-      <code>'boolean'</code>
+      <code><![CDATA['boolean']]></code>
+      <code><![CDATA['boolean']]></code>
       <code>true</code>
     </InvalidArgument>
   </file>
   <file src="test/RegexTest.php">
-    <InvalidArgument occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidArgument>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$options</code>
       <code>$options</code>
     </MixedArgument>
   </file>
   <file src="test/Sitemap/ChangefreqTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$value</code>
     </InvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="test/Sitemap/LastmodTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$value</code>
     </InvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="test/Sitemap/LocTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$value</code>
     </InvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="test/Sitemap/PriorityTest.php">
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="test/StaticValidatorTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>1</code>
     </InvalidArgument>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
   </file>
   <file src="test/StepTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$baseValue</code>
     </InvalidArgument>
   </file>
   <file src="test/StringLengthTest.php">
-    <InvalidArgument occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidArgument>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>[1 =&gt; 1]</code>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options</code>
     </MixedArgument>
   </file>
   <file src="test/TimezoneTest.php">
-    <InvalidArgument occurrences="4">
-      <code>'abbreviation'</code>
-      <code>'abbreviation'</code>
-      <code>'location'</code>
-      <code>'location'</code>
+    <InvalidArgument>
+      <code><![CDATA['abbreviation']]></code>
+      <code><![CDATA['abbreviation']]></code>
+      <code><![CDATA['location']]></code>
+      <code><![CDATA['location']]></code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
   </file>
-  <file src="test/UndisclosedPasswordTest.php">
-    <MixedArgument occurrences="2"/>
-  </file>
   <file src="test/UriTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$uriMock</code>
       <code>new stdClass()</code>
       <code>new stdClass()</code>
       <code>stdClass::class</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
   </file>
   <file src="test/ValidatorChainTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>1</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;error</code>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->error]]></code>
     </UndefinedThisPropertyAssignment>
-    <UnusedClosureParam occurrences="2">
+    <UnusedClosureParam>
       <code>$value</code>
       <code>$value</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/ValidatorPluginManagerCompatibilityTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$exceptionClassName</code>
-    </ArgumentTypeCoercion>
-    <MixedArgument occurrences="8">
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-      <code>$target</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$alias</code>
-      <code>$aliases</code>
-      <code>$target</code>
-    </MixedAssignment>
-    <MoreSpecificReturnType occurrences="1">
-      <code>iterable&lt;string, array{0: string, 1: string}&gt;</code>
-    </MoreSpecificReturnType>
-  </file>
-  <file src="test/ValidatorPluginManagerFactoryTest.php">
-    <MissingClosureParamType occurrences="1">
-      <code>$container</code>
-    </MissingClosureParamType>
-    <UnusedClosureParam occurrences="1">
-      <code>$container</code>
     </UnusedClosureParam>
   </file>
   <file src="test/_files/MyBarcode1.php">
-    <UndefinedFunction occurrences="1">
-      <code>'invalid'</code>
+    <UndefinedFunction>
+      <code><![CDATA['invalid']]></code>
     </UndefinedFunction>
   </file>
   <file src="test/_files/MyBarcode2.php">
-    <UndefinedFunction occurrences="1">
-      <code>'_mod10'</code>
+    <UndefinedFunction>
+      <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
   </file>
   <file src="test/_files/MyBarcode3.php">
-    <UndefinedFunction occurrences="1">
-      <code>'_mod10'</code>
+    <UndefinedFunction>
+      <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
   </file>
   <file src="test/_files/MyBarcode4.php">
-    <InvalidArgument occurrences="1">
-      <code>'odd'</code>
+    <InvalidArgument>
+      <code><![CDATA['odd']]></code>
     </InvalidArgument>
-    <UndefinedFunction occurrences="1">
-      <code>'_mod10'</code>
+    <UndefinedFunction>
+      <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2712,6 +2712,9 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
+    <PossiblyUnusedMethod>
+      <code>invalidOptionsArguments</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/BarcodeTest.php">
     <ArgumentTypeCoercion>
@@ -2729,6 +2732,9 @@
       <code><![CDATA[['065100004327']]]></code>
       <code><![CDATA[['065100004327']]]></code>
     </InvalidCast>
+    <PossiblyUnusedMethod>
+      <code>provideBarcodeConstructor</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/BetweenTest.php">
     <InvalidArgument>
@@ -2740,6 +2746,10 @@
     <PossiblyInvalidArgument>
       <code>$args</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>constructBetweenValidatorInvalidDataProvider</code>
+      <code>providerBasic</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/BitwiseTest.php">
     <InvalidArgument>
@@ -2751,6 +2761,18 @@
       <code>0x1</code>
       <code>0x1</code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>bitwiseXorProvider</code>
+      <code>constructDataProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/BusinessIdentifierCodeTest.php">
+    <PossiblyUnusedMethod>
+      <code>notAStringProvider</code>
+      <code>notBicFormatProvider</code>
+      <code>notSwiftCountryCodeProvider</code>
+      <code>successProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/CallbackTest.php">
     <MissingClosureParamType>
@@ -2778,6 +2800,15 @@
     <InvalidCast>
       <code><![CDATA[['something']]]></code>
     </InvalidCast>
+    <PossiblyUnusedMethod>
+      <code>basicValues</code>
+      <code>jcbValues</code>
+      <code>mastercardValues</code>
+      <code>mirValues</code>
+      <code>optionsValues</code>
+      <code>serviceValues</code>
+      <code>visaValues</code>
+    </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
       <code>false</code>
     </PossiblyUnusedReturnValue>
@@ -2801,13 +2832,30 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
+    <PossiblyUnusedMethod>
+      <code>fakeValuesDataProvider</code>
+      <code>timeoutValuesDataProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/DateStepTest.php">
+    <PossiblyUnusedMethod>
+      <code>moscowWinterTimeDataProvider</code>
+      <code>stepTestsDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/DateTest.php">
+    <PossiblyUnusedMethod>
+      <code>datesDataProvider</code>
+    </PossiblyUnusedMethod>
     <UnusedParam>
       <code>$result</code>
     </UnusedParam>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
+    <DeprecatedMethod>
+      <code>addMethods</code>
+      <code>addMethods</code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA['users']]></code>
       <code><![CDATA['users']]></code>
@@ -2823,6 +2871,10 @@
     </MissingTemplateParam>
   </file>
   <file src="test/Db/RecordExistsTest.php">
+    <DeprecatedMethod>
+      <code>addMethods</code>
+      <code>addMethods</code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA['users']]></code>
       <code><![CDATA['users']]></code>
@@ -2852,6 +2904,9 @@
     <InvalidCast>
       <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/EmailAddressTest.php">
     <InvalidArgument>
@@ -2871,7 +2926,10 @@
       <code>null</code>
     </NullArgument>
     <PossiblyUnusedMethod>
+      <code>emailAddressesForMxChecks</code>
       <code>errorHandler</code>
+      <code>invalidEmailAddresses</code>
+      <code>validEmailAddresses</code>
     </PossiblyUnusedMethod>
     <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
@@ -2892,17 +2950,27 @@
       <code>$c</code>
       <code>$v</code>
     </MissingClosureParamType>
+    <PossiblyUnusedMethod>
+      <code>getExpectedData</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/CountTest.php">
     <MixedArgument>
       <code>$max</code>
       <code>$min</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+      <code>invalidMinMaxValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/Crc32Test.php">
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExcludeExtensionTest.php">
     <InvalidReturnStatement>
@@ -2925,11 +2993,21 @@
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getExtensionProvider</code>
+      <code>setExtensionProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExcludeMimeTypeTest.php">
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getMimeTypeProvider</code>
+      <code>setMimeTypeProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExistsTest.php">
     <ArgumentTypeCoercion>
@@ -2941,6 +3019,12 @@
     <PossiblyNullArgument>
       <code>$value</code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getDirectoryProvider</code>
+      <code>invalidDirectoryArguments</code>
+      <code>setDirectoryProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExtensionTest.php">
     <InvalidReturnStatement>
@@ -2963,11 +3047,19 @@
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getExtensionProvider</code>
+      <code>setExtensionProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/FilesSizeTest.php">
     <MixedArgument>
       <code>$options</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+    </PossiblyUnusedMethod>
     <PossiblyUnusedProperty>
       <code>$multipleOptionsDetected</code>
     </PossiblyUnusedProperty>
@@ -2983,6 +3075,11 @@
     <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>hashProvider</code>
+      <code>invalidHashTypes</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ImageSizeTest.php">
     <InvalidArgument>
@@ -2991,6 +3088,10 @@
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>imageMaxProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/IsCompressedTest.php">
     <PossiblyInvalidArgument>
@@ -3000,6 +3101,11 @@
       <code>$options</code>
       <code>$options</code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getMimeTypeProvider</code>
+      <code>setMimeTypeProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/IsImageTest.php">
     <PossiblyInvalidArgument>
@@ -3009,6 +3115,11 @@
       <code>$options</code>
       <code>$options</code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getMimeTypeProvider</code>
+      <code>setMimeTypeProvider</code>
+    </PossiblyUnusedMethod>
     <RedundantCondition>
       <code>is_array($isValidParam)</code>
     </RedundantCondition>
@@ -3017,6 +3128,9 @@
     <MixedArgument>
       <code><![CDATA[$isValidParam['tmp_name']]]></code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/MimeTypeTest.php">
     <ArgumentTypeCoercion>
@@ -3040,6 +3154,12 @@
     <PossiblyNullArgument>
       <code>$type</code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getMimeTypeProvider</code>
+      <code>invalidMimeTypeTypes</code>
+      <code>setMimeTypeProvider</code>
+    </PossiblyUnusedMethod>
     <RedundantConditionGivenDocblockType>
       <code>is_array($isValidParam)</code>
     </RedundantConditionGivenDocblockType>
@@ -3054,6 +3174,12 @@
     <PossiblyNullArgument>
       <code>$value</code>
     </PossiblyNullArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getDirectoryProvider</code>
+      <code>invalidDirectoryArguments</code>
+      <code>setDirectoryProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/Sha1Test.php">
     <MixedArgument>
@@ -3062,6 +3188,10 @@
     <MixedArgumentTypeCoercion>
       <code>$isValidParam</code>
     </MixedArgumentTypeCoercion>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>getHashProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/SizeTest.php">
     <MixedArgument>
@@ -3069,11 +3199,24 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>invalidMinMaxValues</code>
+      <code>setMaxProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/File/UploadFileTest.php">
+    <PossiblyUnusedMethod>
+      <code>uploadErrorsTestDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/UploadTest.php">
     <NullArgument>
       <code>null</code>
     </NullArgument>
+    <PossiblyUnusedMethod>
+      <code>invalidPsr7UploadedFiles</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/WordCountTest.php">
     <MixedArgument>
@@ -3081,6 +3224,17 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicBehaviorDataProvider</code>
+      <code>invalidMinMaxValues</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/GPSPointTest.php">
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+      <code>boundariesProvider</code>
+      <code>errorMessageTestValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/GreaterThanTest.php">
     <InvalidArgument>
@@ -3095,9 +3249,11 @@
     <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <PossiblyInvalidArgument>
-      <code>testBasic</code>
-    </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+      <code>correctInclusiveMessageDataProvider</code>
+      <code>correctNotInclusiveMessageDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/HexTest.php">
     <InvalidArgument>
@@ -3109,6 +3265,9 @@
     <PossiblyInvalidArgument>
       <code>$input</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/HostnameTest.php">
     <InvalidArgument>
@@ -3140,11 +3299,53 @@
       <code>$code</code>
       <code>$message</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+      <code>combinationDataProvider</code>
+      <code>dashesDataProvider</code>
+      <code>differentIconvEncodingDataProvider</code>
+      <code>domainsWithUnderscores</code>
+      <code>idnMatchingDataProvider</code>
+      <code>idnNoMatchingDataProvider</code>
+      <code>idnilDataProvider</code>
+      <code>idnsiProvider</code>
+      <code>invalidLatinSpecialCharsProvider</code>
+      <code>invalidTLDHostnames</code>
+      <code>numberNamesDataProvider</code>
+      <code>punyCodeDecodingDataProvider</code>
+      <code>tldMatchingDataProvider</code>
+      <code>tldNoMatchingDataProvider</code>
+      <code>trailingDotDataProvider</code>
+      <code>uriDataProvider</code>
+      <code>validTLDHostnames</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/IbanTest.php">
+    <PossiblyUnusedMethod>
+      <code>ibanDataProvider</code>
+      <code>invalidValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/IdenticalTest.php">
     <MixedArgument>
       <code>$context</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>invalidContextProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/InArrayTest.php">
+    <PossiblyUnusedMethod>
+      <code>nonStrictValidationSet</code>
+      <code>strictValidationSet</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/IpTest.php">
+    <PossiblyUnusedMethod>
+      <code>iPvFutureAddressesProvider</code>
+      <code>invalidIpV4Addresses</code>
+      <code>ipvFutureProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/IsCountableTest.php">
     <InvalidArgument>
@@ -3154,6 +3355,10 @@
       <code>$options</code>
       <code>$originalOptions</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>conflictingOptionsProvider</code>
+      <code>conflictingSecondaryOptionsProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/IsInstanceOfTest.php">
     <InvalidArgument>
@@ -3166,6 +3371,14 @@
       <code>TestCase::class</code>
     </InvalidArgument>
   </file>
+  <file src="test/IsJsonStringTest.php">
+    <PossiblyUnusedMethod>
+      <code>allowProvider</code>
+      <code>invalidStringProvider</code>
+      <code>pluginManagerNameProvider</code>
+      <code>provideThingsThatAreNotStrings</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/IsbnTest.php">
     <InvalidArgument>
       <code>(float) 1.2345</code>
@@ -3174,6 +3387,9 @@
     <InvalidCast>
       <code><![CDATA[(object) 'Test']]></code>
     </InvalidCast>
+    <PossiblyUnusedMethod>
+      <code>basicProvider</code>
+    </PossiblyUnusedMethod>
     <RedundantCast>
       <code>(float) 1.2345</code>
     </RedundantCast>
@@ -3190,9 +3406,9 @@
     <MixedArgument>
       <code>$options</code>
     </MixedArgument>
-    <PossiblyInvalidArgument>
-      <code>testBasic</code>
-    </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/MessageTest.php">
     <InaccessibleProperty>
@@ -3214,6 +3430,28 @@
       <code><![CDATA['boolean']]></code>
       <code>true</code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>arrayConfigNotationProvider</code>
+      <code>arrayConfigNotationWithoutKeyProvider</code>
+      <code>arrayConstantNotationProvider</code>
+      <code>arrayOnlyProvider</code>
+      <code>basicProvider</code>
+      <code>booleanProvider</code>
+      <code>configObjectProvider</code>
+      <code>constructorWithTypeArrayProvider</code>
+      <code>duplicateStringSettingProvider</code>
+      <code>floatOnlyProvider</code>
+      <code>integerOnlyProvider</code>
+      <code>multiConstantNotationProvider</code>
+      <code>nullOnlyProvider</code>
+      <code>onlyAllProvider</code>
+      <code>phpOnlyProvider</code>
+      <code>singleStringNotationProvider</code>
+      <code>spaceOnlyProvider</code>
+      <code>stringNotationProvider</code>
+      <code>stringOnlyProvider</code>
+      <code>zeroOnlyProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/RegexTest.php">
     <InvalidArgument>
@@ -3226,6 +3464,11 @@
       <code>$options</code>
       <code>$options</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+      <code>invalidConstructorArgumentsProvider</code>
+      <code>specialCharValidationProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Sitemap/ChangefreqTest.php">
     <InvalidArgument>
@@ -3250,6 +3493,9 @@
     <PossiblyInvalidCast>
       <code>$value</code>
     </PossiblyInvalidCast>
+    <PossiblyUnusedMethod>
+      <code>invalidLocs</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Sitemap/PriorityTest.php">
     <PossiblyInvalidArgument>
@@ -3268,11 +3514,22 @@
     <NullArgument>
       <code>null</code>
     </NullArgument>
+    <PossiblyUnusedMethod>
+      <code>invalidParameterizedData</code>
+      <code>parameterizedData</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/StepTest.php">
     <InvalidArgument>
       <code>$baseValue</code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>decimalHundredthStepValues</code>
+      <code>decimalStepSubstractionBugValues</code>
+      <code>decimalStepValues</code>
+      <code>decimalValues</code>
+      <code>valuesToValidate</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/StringLengthTest.php">
     <InvalidArgument>
@@ -3284,6 +3541,9 @@
     <MixedArgument>
       <code>$options</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>basicDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/TimezoneTest.php">
     <InvalidArgument>
@@ -3295,6 +3555,19 @@
     <MixedArgument>
       <code>$value</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>abbreviationProvider</code>
+      <code>getInvalidTypes</code>
+      <code>locationAndAbbreviationProvider</code>
+      <code>locationProvider</code>
+      <code>wrongTypesProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/UndisclosedPasswordTest.php">
+    <PossiblyUnusedMethod>
+      <code>goodPasswordProvider</code>
+      <code>seenPasswordProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/UriTest.php">
     <InvalidArgument>
@@ -3306,6 +3579,16 @@
     <MixedArgument>
       <code>$value</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>allowOptionsDataProvider</code>
+      <code>invalidValueTypes</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/UuidTest.php">
+    <PossiblyUnusedMethod>
+      <code>invalidUuidProvider</code>
+      <code>validUuidProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/ValidatorChainTest.php">
     <InvalidArgument>
@@ -3316,6 +3599,7 @@
       <code>$value</code>
     </MissingClosureParamType>
     <PossiblyUnusedMethod>
+      <code>breakChainFlags</code>
       <code>handleNotFoundError</code>
     </PossiblyUnusedMethod>
     <UndefinedThisPropertyAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -47,6 +47,9 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$this->abstractOptions]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyUnusedParam>
+      <code>$messageKey</code>
+    </PossiblyUnusedParam>
     <UndefinedThisPropertyAssignment>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
@@ -117,6 +120,9 @@
     <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>getChecksum</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Barcode/AbstractAdapter.php">
     <DocblockTypeContradiction>
@@ -159,6 +165,12 @@
     <PossiblyInvalidCast>
       <code>$characters</code>
     </PossiblyInvalidCast>
+    <PossiblyUnusedMethod>
+      <code>code25</code>
+      <code>gtin</code>
+      <code>identcode</code>
+      <code>postnet</code>
+    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code>(bool) $check</code>
     </RedundantCastGivenDocblockType>
@@ -171,6 +183,9 @@
     <PossiblyInvalidArgument>
       <code>$chars</code>
     </PossiblyInvalidArgument>
+    <UnusedClass>
+      <code>Codabar</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Code128.php">
     <DocblockTypeContradiction>
@@ -529,6 +544,9 @@
     <UndefinedFunction>
       <code><![CDATA['code128']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Code128</code>
+    </UnusedClass>
     <UnusedVariable>
       <code>$read</code>
       <code>$read</code>
@@ -549,6 +567,9 @@
     <UndefinedFunction>
       <code><![CDATA['code25']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Code25</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Code25interleaved.php">
     <InvalidArgument>
@@ -558,6 +579,9 @@
     <UndefinedFunction>
       <code><![CDATA['code25']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Code25interleaved</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Code39.php">
     <InvalidArgument>
@@ -574,6 +598,14 @@
     <UndefinedFunction>
       <code><![CDATA['code39']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Code39</code>
+    </UnusedClass>
+  </file>
+  <file src="src/Barcode/Code39ext.php">
+    <UnusedClass>
+      <code>Code39ext</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Code93.php">
     <InvalidArgument>
@@ -598,6 +630,14 @@
     <UndefinedFunction>
       <code><![CDATA['code93']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Code93</code>
+    </UnusedClass>
+  </file>
+  <file src="src/Barcode/Code93ext.php">
+    <UnusedClass>
+      <code>Code93ext</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean12.php">
     <InvalidArgument>
@@ -606,11 +646,17 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Ean12</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean13.php">
     <InvalidArgument>
       <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+    </PossiblyUnusedMethod>
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
@@ -622,6 +668,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Ean14</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean18.php">
     <InvalidArgument>
@@ -630,16 +679,25 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Ean18</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean2.php">
     <InvalidArgument>
       <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
+    <UnusedClass>
+      <code>Ean2</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean5.php">
     <InvalidArgument>
       <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
+    <UnusedClass>
+      <code>Ean5</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Ean8.php">
     <InvalidArgument>
@@ -648,6 +706,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Ean8</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Gtin12.php">
     <InvalidArgument>
@@ -656,6 +717,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Gtin12</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Gtin13.php">
     <InvalidArgument>
@@ -664,6 +728,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Gtin13</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Gtin14.php">
     <InvalidArgument>
@@ -672,6 +739,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Gtin14</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Identcode.php">
     <InvalidArgument>
@@ -680,11 +750,17 @@
     <UndefinedFunction>
       <code><![CDATA['identcode']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Identcode</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Intelligentmail.php">
     <InvalidArgument>
       <code><![CDATA['0123456789']]></code>
     </InvalidArgument>
+    <UnusedClass>
+      <code>Intelligentmail</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Issn.php">
     <InvalidArgument>
@@ -698,6 +774,9 @@
       <code><![CDATA['gtin']]></code>
       <code><![CDATA['issn']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Issn</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Itf14.php">
     <InvalidArgument>
@@ -706,6 +785,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Itf14</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Leitcode.php">
     <InvalidArgument>
@@ -714,6 +796,9 @@
     <UndefinedFunction>
       <code><![CDATA['identcode']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Leitcode</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Planet.php">
     <InvalidArgument>
@@ -722,6 +807,9 @@
     <UndefinedFunction>
       <code><![CDATA['postnet']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Planet</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Postnet.php">
     <InvalidArgument>
@@ -730,6 +818,9 @@
     <UndefinedFunction>
       <code><![CDATA['postnet']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Postnet</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Royalmail.php">
     <InvalidArgument>
@@ -738,6 +829,9 @@
     <UndefinedFunction>
       <code><![CDATA['royalmail']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Royalmail</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Sscc.php">
     <InvalidArgument>
@@ -746,6 +840,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Sscc</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Upca.php">
     <InvalidArgument>
@@ -754,6 +851,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Upca</code>
+    </UnusedClass>
   </file>
   <file src="src/Barcode/Upce.php">
     <InvalidArgument>
@@ -762,6 +862,9 @@
     <UndefinedFunction>
       <code><![CDATA['gtin']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>Upce</code>
+    </UnusedClass>
   </file>
   <file src="src/Between.php">
     <MixedInferredReturnType>
@@ -770,6 +873,11 @@
     <MixedReturnStatement>
       <code><![CDATA[$this->options['inclusive']]]></code>
     </MixedReturnStatement>
+    <PossiblyUnusedMethod>
+      <code>setInclusive</code>
+      <code>setMax</code>
+      <code>setMin</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Bitwise.php">
     <DocblockTypeContradiction>
@@ -872,6 +980,9 @@
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedReturnValue>
+      <code>CreditCard</code>
+    </PossiblyUnusedReturnValue>
     <UndefinedAttributeClass>
       <code>SensitiveParameter</code>
     </UndefinedAttributeClass>
@@ -954,6 +1065,9 @@
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
+    <PossiblyUnusedMethod>
+      <code>setStep</code>
+    </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code>$step</code>
       <code>$timezone</code>
@@ -1027,6 +1141,12 @@
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code>getExclude</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedReturnValue>
+      <code>self</code>
+    </PossiblyUnusedReturnValue>
     <PropertyNotSetInConstructor>
       <code>$schema</code>
       <code>AbstractDb</code>
@@ -1128,6 +1248,11 @@
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code>idnToUtf8</code>
+      <code>setAllow</code>
+      <code>useDeepMxCheck</code>
+    </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code>$hostname</code>
       <code>$localPart</code>
@@ -1145,6 +1270,16 @@
       <code><![CDATA[false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="src/Exception/BadMethodCallException.php">
+    <UnusedClass>
+      <code>BadMethodCallException</code>
+    </UnusedClass>
+  </file>
+  <file src="src/Exception/ExtensionNotLoadedException.php">
+    <UnusedClass>
+      <code>ExtensionNotLoadedException</code>
+    </UnusedClass>
+  </file>
   <file src="src/Explode.php">
     <DocblockTypeContradiction>
       <code>[$value]</code>
@@ -1155,6 +1290,10 @@
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code>setBreakOnFirstFailure</code>
+      <code>setValueDelimiter</code>
+    </PossiblyUnusedMethod>
     <PropertyTypeCoercion>
       <code><![CDATA[$this->abstractOptions]]></code>
     </PropertyTypeCoercion>
@@ -1377,6 +1516,10 @@
     <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>setAllowNonExistentFile</code>
+      <code>setCase</code>
+    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code>(bool) $case</code>
       <code>(bool) $flag</code>
@@ -1470,6 +1613,9 @@
       <code>$file</code>
       <code>$file</code>
     </PossiblyInvalidCast>
+    <PossiblyUnusedReturnValue>
+      <code>false</code>
+    </PossiblyUnusedReturnValue>
     <PropertyNotSetInConstructor>
       <code>FilesSize</code>
     </PropertyNotSetInConstructor>
@@ -1552,6 +1698,12 @@
       <code>$options</code>
       <code>$options</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>setMaxHeight</code>
+      <code>setMaxWidth</code>
+      <code>setMinHeight</code>
+      <code>setMinWidth</code>
+    </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code>$height</code>
       <code>$width</code>
@@ -2012,6 +2164,10 @@
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code>setAllow</code>
+      <code>setIpValidator</code>
+    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code>(bool) $useIdnCheck</code>
       <code>(bool) $useTldCheck</code>
@@ -2109,6 +2265,14 @@
     <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
+    <PossiblyUnusedReturnValue>
+      <code>$this</code>
+    </PossiblyUnusedReturnValue>
+    <UnusedMethod>
+      <code>setCount</code>
+      <code>setMax</code>
+      <code>setMin</code>
+    </UnusedMethod>
   </file>
   <file src="src/IsInstanceOf.php">
     <MixedAssignment>
@@ -2117,6 +2281,9 @@
     <PossiblyInvalidArgument>
       <code>$options</code>
     </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>setClassName</code>
+    </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code>$className</code>
     </PropertyNotSetInConstructor>
@@ -2166,9 +2333,15 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Module.php">
+    <PossiblyUnusedParam>
+      <code>$moduleManager</code>
+    </PossiblyUnusedParam>
     <UndefinedDocblockClass>
       <code>ModuleManager</code>
     </UndefinedDocblockClass>
+    <UnusedClass>
+      <code>Module</code>
+    </UnusedClass>
   </file>
   <file src="src/NotEmpty.php">
     <MixedAssignment>
@@ -2319,6 +2492,9 @@
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code>setStringWrapper</code>
+    </PossiblyUnusedMethod>
     <RedundantCastGivenDocblockType>
       <code>(int) $length</code>
       <code>(int) $max</code>
@@ -2364,6 +2540,12 @@
     <RedundantConditionGivenDocblockType>
       <code>gettype($type)</code>
     </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Translator/TranslatorAwareInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code>TranslatorAwareInterface</code>
+      <code>self</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/UndisclosedPassword.php">
     <UndefinedAttributeClass>
@@ -2447,6 +2629,11 @@
     <MixedPropertyTypeCoercion>
       <code>new PriorityQueue()</code>
     </MixedPropertyTypeCoercion>
+    <PossiblyUnusedMethod>
+      <code>addByName</code>
+      <code>addValidator</code>
+      <code>count</code>
+    </PossiblyUnusedMethod>
     <TooManyArguments>
       <code>isValid</code>
     </TooManyArguments>
@@ -2473,6 +2660,12 @@
     <NonInvariantDocblockPropertyType>
       <code>$instanceOf</code>
     </NonInvariantDocblockPropertyType>
+    <PossiblyUnusedMethod>
+      <code>validatePlugin</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code>$shareByDefault</code>
+    </PossiblyUnusedProperty>
     <RedundantCondition>
       <code><![CDATA[$container === $this && method_exists($container, 'getServiceLocator')]]></code>
     </RedundantCondition>
@@ -2500,12 +2693,14 @@
       <code>$container</code>
     </ParamNameMismatch>
   </file>
+  <file src="src/ValidatorProviderInterface.php">
+    <UnusedClass>
+      <code>ValidatorProviderInterface</code>
+    </UnusedClass>
+  </file>
   <file src="test/AbstractValidatorTest.php">
     <InvalidArgument>
       <code>$options</code>
-      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
-      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
-      <code><![CDATA[[$this, 'errorHandlerIgnore']]]></code>
     </InvalidArgument>
     <MixedArgument>
       <code>$message</code>
@@ -2571,6 +2766,9 @@
     <MixedAssignment>
       <code>$options</code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code>optionsCallback</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/CreditCardTest.php">
     <InvalidArgument>
@@ -2580,6 +2778,9 @@
     <InvalidCast>
       <code><![CDATA[['something']]]></code>
     </InvalidCast>
+    <PossiblyUnusedReturnValue>
+      <code>false</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="test/CsrfTest.php">
     <InvalidArgument>
@@ -2600,6 +2801,11 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$_SERVER['REQUEST_TIME']]]></code>
     </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="test/DateTest.php">
+    <UnusedParam>
+      <code>$result</code>
+    </UnusedParam>
   </file>
   <file src="test/Db/NoRecordExistsTest.php">
     <InvalidArgument>
@@ -2664,9 +2870,19 @@
     <NullArgument>
       <code>null</code>
     </NullArgument>
+    <PossiblyUnusedMethod>
+      <code>errorHandler</code>
+    </PossiblyUnusedMethod>
     <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
+    <UnusedParam>
+      <code>$errno</code>
+      <code>$errstr</code>
+    </UnusedParam>
+    <UnusedPsalmSuppress>
+      <code>TooManyArguments</code>
+    </UnusedPsalmSuppress>
   </file>
   <file src="test/ExplodeTest.php">
     <InvalidArgument>
@@ -2752,6 +2968,9 @@
     <MixedArgument>
       <code>$options</code>
     </MixedArgument>
+    <PossiblyUnusedProperty>
+      <code>$multipleOptionsDetected</code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="test/File/HashTest.php">
     <MixedArgument>
@@ -2921,14 +3140,6 @@
       <code>$code</code>
       <code>$message</code>
     </PossiblyUndefinedVariable>
-  </file>
-  <file src="test/IbanTest.php">
-    <InvalidArgument>
-      <code>[]</code>
-    </InvalidArgument>
-    <InvalidCast>
-      <code>[]</code>
-    </InvalidCast>
   </file>
   <file src="test/IdenticalTest.php">
     <MixedArgument>
@@ -3104,6 +3315,9 @@
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
+    <PossiblyUnusedMethod>
+      <code>handleNotFoundError</code>
+    </PossiblyUnusedMethod>
     <UndefinedThisPropertyAssignment>
       <code><![CDATA[$this->error]]></code>
     </UndefinedThisPropertyAssignment>
@@ -3111,21 +3325,33 @@
       <code>$value</code>
       <code>$value</code>
     </UnusedClosureParam>
+    <UnusedParam>
+      <code>$errnum</code>
+    </UnusedParam>
   </file>
   <file src="test/_files/MyBarcode1.php">
     <UndefinedFunction>
       <code><![CDATA['invalid']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>MyBarcode1</code>
+    </UnusedClass>
   </file>
   <file src="test/_files/MyBarcode2.php">
     <UndefinedFunction>
       <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>MyBarcode2</code>
+    </UnusedClass>
   </file>
   <file src="test/_files/MyBarcode3.php">
     <UndefinedFunction>
       <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>MyBarcode3</code>
+    </UnusedClass>
   </file>
   <file src="test/_files/MyBarcode4.php">
     <InvalidArgument>
@@ -3134,5 +3360,13 @@
     <UndefinedFunction>
       <code><![CDATA['_mod10']]></code>
     </UndefinedFunction>
+    <UnusedClass>
+      <code>MyBarcode4</code>
+    </UnusedClass>
+  </file>
+  <file src="test/_files/MyBarcode5.php">
+    <UnusedClass>
+      <code>MyBarcode5</code>
+    </UnusedClass>
   </file>
 </files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,7 +3,12 @@
     errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="psalm-baseline.xml">
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+    findUnusedPsalmSuppress="true"
+    findUnusedCode="true"
+    findUnusedBaselineEntry="true"
+>
     <projectFiles>
         <directory name="bin"/>
         <directory name="src"/>
@@ -13,20 +18,6 @@
 			<directory name="test/TestAsset"/>
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
-            </errorLevel>
-        </InternalMethod>
-    </issueHandlers>
 
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/Barcode/Royalmail.php
+++ b/src/Barcode/Royalmail.php
@@ -11,7 +11,7 @@ use function substr;
 
 class Royalmail extends AbstractAdapter
 {
-    /** @var array<string, int> */
+    /** @var array<array-key, int> */
     protected $rows = [
         '0' => 1,
         '1' => 1,
@@ -51,7 +51,7 @@ class Royalmail extends AbstractAdapter
         'Z' => 0,
     ];
 
-    /** @var array<string, int> */
+    /** @var array<array-key, int> */
     protected $columns = [
         '0' => 1,
         '1' => 2,

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\File;
 
+use finfo;
 use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\ErrorHandler;
 use Laminas\Validator\AbstractValidator;
@@ -65,7 +66,7 @@ class MimeType extends AbstractValidator
     /**
      * Finfo object to use
      *
-     * @var resource
+     * @var finfo|null
      */
     protected $finfo;
 

--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -39,6 +39,13 @@ use function substr;
  *
  * The second is tests/Laminas/Validator/HostnameTestForm.php which is designed to be run via HTML
  * to allow users to test entering UTF-8 characters in a form.
+ *
+ * @psalm-type Options = array{
+ *    allow?: int-mask-of<self::ALLOW_*>,
+ *    useIdnCheck?: bool,
+ *    useTldCheck?: bool,
+ *    ipValidator?: null|ValidatorInterface,
+ * }
  */
 class Hostname extends AbstractValidator
 {
@@ -1808,7 +1815,7 @@ class Hostname extends AbstractValidator
     /**
      * Options for the hostname validator
      *
-     * @var array
+     * @var Options
      */
     protected $options = [
         'allow'       => self::ALLOW_DNS, // Allow these hostnames
@@ -1824,15 +1831,20 @@ class Hostname extends AbstractValidator
      *
      * @see http://www.iana.org/cctld/specifications-policies-cctlds-01apr02.htm  Technical Specifications for ccTLDs
      *
-     * @param array $options    OPTIONAL Array of validator options; see Hostname::$options
-     * @param int  $allow       OPTIONAL Set what types of hostname to allow (default ALLOW_DNS)
-     * @param bool $useIdnCheck OPTIONAL Set whether IDN domains are validated (default true)
-     * @param bool $useTldCheck Set whether the TLD element of a hostname is validated (default true)
-     * @param Ip   $ipValidator OPTIONAL
+     * Options Parameters should be passed as an array in the following format:
+     * $options = [
+     *      'allow' => ALLOW_DNS, // OPTIONAL Set what types of hostname to allow (default ALLOW_DNS)
+     *      'useIdnCheck' => true, // OPTIONAL Set whether IDN domains are validated (default true)
+     *      'useTldCheck' => true, // Set whether the TLD element of a hostname is validated (default true)
+     *      'ipValidator' => null, // An IP validator instance or null @link Ip
+     * ];
+     *
+     * For backwards compatibility, options can also be passed as variables in the order stated above.
+     *
+     * @param Options $options OPTIONAL Array of validator options; see Hostname::$options
      */
     public function __construct($options = [])
     {
-        // phpcs:enable
         if (! is_array($options)) {
             $options       = func_get_args();
             $temp['allow'] = array_shift($options);

--- a/src/StaticValidator.php
+++ b/src/StaticValidator.php
@@ -62,9 +62,7 @@ class StaticValidator
             );
         }
 
-        $plugins = static::getPluginManager();
-
-        /** @var ValidatorInterface $validator */
+        $plugins   = static::getPluginManager();
         $validator = $plugins->get($classBaseName, $options);
 
         return $validator->isValid($value);

--- a/src/StaticValidator.php
+++ b/src/StaticValidator.php
@@ -64,7 +64,9 @@ class StaticValidator
 
         $plugins = static::getPluginManager();
 
+        /** @var ValidatorInterface $validator */
         $validator = $plugins->get($classBaseName, $options);
+
         return $validator->isValid($value);
     }
 }

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -50,7 +50,6 @@ class ValidatorChain implements Countable, IteratorAggregate, ValidatorInterface
      */
     public function __construct()
     {
-        /** @psalm-suppress InvalidPropertyAssignmentValue */
         $this->validators = new PriorityQueue();
     }
 

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -28,7 +28,7 @@ class ValidatorChain implements Countable, IteratorAggregate, ValidatorInterface
      */
     public const DEFAULT_PRIORITY = 1;
 
-    /** @var ValidatorPluginManager<ValidatorInterface>|null */
+    /** @var ValidatorPluginManager|null */
     protected $plugins;
 
     /**
@@ -67,7 +67,7 @@ class ValidatorChain implements Countable, IteratorAggregate, ValidatorInterface
     /**
      * Get plugin manager instance
      *
-     * @return ValidatorPluginManager<ValidatorInterface>
+     * @return ValidatorPluginManager
      */
     public function getPluginManager()
     {

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -4,7 +4,6 @@ namespace Laminas\Validator;
 
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
@@ -47,12 +46,8 @@ use function method_exists;
 use function sprintf;
 
 /**
- * @link ConfigInterface
- * @link ServiceManager
- *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @template InstanceType of ValidatorInterface
- * @extends AbstractPluginManager<InstanceType>
+ * @extends AbstractPluginManager<ValidatorInterface>
  */
 class ValidatorPluginManager extends AbstractPluginManager
 {
@@ -544,7 +539,7 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Default instance type
      *
-     * @var string
+     * @inheritDoc
      */
     protected $instanceOf = ValidatorInterface::class;
 
@@ -567,12 +562,8 @@ class ValidatorPluginManager extends AbstractPluginManager
     }
 
     /**
-     * Validate plugin instance
-     *
-     * {@inheritDoc}
-     *
      * @param mixed $instance
-     * @psalm-assert InstanceType $instance
+     * @psalm-assert ValidatorInterface $instance
      */
     public function validate($instance)
     {
@@ -580,7 +571,7 @@ class ValidatorPluginManager extends AbstractPluginManager
             throw new InvalidServiceException(sprintf(
                 '%s expects only to create instances of %s; %s is invalid',
                 static::class,
-                $this->instanceOf,
+                (string) $this->instanceOf,
                 get_debug_type($instance)
             ));
         }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -8,38 +8,6 @@ use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
-use Zend\I18n\Validator\Alnum;
-use Zend\I18n\Validator\Alpha;
-use Zend\I18n\Validator\DateTime;
-use Zend\I18n\Validator\IsFloat;
-use Zend\I18n\Validator\IsInt;
-use Zend\I18n\Validator\PhoneNumber;
-use Zend\I18n\Validator\PostCode;
-use Zend\Validator\Db\NoRecordExists;
-use Zend\Validator\Db\RecordExists;
-use Zend\Validator\File\Count;
-use Zend\Validator\File\Crc32;
-use Zend\Validator\File\ExcludeExtension;
-use Zend\Validator\File\ExcludeMimeType;
-use Zend\Validator\File\Exists;
-use Zend\Validator\File\Extension;
-use Zend\Validator\File\FilesSize;
-use Zend\Validator\File\Hash;
-use Zend\Validator\File\ImageSize;
-use Zend\Validator\File\IsCompressed;
-use Zend\Validator\File\IsImage;
-use Zend\Validator\File\Md5;
-use Zend\Validator\File\MimeType;
-use Zend\Validator\File\NotExists;
-use Zend\Validator\File\Sha1;
-use Zend\Validator\File\Size;
-use Zend\Validator\File\Upload;
-use Zend\Validator\File\UploadFile;
-use Zend\Validator\File\WordCount;
-use Zend\Validator\Sitemap\Changefreq;
-use Zend\Validator\Sitemap\Lastmod;
-use Zend\Validator\Sitemap\Loc;
-use Zend\Validator\Sitemap\Priority;
 
 use function get_debug_type;
 use function method_exists;
@@ -55,7 +23,6 @@ class ValidatorPluginManager extends AbstractPluginManager
      * Default set of aliases
      *
      * @inheritDoc
-     * @psalm-suppress UndefinedClass
      */
     protected $aliases = [
         'alnum'                  => I18nValidator\Alnum::class,
@@ -233,67 +200,67 @@ class ValidatorPluginManager extends AbstractPluginManager
         'Uuid'                   => Uuid::class,
 
         // Legacy Zend Framework aliases
-        Alnum::class                        => I18nValidator\Alnum::class,
-        Alpha::class                        => I18nValidator\Alpha::class,
-        \Zend\Validator\Barcode::class      => Barcode::class,
-        \Zend\Validator\Between::class      => Between::class,
-        \Zend\Validator\Bitwise::class      => Bitwise::class,
-        \Zend\Validator\Callback::class     => Callback::class,
-        \Zend\Validator\CreditCard::class   => CreditCard::class,
-        \Zend\Validator\Csrf::class         => Csrf::class,
-        \Zend\Validator\DateStep::class     => DateStep::class,
-        \Zend\Validator\Date::class         => Date::class,
-        DateTime::class                     => I18nValidator\DateTime::class,
-        NoRecordExists::class               => Db\NoRecordExists::class,
-        RecordExists::class                 => Db\RecordExists::class,
-        \Zend\Validator\Digits::class       => Digits::class,
-        \Zend\Validator\EmailAddress::class => EmailAddress::class,
-        \Zend\Validator\Explode::class      => Explode::class,
-        Count::class                        => File\Count::class,
-        Crc32::class                        => File\Crc32::class,
-        ExcludeExtension::class             => File\ExcludeExtension::class,
-        ExcludeMimeType::class              => File\ExcludeMimeType::class,
-        Exists::class                       => File\Exists::class,
-        Extension::class                    => File\Extension::class,
-        FilesSize::class                    => File\FilesSize::class,
-        Hash::class                         => File\Hash::class,
-        ImageSize::class                    => File\ImageSize::class,
-        IsCompressed::class                 => File\IsCompressed::class,
-        IsImage::class                      => File\IsImage::class,
-        Md5::class                          => File\Md5::class,
-        MimeType::class                     => File\MimeType::class,
-        NotExists::class                    => File\NotExists::class,
-        Sha1::class                         => File\Sha1::class,
-        Size::class                         => File\Size::class,
-        Upload::class                       => File\Upload::class,
-        UploadFile::class                   => File\UploadFile::class,
-        WordCount::class                    => File\WordCount::class,
-        IsFloat::class                      => I18nValidator\IsFloat::class,
-        \Zend\Validator\GpsPoint::class     => GpsPoint::class,
-        \Zend\Validator\GreaterThan::class  => GreaterThan::class,
-        \Zend\Validator\Hex::class          => Hex::class,
-        \Zend\Validator\Hostname::class     => Hostname::class,
-        \Zend\Validator\Iban::class         => Iban::class,
-        \Zend\Validator\Identical::class    => Identical::class,
-        \Zend\Validator\InArray::class      => InArray::class,
-        IsInt::class                        => I18nValidator\IsInt::class,
-        \Zend\Validator\Ip::class           => Ip::class,
-        \Zend\Validator\Isbn::class         => Isbn::class,
-        \Zend\Validator\IsInstanceOf::class => IsInstanceOf::class,
-        \Zend\Validator\LessThan::class     => LessThan::class,
-        \Zend\Validator\NotEmpty::class     => NotEmpty::class,
-        PhoneNumber::class                  => I18nValidator\PhoneNumber::class,
-        PostCode::class                     => I18nValidator\PostCode::class,
-        \Zend\Validator\Regex::class        => Regex::class,
-        Changefreq::class                   => Sitemap\Changefreq::class,
-        Lastmod::class                      => Sitemap\Lastmod::class,
-        Loc::class                          => Sitemap\Loc::class,
-        Priority::class                     => Sitemap\Priority::class,
-        \Zend\Validator\StringLength::class => StringLength::class,
-        \Zend\Validator\Step::class         => Step::class,
-        \Zend\Validator\Timezone::class     => Timezone::class,
-        \Zend\Validator\Uri::class          => Uri::class,
-        \Zend\Validator\Uuid::class         => Uuid::class,
+        'Zend\I18nValidator\Alnum'             => I18nValidator\Alnum::class,
+        'Zend\I18n\Validator\Alpha'            => I18nValidator\Alpha::class,
+        'Zend\Validator\Barcode'               => Barcode::class,
+        'Zend\Validator\Between'               => Between::class,
+        'Zend\Validator\Bitwise'               => Bitwise::class,
+        'Zend\Validator\Callback'              => Callback::class,
+        'Zend\Validator\CreditCard'            => CreditCard::class,
+        'Zend\Validator\Csrf'                  => Csrf::class,
+        'Zend\Validator\DateStep'              => DateStep::class,
+        'Zend\Validator\Date'                  => Date::class,
+        'Zend\I18n\Validator\DateTime'         => I18nValidator\DateTime::class,
+        'Zend\Validator\Db\NoRecordExists'     => Db\NoRecordExists::class,
+        'Zend\Validator\Db\RecordExists'       => Db\RecordExists::class,
+        'Zend\Validator\Digits'                => Digits::class,
+        'Zend\Validator\EmailAddress'          => EmailAddress::class,
+        'Zend\Validator\Explode'               => Explode::class,
+        'Zend\Validator\File\Count'            => File\Count::class,
+        'Zend\Validator\File\Crc32'            => File\Crc32::class,
+        'Zend\Validator\File\ExcludeExtension' => File\ExcludeExtension::class,
+        'Zend\Validator\File\ExcludeMimeType'  => File\ExcludeMimeType::class,
+        'Zend\Validator\File\Exists'           => File\Exists::class,
+        'Zend\Validator\File\Extension'        => File\Extension::class,
+        'Zend\Validator\File\FilesSize'        => File\FilesSize::class,
+        'Zend\Validator\File\Hash'             => File\Hash::class,
+        'Zend\Validator\File\ImageSize'        => File\ImageSize::class,
+        'Zend\Validator\File\IsCompressed'     => File\IsCompressed::class,
+        'Zend\Validator\File\IsImage'          => File\IsImage::class,
+        'Zend\Validator\File\Md5'              => File\Md5::class,
+        'Zend\Validator\File\MimeType'         => File\MimeType::class,
+        'Zend\Validator\File\NotExists'        => File\NotExists::class,
+        'Zend\Validator\File\Sha1'             => File\Sha1::class,
+        'Zend\Validator\File\Size'             => File\Size::class,
+        'Zend\Validator\File\Upload'           => File\Upload::class,
+        'Zend\Validator\File\UploadFile'       => File\UploadFile::class,
+        'Zend\Validator\File\WordCount'        => File\WordCount::class,
+        'Zend\I18n\Validator\IsFloatIsFloat'   => I18nValidator\IsFloat::class,
+        'Zend\Validator\GpsPoint'              => GpsPoint::class,
+        'Zend\Validator\GreaterThan'           => GreaterThan::class,
+        'Zend\Validator\Hex'                   => Hex::class,
+        'Zend\Validator\Hostname'              => Hostname::class,
+        'Zend\Validator\Iban'                  => Iban::class,
+        'Zend\Validator\Identical'             => Identical::class,
+        'Zend\Validator\InArray'               => InArray::class,
+        'Zend\I18n\Validator\IsInt'            => I18nValidator\IsInt::class,
+        'Zend\Validator\Ip'                    => Ip::class,
+        'Zend\Validator\Isbn'                  => Isbn::class,
+        'Zend\Validator\IsInstanceOf'          => IsInstanceOf::class,
+        'Zend\Validator\LessThan'              => LessThan::class,
+        'Zend\Validator\NotEmpty'              => NotEmpty::class,
+        'Zend\I18n\Validator\PhoneNumber'      => I18nValidator\PhoneNumber::class,
+        'Zend\I18n\Validator\PostCode'         => I18nValidator\PostCode::class,
+        'Zend\Validator\Regex'                 => Regex::class,
+        'Zend\Validator\Sitemap\Changefreq'    => Sitemap\Changefreq::class,
+        'Zend\Validator\Sitemap\Lastmod'       => Sitemap\Lastmod::class,
+        'Zend\Validator\Sitemap\Loc'           => Sitemap\Loc::class,
+        'Zend\Validator\Sitemap\Priority'      => Sitemap\Priority::class,
+        'Zend\Validator\StringLength'          => StringLength::class,
+        'Zend\Validator\Step'                  => Step::class,
+        'Zend\Validator\Timezone'              => Timezone::class,
+        'Zend\Validator\Uri'                   => Uri::class,
+        'Zend\Validator\Uuid'                  => Uuid::class,
 
         // v2 normalized FQCNs
         'zendvalidatorbarcode'              => Barcode::class,

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -51,7 +51,6 @@ use function sprintf;
  * @link ServiceManager
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  * @template InstanceType of ValidatorInterface
  * @extends AbstractPluginManager<InstanceType>
  */
@@ -60,7 +59,7 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Default set of aliases
      *
-     * @var array<array-key, string>
+     * @inheritDoc
      * @psalm-suppress UndefinedClass
      */
     protected $aliases = [
@@ -368,7 +367,7 @@ class ValidatorPluginManager extends AbstractPluginManager
     /**
      * Default set of factories
      *
-     * @var FactoriesConfigurationType
+     * @inheritDoc
      */
     protected $factories = [
         I18nValidator\Alnum::class       => InvokableFactory::class,

--- a/test/AbstractValidatorTest.php
+++ b/test/AbstractValidatorTest.php
@@ -11,6 +11,8 @@ use Laminas\Validator\Hostname;
 use LaminasTest\Validator\TestAsset\ArrayTranslator;
 use LaminasTest\Validator\TestAsset\ConcreteValidator;
 use LaminasTest\Validator\TestAsset\Translator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use stdClass;
@@ -20,10 +22,6 @@ use function reset;
 use function sprintf;
 use function var_export;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\AbstractValidator
- */
 final class AbstractValidatorTest extends TestCase
 {
     private AbstractValidator $validator;
@@ -122,9 +120,7 @@ final class AbstractValidatorTest extends TestCase
         self::assertStringContainsString('******', $message);
     }
 
-    /**
-     * @group Laminas-4463
-     */
+    #[Group('Laminas-4463')]
     public function testDoesNotFailOnObjectInput(): void
     {
         self::assertFalse($this->validator->isValid(new stdClass()));
@@ -303,7 +299,7 @@ final class AbstractValidatorTest extends TestCase
     /**
      * @psalm-return array<string, array{scalar|object|null}>
      */
-    public function invalidOptionsArguments(): array
+    public static function invalidOptionsArguments(): array
     {
         return [
             'null'       => [null],
@@ -319,9 +315,9 @@ final class AbstractValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidOptionsArguments
      * @psalm-param scalar|object|null $options
      */
+    #[DataProvider('invalidOptionsArguments')]
     public function testSettingOptionsWithNonTraversableRaisesException($options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/test/AbstractValidatorTest.php
+++ b/test/AbstractValidatorTest.php
@@ -17,8 +17,6 @@ use stdClass;
 
 use function extension_loaded;
 use function reset;
-use function restore_error_handler;
-use function set_error_handler;
 use function sprintf;
 use function var_export;
 
@@ -29,11 +27,6 @@ use function var_export;
 final class AbstractValidatorTest extends TestCase
 {
     private AbstractValidator $validator;
-
-    /**
-     * Whether an error occurred
-     */
-    private bool $errorOccurred = false;
 
     protected function setUp(): void
     {
@@ -56,12 +49,7 @@ final class AbstractValidatorTest extends TestCase
 
     public function testCanSetTranslator(): void
     {
-        $this->testTranslatorNullByDefault();
-
-        set_error_handler([$this, 'errorHandlerIgnore']);
         $translator = new Translator();
-        restore_error_handler();
-
         $this->validator->setTranslator($translator);
 
         self::assertSame($translator, $this->validator->getTranslator());
@@ -70,10 +58,7 @@ final class AbstractValidatorTest extends TestCase
     public function testCanSetTranslatorToNull(): void
     {
         $this->testCanSetTranslator();
-
-        set_error_handler([$this, 'errorHandlerIgnore']);
         $this->validator->setTranslator(null);
-        restore_error_handler();
 
         self::assertNull($this->validator->getTranslator());
     }
@@ -151,7 +136,6 @@ final class AbstractValidatorTest extends TestCase
 
     public function testTranslatorEnabledPerDefault(): void
     {
-        set_error_handler([$this, 'errorHandlerIgnore']);
         $translator = new Translator();
         $this->validator->setTranslator($translator);
 
@@ -304,19 +288,6 @@ final class AbstractValidatorTest extends TestCase
         self::assertCount(2, $validator->getMessages());
         self::assertArrayHasKey(EmailAddress::INVALID_HOSTNAME, $validator->getMessages());
         self::assertArrayHasKey(Hostname::LOCAL_NAME_NOT_ALLOWED, $validator->getMessages());
-    }
-
-    /**
-     * Ignores a raised PHP error when in effect, but throws a flag to indicate an error occurred
-     */
-    public function errorHandlerIgnore(
-        int $errno,
-        string $errstr,
-        string $errfile,
-        int $errline,
-        array $errcontext
-    ): void {
-        $this->errorOccurred = true;
     }
 
     public function testRetrievingUnknownOptionRaisesException(): void

--- a/test/AbstractValidatorTest.php
+++ b/test/AbstractValidatorTest.php
@@ -252,7 +252,6 @@ final class AbstractValidatorTest extends TestCase
     public function testMessageCreationWithNestedArrayValueDoesNotRaiseNotice(): void
     {
         $r = new ReflectionMethod($this->validator, 'createMessage');
-        $r->setAccessible(true);
 
         $message = $r->invoke($this->validator, 'fooMessage', ['foo' => ['bar' => 'baz']]);
 

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -9,23 +9,19 @@ use Laminas\Validator\Barcode;
 use Laminas\Validator\Barcode\AdapterInterface;
 use Laminas\Validator\Barcode\Ean13;
 use Laminas\Validator\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function extension_loaded;
 
-/**
- * \Laminas\Barcode
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Barcode
- */
 final class BarcodeTest extends TestCase
 {
     /**
      * @psalm-return array<string, array{0: null|array, 1: string}>
      */
-    public function provideBarcodeConstructor(): array
+    public static function provideBarcodeConstructor(): array
     {
         return [
             'null'        => [null, Barcode\Ean13::class],
@@ -33,9 +29,7 @@ final class BarcodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideBarcodeConstructor
-     */
+    #[DataProvider('provideBarcodeConstructor')]
     public function testBarcodeConstructor(?array $options, string $expectedInstance): void
     {
         $barcode = new Barcode($options);
@@ -474,9 +468,7 @@ final class BarcodeTest extends TestCase
         self::assertTrue($barcode->isValid('0234567'));
     }
 
-    /**
-     * @group Laminas-10116
-     */
+    #[Group('Laminas-10116')]
     public function testArrayLengthMessage(): void
     {
         $barcode = new Barcode('ean8');
@@ -489,9 +481,7 @@ final class BarcodeTest extends TestCase
         self::assertStringContainsString('length of 7/8 characters', $message['barcodeInvalidLength']);
     }
 
-    /**
-     * @group Laminas-8673
-     */
+    #[Group('Laminas-8673')]
     public function testCODABAR(): void
     {
         $barcode = new Barcode('codabar');
@@ -505,9 +495,7 @@ final class BarcodeTest extends TestCase
         self::assertFalse($barcode->isValid('*123A'));
     }
 
-    /**
-     * @group Laminas-11532
-     */
+    #[Group('Laminas-11532')]
     public function testIssnWithMod0(): void
     {
         $barcode = new Barcode('issn');
@@ -515,9 +503,7 @@ final class BarcodeTest extends TestCase
         self::assertTrue($barcode->isValid('18710360'));
     }
 
-    /**
-     * @group Laminas-8674
-     */
+    #[Group('Laminas-8674')]
     public function testCODE128(): void
     {
         if (! extension_loaded('iconv')) {
@@ -538,9 +524,8 @@ final class BarcodeTest extends TestCase
 
     /**
      * Test if EAN-13 contains only numeric characters
-     *
-     * @group Laminas-3297
      */
+    #[Group('Laminas-3297')]
     public function testEan13ContainsOnlyNumeric(): void
     {
         $barcode = new Barcode('ean13');

--- a/test/BetweenTest.php
+++ b/test/BetweenTest.php
@@ -7,15 +7,12 @@ namespace LaminasTest\Validator;
 use ArrayObject;
 use Laminas\Validator\Between;
 use Laminas\Validator\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function implode;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Between
- */
 final class BetweenTest extends TestCase
 {
     /**
@@ -27,7 +24,7 @@ final class BetweenTest extends TestCase
      *     value: int|float|string
      * }>
      */
-    public function providerBasic(): array
+    public static function providerBasic(): array
     {
         return [
             'inclusive-int-valid-floor'              => [
@@ -183,10 +180,10 @@ final class BetweenTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider providerBasic
      * @param int|float|string $min
      * @param int|float|string $max
      */
+    #[DataProvider('providerBasic')]
     public function testBasic($min, $max, bool $inclusive, bool $expected, mixed $value): void
     {
         $validator = new Between(['min' => $min, 'max' => $max, 'inclusive' => $inclusive]);
@@ -266,10 +263,7 @@ final class BetweenTest extends TestCase
         self::assertSame(array_keys($messageVariables), $validator->getMessageVariables());
     }
 
-    /**
-     * @covers \Laminas\Validator\Between::__construct()
-     * @dataProvider constructBetweenValidatorInvalidDataProvider
-     */
+    #[DataProvider('constructBetweenValidatorInvalidDataProvider')]
     public function testMissingMinOrMax(array $args): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -283,7 +277,7 @@ final class BetweenTest extends TestCase
      *     0: array<string, mixed>
      * }>
      */
-    public function constructBetweenValidatorInvalidDataProvider(): array
+    public static function constructBetweenValidatorInvalidDataProvider(): array
     {
         return [
             'only-min'      => [['min' => 1]],

--- a/test/BitwiseTest.php
+++ b/test/BitwiseTest.php
@@ -6,14 +6,12 @@ namespace LaminasTest\Validator;
 
 use ArrayObject;
 use Laminas\Validator\Bitwise;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BitwiseTest extends TestCase
 {
-    /**
-     * @covers \Laminas\Validator\Bitwise::__construct()
-     * @dataProvider constructDataProvider
-     */
+    #[DataProvider('constructDataProvider')]
     public function testConstruct(array $args, array $options): void
     {
         $validator = new Bitwise($args);
@@ -23,10 +21,7 @@ final class BitwiseTest extends TestCase
         self::assertSame($options['strict'], $validator->getStrict());
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::__construct()
-     * @dataProvider constructDataProvider
-     */
+    #[DataProvider('constructDataProvider')]
     public function testConstructWithTraversableOptions(array $args, array $options): void
     {
         $validator = new Bitwise(
@@ -44,7 +39,7 @@ final class BitwiseTest extends TestCase
      *     1: array<string, mixed>
      * }>
      */
-    public function constructDataProvider(): array
+    public static function constructDataProvider(): array
     {
         return [
             [
@@ -66,9 +61,6 @@ final class BitwiseTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::isvalid()
-     */
     public function testBitwiseAndNotStrict(): void
     {
         $controlSum = 0x7; // (0x1 | 0x2 | 0x4) === 0x7
@@ -93,9 +85,6 @@ final class BitwiseTest extends TestCase
         self::assertTrue($validator->isValid(0x1 | 0x8));
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::isvalid()
-     */
     public function testBitwiseAndStrict(): void
     {
         $controlSum = 0x7; // (0x1 | 0x2 | 0x4) === 0x7
@@ -131,7 +120,7 @@ final class BitwiseTest extends TestCase
      *     2: array<string, string>
      * }>
      */
-    public function bitwiseXorProvider(): array
+    public static function bitwiseXorProvider(): array
     {
         return [
             [0x2, true, []],
@@ -146,10 +135,7 @@ final class BitwiseTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::isvalid()
-     * @dataProvider bitwiseXorProvider
-     */
+    #[DataProvider('bitwiseXorProvider')]
     public function testBitwiseXor(int $value, bool $expected, array $expectedMessages): void
     {
         $controlSum = 0x5; // (0x1 | 0x4) === 0x5
@@ -179,9 +165,6 @@ final class BitwiseTest extends TestCase
          */
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::setOperator()
-     */
     public function testSetOperator(): void
     {
         $validator = new Bitwise();
@@ -195,9 +178,6 @@ final class BitwiseTest extends TestCase
         self::assertSame(Bitwise::OP_XOR, $validator->getOperator());
     }
 
-    /**
-     * @covers \Laminas\Validator\Bitwise::setStrict()
-     */
     public function testSetStrict(): void
     {
         $validator = new Bitwise();

--- a/test/BitwiseTest.php
+++ b/test/BitwiseTest.php
@@ -8,18 +8,8 @@ use ArrayObject;
 use Laminas\Validator\Bitwise;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Laminas\Validator\Bitwise */
 final class BitwiseTest extends TestCase
 {
-    private Bitwise $validator;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->validator = new Bitwise();
-    }
-
     /**
      * @covers \Laminas\Validator\Bitwise::__construct()
      * @dataProvider constructDataProvider
@@ -37,7 +27,7 @@ final class BitwiseTest extends TestCase
      * @covers \Laminas\Validator\Bitwise::__construct()
      * @dataProvider constructDataProvider
      */
-    public function testConstructWithTravesableOptions(array $args, array $options): void
+    public function testConstructWithTraversableOptions(array $args, array $options): void
     {
         $validator = new Bitwise(
             new ArrayObject($args)

--- a/test/BusinessIdentifierCodeTest.php
+++ b/test/BusinessIdentifierCodeTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\BusinessIdentifierCode;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/** @covers \Laminas\Validator\BusinessIdentifierCode */
 final class BusinessIdentifierCodeTest extends TestCase
 {
     /** @psalm-return array<string, array{0: string}> */
-    public function successProvider(): array
+    public static function successProvider(): array
     {
         return [
             // UPPERCASE
@@ -39,9 +39,7 @@ final class BusinessIdentifierCodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider successProvider
-     */
+    #[DataProvider('successProvider')]
     public function testValidateSuccess(string $code): void
     {
         $validator = new BusinessIdentifierCode();
@@ -50,7 +48,7 @@ final class BusinessIdentifierCodeTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: mixed}> */
-    public function notAStringProvider(): array
+    public static function notAStringProvider(): array
     {
         return [
             'number' => [123],
@@ -59,9 +57,7 @@ final class BusinessIdentifierCodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider notAStringProvider
-     */
+    #[DataProvider('notAStringProvider')]
     public function testNotAStringFailure(mixed $code): void
     {
         $validator = new BusinessIdentifierCode();
@@ -75,7 +71,7 @@ final class BusinessIdentifierCodeTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: string}> */
-    public function notBicFormatProvider(): array
+    public static function notBicFormatProvider(): array
     {
         return [
             'too short'                    => ['SHORT'],
@@ -84,9 +80,7 @@ final class BusinessIdentifierCodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider notBicFormatProvider
-     */
+    #[DataProvider('notBicFormatProvider')]
     public function testNotBicFormatFailure(string $code): void
     {
         $validator = new BusinessIdentifierCode();
@@ -97,7 +91,7 @@ final class BusinessIdentifierCodeTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: string}> */
-    public function notSwiftCountryCodeProvider(): array
+    public static function notSwiftCountryCodeProvider(): array
     {
         return [
             'AA is not a assigned code'                     => ['DEUTAAFF'],
@@ -105,9 +99,7 @@ final class BusinessIdentifierCodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider notSwiftCountryCodeProvider
-     */
+    #[DataProvider('notSwiftCountryCodeProvider')]
     public function testNotSwiftCountryCodeFailure(string $code): void
     {
         $validator = new BusinessIdentifierCode();

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -12,10 +12,6 @@ use ReflectionProperty;
 use function array_keys;
 use function func_get_args;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Callback
- */
 final class CallbackTest extends TestCase
 {
     /**

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -149,7 +149,6 @@ final class CallbackTest extends TestCase
         $validator = new Callback();
 
         $r = new ReflectionProperty($validator, 'options');
-        $r->setAccessible(true);
 
         $options             = $r->getValue($validator);
         $options['callback'] = [];

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -8,15 +8,13 @@ use ArrayObject;
 use Laminas\Validator\CreditCard;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use LaminasTest\Validator\TestAsset\CreditCardValidatorExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function current;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\CreditCard
- */
 final class CreditCardTest extends TestCase
 {
     /**
@@ -35,9 +33,8 @@ final class CreditCardTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider basicValues
      */
+    #[DataProvider('basicValues')]
     public function testBasic(string $input, bool $expected): void
     {
         $validator = new CreditCard();
@@ -113,9 +110,8 @@ final class CreditCardTest extends TestCase
 
     /**
      * Test specific provider
-     *
-     * @dataProvider visaValues
      */
+    #[DataProvider('visaValues')]
     public function testProvider(string $input, bool $expected): void
     {
         $validator = new CreditCard(CreditCard::VISA);
@@ -149,9 +145,8 @@ final class CreditCardTest extends TestCase
 
     /**
      * Test service class with invalid validation
-     *
-     * @dataProvider serviceValues
      */
+    #[DataProvider('serviceValues')]
     public function testServiceClass(string $input, bool $expected): void
     {
         $validator = new CreditCard();
@@ -179,9 +174,8 @@ final class CreditCardTest extends TestCase
 
     /**
      * Test non string input
-     *
-     * @dataProvider optionsValues
      */
+    #[DataProvider('optionsValues')]
     public function testConstructionWithOptions(string $input, bool $expected): void
     {
         $validator = new CreditCard(
@@ -199,7 +193,7 @@ final class CreditCardTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function jcbValues(): array
+    public static function jcbValues(): array
     {
         return [
             ['3566003566003566', true],
@@ -217,12 +211,12 @@ final class CreditCardTest extends TestCase
     /**
      * Test JCB number validity
      *
-     * @dataProvider jcbValues
      * @param string $input
      * @param bool   $expected
-     * @group 6278
-     * @group 6927
      */
+    #[DataProvider('jcbValues')]
+    #[Group('6278')]
+    #[Group('6927')]
     public function testJcbCard($input, $expected): void
     {
         $validator = new CreditCard(['type' => CreditCard::JCB]);
@@ -235,7 +229,7 @@ final class CreditCardTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function mastercardValues(): array
+    public static function mastercardValues(): array
     {
         return [
             ['4111111111111111', false],
@@ -256,10 +250,10 @@ final class CreditCardTest extends TestCase
     /**
      * Test mastercard number validity
      *
-     * @dataProvider mastercardValues
      * @param string $input
      * @param bool   $expected
      */
+    #[DataProvider('mastercardValues')]
     public function testMastercardCard($input, $expected): void
     {
         $validator = new CreditCard(['type' => CreditCard::MASTERCARD]);
@@ -272,7 +266,7 @@ final class CreditCardTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function mirValues(): array
+    public static function mirValues(): array
     {
         return [
             ['3011111111111000', false],
@@ -294,10 +288,10 @@ final class CreditCardTest extends TestCase
     /**
      * Test mir card number validity
      *
-     * @dataProvider mirValues
      * @param string $input
      * @param bool   $expected
      */
+    #[DataProvider('mirValues')]
     public function testMirCard($input, $expected): void
     {
         $validator = new CreditCard(['type' => CreditCard::MIR]);
@@ -359,9 +353,7 @@ final class CreditCardTest extends TestCase
         self::assertSame([self::class, 'staticCallback'], $validator->getService());
     }
 
-    /**
-     * @group Laminas-9477
-     */
+    #[Group('Laminas-9477')]
     public function testMultiInstitute(): void
     {
         $validator = new CreditCard(['type' => CreditCard::MASTERCARD]);

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -9,6 +9,7 @@ use Laminas\Session\Container;
 use Laminas\Session\Storage\ArrayStorage;
 use Laminas\Validator\Csrf;
 use LaminasTest\Validator\TestAsset\SessionManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
@@ -19,12 +20,6 @@ use function str_replace;
 use function strtr;
 use function uniqid;
 
-/**
- * Laminas\Csrf
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Csrf
- */
 final class CsrfTest extends TestCase
 {
     private Csrf $validator;
@@ -107,7 +102,7 @@ final class CsrfTest extends TestCase
      * @return (int|null|string)[][]
      * @psalm-return array<array-key, array{0: null|int|string, 1: null|int}>
      */
-    public function timeoutValuesDataProvider(): array
+    public static function timeoutValuesDataProvider(): array
     {
         return [
             //    timeout  expected
@@ -119,9 +114,9 @@ final class CsrfTest extends TestCase
     }
 
     /**
-     * @dataProvider timeoutValuesDataProvider
      * @param null|int|string $timeout
      */
+    #[DataProvider('timeoutValuesDataProvider')]
     public function testTimeoutIsMutable($timeout, ?int $expected): void
     {
         $this->validator->setTimeout($timeout);
@@ -306,7 +301,7 @@ final class CsrfTest extends TestCase
      * @return string[][]
      * @psalm-return array<array-key, array{0: string}>
      */
-    public function fakeValuesDataProvider(): array
+    public static function fakeValuesDataProvider(): array
     {
         return [
             [''],
@@ -320,9 +315,7 @@ final class CsrfTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider fakeValuesDataProvider
-     */
+    #[DataProvider('fakeValuesDataProvider')]
     public function testWithFakeValues(string $value): void
     {
         $validator = new Csrf();

--- a/test/CsrfTest.php
+++ b/test/CsrfTest.php
@@ -290,7 +290,6 @@ final class CsrfTest extends TestCase
     public function testCanValidateHasheWithoutId(): void
     {
         $method = new ReflectionMethod($this->validator::class, 'getTokenFromHash');
-        $method->setAccessible(true);
 
         $hash      = $this->validator->getHash();
         $bareToken = $method->invoke($this->validator, $hash);

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -9,16 +9,13 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Laminas\Validator\DateStep;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
 use function array_keys;
 use function date;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\DateStep
- */
 final class DateStepTest extends TestCase
 {
     /**
@@ -31,7 +28,7 @@ final class DateStepTest extends TestCase
      *     4: bool
      * }>
      */
-    public function stepTestsDataProvider(): array
+    public static function stepTestsDataProvider(): array
     {
         return [
             //    interval format            baseValue               value                  isValid
@@ -92,9 +89,7 @@ final class DateStepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider stepTestsDataProvider
-     */
+    #[DataProvider('stepTestsDataProvider')]
     public function testDateStepValidation(
         string $interval,
         string $format,
@@ -179,7 +174,7 @@ final class DateStepTest extends TestCase
      * @return array[]
      * @psalm-return array<array{0: string}>
      */
-    public function moscowWinterTimeDataProvider(): array
+    public static function moscowWinterTimeDataProvider(): array
     {
         // dates before during and after Moscow's wintertime
         return [
@@ -190,9 +185,7 @@ final class DateStepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider moscowWinterTimeDataProvider
-     */
+    #[DataProvider('moscowWinterTimeDataProvider')]
     public function testMoscowWinterTime(string $dateToValidate): void
     {
         $validator = new DateStep([

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -258,7 +258,6 @@ final class DateStepTest extends TestCase
         ]);
 
         $r = new ReflectionMethod($validator, 'convertString');
-        $r->setAccessible(true);
 
         $invalidValue = '20-20-20';
 

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -113,7 +113,7 @@ final class DateTest extends TestCase
      * @dataProvider datesDataProvider
      * @param string|numeric|DateTime|object|array|null $input
      */
-    public function testBasic($input, ?string $format, bool $result, bool $resultStrict): void
+    public function testBasic($input, ?string $format, bool $result): void
     {
         $this->validator->setFormat($format);
 

--- a/test/DateTest.php
+++ b/test/DateTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Validator;
 use DateTime;
 use DateTimeImmutable;
 use Laminas\Validator\Date;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -14,10 +16,6 @@ use function array_keys;
 use function date_get_last_errors;
 use function var_export;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Date
- */
 final class DateTest extends TestCase
 {
     private Date $validator;
@@ -48,7 +46,7 @@ final class DateTest extends TestCase
      *     3: bool
      * }>
      */
-    public function datesDataProvider(): array
+    public static function datesDataProvider(): array
     {
         return [
             // date                     format             isValid   isValid Strict
@@ -110,9 +108,9 @@ final class DateTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider datesDataProvider
      * @param string|numeric|DateTime|object|array|null $input
      */
+    #[DataProvider('datesDataProvider')]
     public function testBasic($input, ?string $format, bool $result): void
     {
         $this->validator->setFormat($format);
@@ -122,9 +120,9 @@ final class DateTest extends TestCase
     }
 
     /**
-     * @dataProvider datesDataProvider
      * @param string|numeric|DateTime|object|array|null $input
      */
+    #[DataProvider('datesDataProvider')]
     public function testBasicStrictMode($input, ?string $format, bool $result, bool $resultStrict): void
     {
         $this->validator->setStrict(true);
@@ -149,9 +147,8 @@ final class DateTest extends TestCase
 
     /**
      * Ensures that the validator can handle different manual dateformats
-     *
-     * @group Laminas-2003
      */
+    #[Group('Laminas-2003')]
     public function testUseManualFormat(): void
     {
         self::assertTrue(

--- a/test/Db/AbstractDbTest.php
+++ b/test/Db/AbstractDbTest.php
@@ -9,12 +9,9 @@ use Laminas\Db\Adapter\AdapterAwareInterface;
 use Laminas\Db\Sql\Select;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use LaminasTest\Validator\Db\TestAsset\ConcreteDbValidator;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Db\AbstractDb
- */
 final class AbstractDbTest extends TestCase
 {
     private ConcreteDbValidator $validator;
@@ -91,17 +88,13 @@ final class AbstractDbTest extends TestCase
         self::assertSame($field, $this->validator->getField());
     }
 
-    /**
-     * @group #46
-     */
+    #[Group('#46')]
     public function testImplementationsAreDbAdapterAware(): void
     {
         self::assertInstanceOf(AdapterAwareInterface::class, $this->validator);
     }
 
-    /**
-     * @group #46
-     */
+    #[Group('#46')]
     public function testSetAdapterIsEquivalentToSetDbAdapter(): void
     {
         $adapterFirst  = $this->createStub(Adapter::class);

--- a/test/Db/NoRecordExistsTest.php
+++ b/test/Db/NoRecordExistsTest.php
@@ -15,10 +15,6 @@ use Laminas\Validator\Exception\RuntimeException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Db\NoRecordExists
- */
 final class NoRecordExistsTest extends TestCase
 {
     /**

--- a/test/Db/RecordExistsTest.php
+++ b/test/Db/RecordExistsTest.php
@@ -16,13 +16,10 @@ use Laminas\Db\Sql\TableIdentifier;
 use Laminas\Validator\Db\RecordExists;
 use Laminas\Validator\Exception\RuntimeException;
 use LaminasTest\Validator\Db\TestAsset\TrustingSql92Platform;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Db\RecordExists
- */
 final class RecordExistsTest extends TestCase
 {
     /**
@@ -202,9 +199,7 @@ final class RecordExistsTest extends TestCase
         self::assertFalse($validator->isValid('nosuchvalue'));
     }
 
-    /**
-     * @group Laminas-8863
-     */
+    #[Group('Laminas-8863')]
     public function testExcludeConstructor(): void
     {
         $validator = new RecordExists('users', 'field1', 'id != 1', $this->getMockHasResult());
@@ -280,9 +275,6 @@ final class RecordExistsTest extends TestCase
         self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
-    /**
-     * @testdox Laminas\Validator\Db\RecordExists::getSelect
-     */
     public function testGetSelect(): void
     {
         $validator = new RecordExists(
@@ -313,10 +305,7 @@ final class RecordExistsTest extends TestCase
         self::assertSame($parameters['where2'], 'bar');
     }
 
-    /**
-     * @cover Laminas\Validator\Db\RecordExists::getSelect
-     * @group Laminas-4521
-     */
+    #[Group('Laminas-4521')]
     public function testGetSelectWithSameValidatorTwice(): void
     {
         $validator = new RecordExists(

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\Digits;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Digits
- */
 final class DigitsTest extends TestCase
 {
     private Digits $validator;
@@ -26,9 +23,8 @@ final class DigitsTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for basic input values
-     *
-     * @dataProvider basicDataProvider
      */
+    #[DataProvider('basicDataProvider')]
     public function testExpectedResultsWithBasicInputValues(string $input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
@@ -37,7 +33,7 @@ final class DigitsTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string, 1: bool}>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -793,7 +793,7 @@ final class EmailAddressTest extends TestCase
             'BoB@aol.com',
             'bobjones@nist.gov',
             "B.O'Callaghan@usmc.mil",
-            'bob+jones@nic.us',
+            'bob+jones@php.net',
             'bob+jones@dailymail.co.uk',
             'bob@teaparty.uk.com',
             'bob@thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com',

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Validator;
 use Laminas\Validator\EmailAddress;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Hostname;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_key_exists;
@@ -218,7 +220,7 @@ final class EmailAddressTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function validEmailAddresses(): array
+    public static function validEmailAddresses(): array
     {
         // @codingStandardsIgnoreStart
         $return = [
@@ -248,9 +250,8 @@ final class EmailAddressTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for valid email addresses
-     *
-     * @dataProvider validEmailAddresses
      */
+    #[DataProvider('validEmailAddresses')]
     public function testBasicValid(string $value): void
     {
         self::assertTrue(
@@ -266,7 +267,7 @@ final class EmailAddressTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function invalidEmailAddresses(): array
+    public static function invalidEmailAddresses(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -292,9 +293,8 @@ final class EmailAddressTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for invalid email addresses
-     *
-     * @dataProvider invalidEmailAddresses
      */
+    #[DataProvider('invalidEmailAddresses')]
     public function testBasicInvalid(string $value): void
     {
         self::assertFalse($this->validator->isValid($value));
@@ -355,9 +355,8 @@ final class EmailAddressTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for checking MX records
-     *
-     * @dataProvider emailAddressesForMxChecks
      */
+    #[DataProvider('emailAddressesForMxChecks')]
     public function testMXRecords(string $emailAddress, bool $expect): void
     {
         $this->skipIfOnlineTestsDisabled();
@@ -455,9 +454,7 @@ final class EmailAddressTest extends TestCase
         self::assertSame([], $this->validator->getMessages());
     }
 
-    /**
-     * @group Laminas-2861
-     */
+    #[Group('Laminas-2861')]
     public function testHostnameValidatorMessagesShouldBeTranslated(): void
     {
         if (! extension_loaded('intl')) {
@@ -500,9 +497,7 @@ final class EmailAddressTest extends TestCase
         self::assertTrue($found);
     }
 
-    /**
-     * @group Laminas-4888
-     */
+    #[Group('Laminas-4888')]
     public function testEmailsExceedingLength(): void
     {
         // @codingStandardsIgnoreStart
@@ -517,17 +512,13 @@ final class EmailAddressTest extends TestCase
         }
     }
 
-    /**
-     * @group Laminas-4352
-     */
+    #[Group('Laminas-4352')]
     public function testNonStringValidation(): void
     {
         self::assertFalse($this->validator->isValid([1 => 1]));
     }
 
-    /**
-     * @group Laminas-7490
-     */
+    #[Group('Laminas-7490')]
     public function testSettingHostnameMessagesThroughEmailValidator(): void
     {
         $translations = [
@@ -654,9 +645,8 @@ final class EmailAddressTest extends TestCase
 
     /**
      * Testing setMessage for all messages
-     *
-     * @group Laminas-10690
      */
+    #[Group('Laminas-10690')]
     public function testSetMultipleMessages(): void
     {
         $messages = $this->validator->getMessageTemplates();
@@ -686,10 +676,8 @@ final class EmailAddressTest extends TestCase
     {
     }
 
-    /**
-     * @group Laminas-11222
-     * @group Laminas-11451
-     */
+    #[Group('Laminas-11222')]
+    #[Group('Laminas-11451')]
     public function testEmailAddressesWithTrailingDotInHostPartAreRejected(): void
     {
         self::assertFalse($this->validator->isValid('example@gmail.com.'));
@@ -697,9 +685,7 @@ final class EmailAddressTest extends TestCase
         self::assertFalse($this->validator->isValid('test@test.co.za.'));
     }
 
-    /**
-     * @group Laminas-11239
-     */
+    #[Group('Laminas-11239')]
     public function testNotSetHostnameValidator(): void
     {
         $hostname = $this->validator->getHostnameValidator();
@@ -764,9 +750,7 @@ final class EmailAddressTest extends TestCase
         self::assertSame(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
-    /**
-     * @group Laminas-130
-     */
+    #[Group('Laminas-130')]
     public function testUseMxCheckBasicValid(): void
     {
         $this->skipIfOnlineTestsDisabled();
@@ -802,9 +786,7 @@ final class EmailAddressTest extends TestCase
         }
     }
 
-    /**
-     * @group Laminas-130
-     */
+    #[Group('Laminas-130')]
     public function testUseMxRecordsBasicInvalid(): void
     {
         $validator = new EmailAddress([
@@ -841,9 +823,7 @@ final class EmailAddressTest extends TestCase
         }
     }
 
-    /**
-     * @group Laminas-12349
-     */
+    #[Group('Laminas-12349')]
     public function testReservedIpRangeValidation(): void
     {
         $validator = new TestAsset\EmailValidatorWithExposedIsReserved();
@@ -908,9 +888,7 @@ final class EmailAddressTest extends TestCase
         self::assertTrue($validator->isReserved('255.255.55.255'));
     }
 
-    /**
-     * @group Laminas-12349
-     */
+    #[Group('Laminas-12349')]
     public function testIpRangeValidationOnRangesNoLongerMarkedAsReserved(): void
     {
         $validator = new TestAsset\EmailValidatorWithExposedIsReserved();

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -22,19 +22,12 @@ use function preg_replace;
 use function set_error_handler;
 use function sprintf;
 use function str_repeat;
-use function strstr;
 
 use const E_USER_NOTICE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\EmailAddress
- */
 final class EmailAddressTest extends TestCase
 {
     private EmailAddress $validator;
-
-    private bool $multipleOptionsDetected;
 
     protected function setUp(): void
     {
@@ -691,9 +684,6 @@ final class EmailAddressTest extends TestCase
 
     public function errorHandler(int $errno, string $errstr): void
     {
-        if (strstr($errstr, 'deprecated')) {
-            $this->multipleOptionsDetected = true;
-        }
     }
 
     /**

--- a/test/ExplodeTest.php
+++ b/test/ExplodeTest.php
@@ -11,15 +11,13 @@ use Laminas\Validator\Explode;
 use Laminas\Validator\InArray;
 use Laminas\Validator\Regex;
 use Laminas\Validator\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Explode
- */
 final class ExplodeTest extends TestCase
 {
     public function testRaisesExceptionWhenValidatorIsMissing(): void
@@ -43,7 +41,7 @@ final class ExplodeTest extends TestCase
      *     6: bool
      * }>
      */
-    public function getExpectedData(): array
+    public static function getExpectedData(): array
     {
         return [
             //    value              delim break  N  valid  messages                   expects
@@ -67,9 +65,7 @@ final class ExplodeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getExpectedData
-     */
+    #[DataProvider('getExpectedData')]
     public function testExpectedBehavior(
         mixed $value,
         ?string $delimiter,
@@ -164,9 +160,7 @@ final class ExplodeTest extends TestCase
         $validator->setValidator('inarray');
     }
 
-    /**
-     * @group Laminas-5796
-     */
+    #[Group('Laminas-5796')]
     public function testGetMessagesMultipleInvalid(): void
     {
         $validator = new Explode([

--- a/test/File/CountTest.php
+++ b/test/File/CountTest.php
@@ -202,12 +202,8 @@ final class CountTest extends TestCase
         $fileArray = ['name' => $filename];
 
         $reflection = new ReflectionClass($validator);
-
-        $method = $reflection->getMethod('throwError');
-        $method->setAccessible(true);
-
-        $property = $reflection->getProperty('value');
-        $property->setAccessible(true);
+        $method     = $reflection->getMethod('throwError');
+        $property   = $reflection->getProperty('value');
 
         $result = $method->invoke($validator, $fileArray, Count::TOO_FEW);
 
@@ -220,14 +216,9 @@ final class CountTest extends TestCase
         $validator  = new Count(['min' => 1000, 'max' => 10000]);
         $filename   = 'test.txt';
         $reflection = new ReflectionClass($validator);
-
-        $method = $reflection->getMethod('throwError');
-        $method->setAccessible(true);
-
-        $property = $reflection->getProperty('value');
-        $property->setAccessible(true);
-
-        $result = $method->invoke($validator, $filename, Count::TOO_FEW);
+        $method     = $reflection->getMethod('throwError');
+        $property   = $reflection->getProperty('value');
+        $result     = $method->invoke($validator, $filename, Count::TOO_FEW);
 
         self::assertFalse($result);
         self::assertSame($filename, $property->getValue($validator));

--- a/test/File/CountTest.php
+++ b/test/File/CountTest.php
@@ -6,24 +6,21 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Count;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 use ReflectionClass;
 
 use function basename;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Count
- */
 final class CountTest extends TestCase
 {
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicDataProvider
      * @param array|int $options
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic($options, bool $expected1, bool $expected2, bool $expected3, bool $expected4): void
     {
         $validator = new Count($options);
@@ -55,7 +52,7 @@ final class CountTest extends TestCase
      *     4: bool
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable
@@ -146,7 +143,7 @@ final class CountTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidMinMaxValues(): array
+    public static function invalidMinMaxValues(): array
     {
         return [
             'null'           => [null],
@@ -158,9 +155,7 @@ final class CountTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSettingMaxWithInvalidArgumentRaisesException(mixed $max): void
     {
         $validator = new Count(['min' => 1000, 'max' => 10000]);
@@ -182,9 +177,7 @@ final class CountTest extends TestCase
         self::assertSame($minValue, $validator->getMin());
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSettingMinWithInvalidArgumentRaisesException(mixed $min): void
     {
         $validator = new Count(['min' => 1000, 'max' => 10000]);

--- a/test/File/Crc32Test.php
+++ b/test/File/Crc32Test.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Crc32;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,10 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Crc32
- */
 final class Crc32Test extends TestCase
 {
     /**
@@ -35,7 +33,7 @@ final class Crc32Test extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
@@ -78,10 +76,10 @@ final class Crc32Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new Crc32($options);
@@ -96,10 +94,10 @@ final class Crc32Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -209,9 +207,7 @@ final class Crc32Test extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Crc32('3f8d07e2');

--- a/test/File/ExcludeExtensionTest.php
+++ b/test/File/ExcludeExtensionTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\ExcludeExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,10 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\ExcludeExtension
- */
 final class ExcludeExtensionTest extends TestCase
 {
     /**
@@ -35,7 +33,7 @@ final class ExcludeExtensionTest extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/testsize.mo';
         $pictureTests = [
@@ -74,10 +72,10 @@ final class ExcludeExtensionTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new ExcludeExtension($options);
@@ -92,10 +90,10 @@ final class ExcludeExtensionTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -130,7 +128,7 @@ final class ExcludeExtensionTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string[]}> */
-    public function getExtensionProvider(): array
+    public static function getExtensionProvider(): array
     {
         return [
             ['mo', ['mo']],
@@ -141,10 +139,10 @@ final class ExcludeExtensionTest extends TestCase
     /**
      * Ensures that getExtension() returns expected value
      *
-     * @dataProvider getExtensionProvider
      * @param string|string[] $extension
      * @param string[] $expected
      */
+    #[DataProvider('getExtensionProvider')]
     public function testGetExtension($extension, array $expected): void
     {
         $validator = new ExcludeExtension($extension);
@@ -153,7 +151,7 @@ final class ExcludeExtensionTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string[]}> */
-    public function setExtensionProvider(): array
+    public static function setExtensionProvider(): array
     {
         return [
             ['gif', ['gif']],
@@ -165,10 +163,10 @@ final class ExcludeExtensionTest extends TestCase
     /**
      * Ensures that setExtension() returns expected value
      *
-     * @dataProvider setExtensionProvider
      * @param string|string[] $extension
      * @param string[] $expected
      */
+    #[DataProvider('setExtensionProvider')]
     public function testSetExtension($extension, array $expected): void
     {
         $validator = new ExcludeExtension('mo');
@@ -200,9 +198,7 @@ final class ExcludeExtensionTest extends TestCase
         self::assertSame(['mo', 'gif', 'jpg', 'to', 'zip', 'ti'], $validator->getExtension());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new ExcludeExtension('mo');

--- a/test/File/ExcludeMimeTypeTest.php
+++ b/test/File/ExcludeMimeTypeTest.php
@@ -6,18 +6,13 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\ExcludeMimeType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * ExcludeMimeType testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\ExcludeMimeType
- */
 final class ExcludeMimeTypeTest extends TestCase
 {
     /**
@@ -34,7 +29,7 @@ final class ExcludeMimeTypeTest extends TestCase
      *     3: array<string, string>
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile   = __DIR__ . '/_files/picture.jpg';
         $fileUpload = [
@@ -62,9 +57,9 @@ final class ExcludeMimeTypeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, array $isValidParam, bool $expected, array $messages): void
     {
         $validator = new ExcludeMimeType($options);
@@ -77,9 +72,9 @@ final class ExcludeMimeTypeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, array $isValidParam, bool $expected): void
     {
         $validator = new ExcludeMimeType($options);
@@ -89,7 +84,7 @@ final class ExcludeMimeTypeTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getMimeTypeProvider(): array
+    public static function getMimeTypeProvider(): array
     {
         return [
             ['image/gif', 'image/gif', false],
@@ -101,10 +96,10 @@ final class ExcludeMimeTypeTest extends TestCase
     /**
      * Ensures that getMimeType() returns expected value
      *
-     * @dataProvider getMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string|string[] $expected
      */
+    #[DataProvider('getMimeTypeProvider')]
     public function testGetMimeType($mimeType, $expected, bool $asArray): void
     {
         $validator = new ExcludeMimeType($mimeType);
@@ -113,7 +108,7 @@ final class ExcludeMimeTypeTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setMimeTypeProvider(): array
+    public static function setMimeTypeProvider(): array
     {
         return [
             ['image/jpeg', 'image/jpeg', ['image/jpeg']],
@@ -125,10 +120,10 @@ final class ExcludeMimeTypeTest extends TestCase
     /**
      * Ensures that setMimeType() returns expected value
      *
-     * @dataProvider setMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setMimeTypeProvider')]
     public function testSetMimeType($mimeType, string $expected, array $expectedAsArray): void
     {
         $validator = new ExcludeMimeType('image/gif');

--- a/test/File/ExistsTest.php
+++ b/test/File/ExistsTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Exists;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -15,10 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Exists
- */
 final class ExistsTest extends TestCase
 {
     /**
@@ -34,7 +32,7 @@ final class ExistsTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile   = __DIR__ . '/_files/testsize.mo';
         $baseDir    = dirname($testFile);
@@ -60,9 +58,9 @@ final class ExistsTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic(string $options, $isValidParam, bool $expected): void
     {
         $validator = new Exists($options);
@@ -73,9 +71,9 @@ final class ExistsTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy(string $options, $isValidParam, bool $expected): void
     {
         if (! is_array($isValidParam)) {
@@ -88,7 +86,7 @@ final class ExistsTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getDirectoryProvider(): array
+    public static function getDirectoryProvider(): array
     {
         return [
             ['C:/temp', 'C:/temp', false],
@@ -100,10 +98,10 @@ final class ExistsTest extends TestCase
     /**
      * Ensures that getDirectory() returns expected value
      *
-     * @dataProvider getDirectoryProvider
      * @param string|string[] $directory
      * @param string|string[] $expected
      */
+    #[DataProvider('getDirectoryProvider')]
     public function testGetDirectory($directory, $expected, bool $asArray): void
     {
         $validator = new Exists($directory);
@@ -112,7 +110,7 @@ final class ExistsTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setDirectoryProvider(): array
+    public static function setDirectoryProvider(): array
     {
         return [
             ['gif', 'gif', ['gif']],
@@ -124,10 +122,10 @@ final class ExistsTest extends TestCase
     /**
      * Ensures that setDirectory() returns expected value
      *
-     * @dataProvider setDirectoryProvider
      * @param string|string[] $directory
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setDirectoryProvider')]
     public function testSetDirectory($directory, string $expected, array $expectedAsArray): void
     {
         $validator = new Exists('temp');
@@ -164,9 +162,7 @@ final class ExistsTest extends TestCase
         self::assertSame(['temp', 'gif', 'jpg', 'to', 'zip', 'ti'], $validator->getDirectory(true));
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Exists(__DIR__);
@@ -207,7 +203,7 @@ final class ExistsTest extends TestCase
     }
 
     /** @psalm-return array<string, array{scalar|object|null}> */
-    public function invalidDirectoryArguments(): array
+    public static function invalidDirectoryArguments(): array
     {
         return [
             'null'       => [null],
@@ -222,9 +218,9 @@ final class ExistsTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidDirectoryArguments
      * @psalm-param scalar|object|null $value
      */
+    #[DataProvider('invalidDirectoryArguments')]
     public function testAddDirectoryShouldRaiseExceptionForInvalidArgument($value): void
     {
         $validator = new Exists();

--- a/test/File/ExtensionTest.php
+++ b/test/File/ExtensionTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Extension;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,10 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Extension
- */
 final class ExtensionTest extends TestCase
 {
     /**
@@ -35,7 +33,7 @@ final class ExtensionTest extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/testsize.mo';
         $pictureTests = [
@@ -74,10 +72,10 @@ final class ExtensionTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options,
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new Extension($options);
@@ -92,10 +90,10 @@ final class ExtensionTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options,
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -130,7 +128,7 @@ final class ExtensionTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string[]}> */
-    public function getExtensionProvider(): array
+    public static function getExtensionProvider(): array
     {
         return [
             ['mo', ['mo']],
@@ -141,10 +139,10 @@ final class ExtensionTest extends TestCase
     /**
      * Ensures that getExtension() returns expected value
      *
-     * @dataProvider getExtensionProvider
      * @param string|string[] $extension
      * @param string[] $expected
      */
+    #[DataProvider('getExtensionProvider')]
     public function testGetExtension($extension, array $expected): void
     {
         $validator = new Extension($extension);
@@ -153,7 +151,7 @@ final class ExtensionTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string[]}> */
-    public function setExtensionProvider(): array
+    public static function setExtensionProvider(): array
     {
         return [
             ['gif', ['gif']],
@@ -165,10 +163,10 @@ final class ExtensionTest extends TestCase
     /**
      * Ensures that setExtension() returns expected value
      *
-     * @dataProvider setExtensionProvider
      * @param string|string[] $extension
      * @param string[] $expected
      */
+    #[DataProvider('setExtensionProvider')]
     public function testSetExtension($extension, array $expected): void
     {
         $validator = new Extension('mo');
@@ -200,9 +198,7 @@ final class ExtensionTest extends TestCase
         self::assertSame(['mo', 'gif', 'jpg', 'to', 'zip', 'ti'], $validator->getExtension());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Extension('gif');

--- a/test/File/FileInformationTraitTest.php
+++ b/test/File/FileInformationTraitTest.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\UploadedFileInterface;
 use function basename;
 use function mime_content_type;
 
-/** @covers \Laminas\Validator\File\FileInformationTrait */
 final class FileInformationTraitTest extends TestCase
 {
     /** @var StreamInterface&MockObject */

--- a/test/File/FilesSizeTest.php
+++ b/test/File/FilesSizeTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\FilesSize;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -14,10 +15,6 @@ use function filesize;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\FilesSize
- */
 final class FilesSizeTest extends TestCase
 {
     public bool $multipleOptionsDetected;
@@ -32,9 +29,9 @@ final class FilesSizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicDataProvider
      * @param array|int $options
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic($options, bool $expected1, bool $expected2, bool $expected3): void
     {
         $validator = new FilesSize(...$options);
@@ -61,7 +58,7 @@ final class FilesSizeTest extends TestCase
      *     3: bool,
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable

--- a/test/File/FilesSizeTest.php
+++ b/test/File/FilesSizeTest.php
@@ -56,9 +56,9 @@ final class FilesSizeTest extends TestCase
     /**
      * @psalm-return array<string, array{
      *     0: array,
-     *     1: bool
-     *     2: bool
-     *     3: bool
+     *     1: bool,
+     *     2: bool,
+     *     3: bool,
      * }>
      */
     public function basicDataProvider(): array

--- a/test/File/HashTest.php
+++ b/test/File/HashTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Hash;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -17,12 +19,6 @@ use function sprintf;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * Hash testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Hash
- */
 final class HashTest extends TestCase
 {
     /**
@@ -39,7 +35,7 @@ final class HashTest extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
@@ -106,10 +102,10 @@ final class HashTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new Hash($options);
@@ -124,10 +120,10 @@ final class HashTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -144,7 +140,7 @@ final class HashTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], array<numeric, string>}> */
-    public function hashProvider(): array
+    public static function hashProvider(): array
     {
         return [
             ['12345', ['12345' => 'crc32']],
@@ -155,10 +151,10 @@ final class HashTest extends TestCase
     /**
      * Ensures that getHash() returns expected value
      *
-     * @dataProvider hashProvider
      * @param string|string[] $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('hashProvider')]
     public function testGetHash($hash, array $expected): void
     {
         $validator = new Hash($hash);
@@ -169,10 +165,10 @@ final class HashTest extends TestCase
     /**
      * Ensures that setHash() returns expected value
      *
-     * @dataProvider hashProvider
      * @param string|string[] $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('hashProvider')]
     public function testSetHash($hash, array $expected): void
     {
         $validator = new Hash('12333');
@@ -199,9 +195,7 @@ final class HashTest extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Hash('3f8d07e2');
@@ -233,7 +227,7 @@ final class HashTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidHashTypes(): array
+    public static function invalidHashTypes(): array
     {
         return [
             'null'       => [null],
@@ -247,9 +241,7 @@ final class HashTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidHashTypes
-     */
+    #[DataProvider('invalidHashTypes')]
     public function testAddHashRaisesExceptionForInvalidType(mixed $value): void
     {
         $validator = new Hash('12345');
@@ -294,9 +286,7 @@ final class HashTest extends TestCase
         self::assertSame($algorithm, $options['algorithm']);
     }
 
-    /**
-     * @dataProvider invalidHashTypes
-     */
+    #[DataProvider('invalidHashTypes')]
     public function testInvalidHashProvidedInArrayFormat(mixed $hash): void
     {
         $validator = new Hash('12345');

--- a/test/File/HashTest.php
+++ b/test/File/HashTest.php
@@ -288,8 +288,7 @@ final class HashTest extends TestCase
         $algorithm = 'md5';
         $validator = new Hash('12345', $algorithm);
 
-        $r = new ReflectionProperty($validator, 'options');
-        $r->setAccessible(true);
+        $r       = new ReflectionProperty($validator, 'options');
         $options = $r->getValue($validator);
 
         self::assertSame($algorithm, $options['algorithm']);

--- a/test/File/ImageSizeTest.php
+++ b/test/File/ImageSizeTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\ImageSize;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,10 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\ImageSize
- */
 final class ImageSizeTest extends TestCase
 {
     /**
@@ -35,7 +33,7 @@ final class ImageSizeTest extends TestCase
      *     3: string|string[]
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
@@ -131,10 +129,10 @@ final class ImageSizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $isValidParam
      * @param string|string[] $messageKeys
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic(array $options, $isValidParam, bool $expected, $messageKeys): void
     {
         $validator = new ImageSize($options);
@@ -155,10 +153,10 @@ final class ImageSizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array $isValidParam
      * @param string|string[] $messageKeys
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy(array $options, $isValidParam, bool $expected, $messageKeys): void
     {
         if (! is_array($isValidParam)) {
@@ -246,7 +244,7 @@ final class ImageSizeTest extends TestCase
     }
 
     /** @psalm-return array<array{array<string, int>, array<string, int>}> */
-    public function imageMaxProvider(): array
+    public static function imageMaxProvider(): array
     {
         return [
             [['maxWidth' => 100, 'maxHeight' => 100], ['maxWidth' => 100, 'maxHeight' => 100]],
@@ -259,10 +257,10 @@ final class ImageSizeTest extends TestCase
     /**
      * Ensures that setImageMax() returns expected value
      *
-     * @dataProvider imageMaxProvider
      * @param array<string, int> $imageMax
      * @param array<string, int> $expected
      */
+    #[DataProvider('imageMaxProvider')]
     public function testSetImageMax(array $imageMax, array $expected): void
     {
         $validator = new ImageSize([
@@ -343,9 +341,7 @@ final class ImageSizeTest extends TestCase
         $validator->setImageHeight(['minHeight' => 20000, 'maxHeight' => 200]);
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new ImageSize([

--- a/test/File/IsCompressedTest.php
+++ b/test/File/IsCompressedTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\File\IsCompressed;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -18,12 +20,6 @@ use function is_array;
 use const FILEINFO_MIME_TYPE;
 use const PHP_VERSION_ID;
 
-/**
- * IsCompressed testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\IsCompressed
- */
 final class IsCompressedTest extends TestCase
 {
     protected function getMagicMime(): string
@@ -44,7 +40,7 @@ final class IsCompressedTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile = __DIR__ . '/_files/test.zip';
 
@@ -113,10 +109,10 @@ final class IsCompressedTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param null|string|string[] $options
      * @psalm-param array<string, string|int> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, array $isValidParam, bool $expected): void
     {
         $this->skipIfNoFileInfoExtension();
@@ -131,10 +127,10 @@ final class IsCompressedTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param null|string|string[] $options
      * @psalm-param array<string, string|int> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, array $isValidParam, bool $expected): void
     {
         $this->skipIfNoFileInfoExtension();
@@ -147,7 +143,7 @@ final class IsCompressedTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getMimeTypeProvider(): array
+    public static function getMimeTypeProvider(): array
     {
         return [
             ['image/gif', 'image/gif', false],
@@ -159,10 +155,10 @@ final class IsCompressedTest extends TestCase
     /**
      * Ensures that getMimeType() returns expected value
      *
-     * @dataProvider getMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string|string[] $expected
      */
+    #[DataProvider('getMimeTypeProvider')]
     public function testGetMimeType($mimeType, $expected, bool $asArray): void
     {
         $validator = new IsCompressed($mimeType);
@@ -171,7 +167,7 @@ final class IsCompressedTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setMimeTypeProvider(): array
+    public static function setMimeTypeProvider(): array
     {
         return [
             ['image/jpeg', 'image/jpeg', ['image/jpeg']],
@@ -183,10 +179,10 @@ final class IsCompressedTest extends TestCase
     /**
      * Ensures that setMimeType() returns expected value
      *
-     * @dataProvider setMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setMimeTypeProvider')]
     public function testSetMimeType($mimeType, string $expected, array $expectedAsArray): void
     {
         $validator = new IsCompressed('image/gif');
@@ -284,9 +280,7 @@ final class IsCompressedTest extends TestCase
         self::assertNotEmpty($validator->getMimeType());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new IsCompressed();

--- a/test/File/IsImageTest.php
+++ b/test/File/IsImageTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\File\IsImage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -14,12 +16,6 @@ use function is_array;
 
 use const PHP_VERSION_ID;
 
-/**
- * IsImage testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\IsImage
- */
 final class IsImageTest extends TestCase
 {
     protected function getMagicMime(): string
@@ -30,7 +26,7 @@ final class IsImageTest extends TestCase
     /**
      * @psalm-return array<array{list<string>|string|null, array<string, string|int>, bool}>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile   = __DIR__ . '/_files/picture.jpg';
         $fileUpload = [
@@ -59,10 +55,10 @@ final class IsImageTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @psalm-param list<string>|string|null $options
      * @param array<string, string|int> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, array $isValidParam, bool $expected): void
     {
         $validator = new IsImage($options);
@@ -74,10 +70,10 @@ final class IsImageTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @psalm-param list<string>|string|null $options
      * @param array<string, string|int> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, array $isValidParam, bool $expected): void
     {
         if (is_array($isValidParam)) {
@@ -89,7 +85,7 @@ final class IsImageTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getMimeTypeProvider(): array
+    public static function getMimeTypeProvider(): array
     {
         return [
             ['image/gif', 'image/gif', false],
@@ -101,10 +97,10 @@ final class IsImageTest extends TestCase
     /**
      * Ensures that getMimeType() returns expected value
      *
-     * @dataProvider getMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string|string[] $expected
      */
+    #[DataProvider('getMimeTypeProvider')]
     public function testGetMimeType($mimeType, $expected, bool $asArray): void
     {
         $validator = new IsImage($mimeType);
@@ -113,7 +109,7 @@ final class IsImageTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setMimeTypeProvider(): array
+    public static function setMimeTypeProvider(): array
     {
         return [
             ['image/jpeg', 'image/jpeg', ['image/jpeg']],
@@ -125,10 +121,10 @@ final class IsImageTest extends TestCase
     /**
      * Ensures that setMimeType() returns expected value
      *
-     * @dataProvider setMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setMimeTypeProvider')]
     public function testSetMimeType($mimeType, string $expected, array $expectedAsArray): void
     {
         $validator = new IsImage('image/gif');
@@ -227,9 +223,7 @@ final class IsImageTest extends TestCase
         self::assertNotEmpty($validator->getMimeType());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new IsImage();

--- a/test/File/Md5Test.php
+++ b/test/File/Md5Test.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Md5;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,12 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * Md5 testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Md5
- */
 final class Md5Test extends TestCase
 {
     /**
@@ -37,7 +33,7 @@ final class Md5Test extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
@@ -100,10 +96,10 @@ final class Md5Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new Md5($options);
@@ -118,10 +114,10 @@ final class Md5Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -227,9 +223,7 @@ final class Md5Test extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Md5('12345');

--- a/test/File/MimeTypeTest.php
+++ b/test/File/MimeTypeTest.php
@@ -311,7 +311,6 @@ final class MimeTypeTest extends TestCase
         $validator->setMagicFile([]);
 
         $r = new ReflectionProperty($validator, 'options');
-        $r->setAccessible(true);
 
         $options = $r->getValue($validator);
 

--- a/test/File/MimeTypeTest.php
+++ b/test/File/MimeTypeTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Validator\File;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Exception\InvalidMagicMimeFileException;
 use Laminas\Validator\File\MimeType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -18,12 +20,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * MimeType testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\MimeType
- */
 final class MimeTypeTest extends TestCase
 {
     /**
@@ -39,7 +35,7 @@ final class MimeTypeTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile   = __DIR__ . '/_files/picture.jpg';
         $fileUpload = [
@@ -68,10 +64,10 @@ final class MimeTypeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected): void
     {
         $validator = new MimeType($options);
@@ -83,10 +79,10 @@ final class MimeTypeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected): void
     {
         if (is_array($isValidParam)) {
@@ -98,7 +94,7 @@ final class MimeTypeTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getMimeTypeProvider(): array
+    public static function getMimeTypeProvider(): array
     {
         return [
             ['image/gif', 'image/gif', false],
@@ -110,10 +106,10 @@ final class MimeTypeTest extends TestCase
     /**
      * Ensures that getMimeType() returns expected value
      *
-     * @dataProvider getMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string|string[] $expected
      */
+    #[DataProvider('getMimeTypeProvider')]
     public function testGetMimeType($mimeType, $expected, bool $asArray): void
     {
         $validator = new MimeType($mimeType);
@@ -122,7 +118,7 @@ final class MimeTypeTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setMimeTypeProvider(): array
+    public static function setMimeTypeProvider(): array
     {
         return [
             ['image/jpeg', 'image/jpeg', ['image/jpeg']],
@@ -134,10 +130,10 @@ final class MimeTypeTest extends TestCase
     /**
      * Ensures that setMimeType() returns expected value
      *
-     * @dataProvider setMimeTypeProvider
      * @param string|string[] $mimeType
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setMimeTypeProvider')]
     public function testSetMimeType($mimeType, string $expected, array $expectedAsArray): void
     {
         $validator = new MimeType('image/gif');
@@ -219,9 +215,7 @@ final class MimeTypeTest extends TestCase
         self::assertSame('image/gif,image/jpg', $validator->getMimeType());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new MimeType([
@@ -257,9 +251,7 @@ final class MimeTypeTest extends TestCase
         }
     }
 
-    /**
-     * @group Laminas-10461
-     */
+    #[Group('Laminas-10461')]
     public function testDisablingMagicFileByConstructor(): void
     {
         $files = [
@@ -320,7 +312,7 @@ final class MimeTypeTest extends TestCase
     /**
      * @psalm-return array<string, array{scalar|object|null}>
      */
-    public function invalidMimeTypeTypes(): array
+    public static function invalidMimeTypeTypes(): array
     {
         return [
             'null'       => [null],
@@ -335,9 +327,9 @@ final class MimeTypeTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidMimeTypeTypes
      * @psalm-param scalar|object|null $type
      */
+    #[DataProvider('invalidMimeTypeTypes')]
     public function testAddingMimeTypeWithInvalidTypeRaisesException($type): void
     {
         $validator = new MimeType();

--- a/test/File/NotExistsTest.php
+++ b/test/File/NotExistsTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\NotExists;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -13,12 +15,6 @@ use function current;
 use function dirname;
 use function is_array;
 
-/**
- * NotExists testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\NotExists
- */
 final class NotExistsTest extends TestCase
 {
     /**
@@ -34,7 +30,7 @@ final class NotExistsTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile   = __DIR__ . '/_files/testsize.mo';
         $baseDir    = dirname($testFile);
@@ -60,9 +56,9 @@ final class NotExistsTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array<string, mixed> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic(string $options, $isValidParam, bool $expected): void
     {
         $validator = new NotExists($options);
@@ -73,9 +69,9 @@ final class NotExistsTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|array<string, mixed> $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy(string $options, $isValidParam, bool $expected): void
     {
         if (! is_array($isValidParam)) {
@@ -88,7 +84,7 @@ final class NotExistsTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string|string[], bool}> */
-    public function getDirectoryProvider(): array
+    public static function getDirectoryProvider(): array
     {
         return [
             ['C:/temp', 'C:/temp', false],
@@ -100,10 +96,10 @@ final class NotExistsTest extends TestCase
     /**
      * Ensures that getDirectory() returns expected value
      *
-     * @dataProvider getDirectoryProvider
      * @param string|string[] $directory
      * @param string|string[] $expected
      */
+    #[DataProvider('getDirectoryProvider')]
     public function testGetDirectory($directory, $expected, bool $asArray): void
     {
         $validator = new NotExists($directory);
@@ -112,7 +108,7 @@ final class NotExistsTest extends TestCase
     }
 
     /** @psalm-return array<array{string|string[], string, string[]}> */
-    public function setDirectoryProvider(): array
+    public static function setDirectoryProvider(): array
     {
         return [
             ['gif', 'gif', ['gif']],
@@ -124,10 +120,10 @@ final class NotExistsTest extends TestCase
     /**
      * Ensures that setDirectory() returns expected value
      *
-     * @dataProvider setDirectoryProvider
      * @param string|string[] $directory
      * @param string[] $expectedAsArray
      */
+    #[DataProvider('setDirectoryProvider')]
     public function testSetDirectory($directory, string $expected, array $expectedAsArray): void
     {
         $validator = new NotExists('temp');
@@ -164,9 +160,7 @@ final class NotExistsTest extends TestCase
         self::assertSame(['temp', 'gif', 'jpg', 'to', 'zip', 'ti'], $validator->getDirectory(true));
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new NotExists();
@@ -190,7 +184,7 @@ final class NotExistsTest extends TestCase
     /**
      * @psalm-return array<string, array{scalar|object|null}>
      */
-    public function invalidDirectoryArguments(): array
+    public static function invalidDirectoryArguments(): array
     {
         return [
             'null'       => [null],
@@ -205,9 +199,9 @@ final class NotExistsTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidDirectoryArguments
      * @psalm-param scalar|object|null $value
      */
+    #[DataProvider('invalidDirectoryArguments')]
     public function testAddingDirectoryUsingInvalidTypeRaisesException($value): void
     {
         $validator = new NotExists();

--- a/test/File/Sha1Test.php
+++ b/test/File/Sha1Test.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Sha1;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -15,12 +17,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * Sha1 testbed
- *
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Sha1
- */
 final class Sha1Test extends TestCase
 {
     /**
@@ -37,7 +33,7 @@ final class Sha1Test extends TestCase
      *     3: string
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
@@ -83,10 +79,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected, string $messageKey): void
     {
         $validator = new Sha1($options);
@@ -101,10 +97,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param string|string[] $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected, string $messageKey): void
     {
         if (! is_array($isValidParam)) {
@@ -121,7 +117,7 @@ final class Sha1Test extends TestCase
     }
 
     /** @psalm-return array<array{string|list<string>, array<numeric, string>}> */
-    public function getHashProvider(): array
+    public static function getHashProvider(): array
     {
         return [
             ['12333', ['12333' => 'sha1']],
@@ -132,10 +128,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that getSha1() returns expected value
      *
-     * @dataProvider getHashProvider
      * @psalm-param string|list<string> $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('getHashProvider')]
     public function testGetSha1($hash, array $expected): void
     {
         $validator = new Sha1($hash);
@@ -146,10 +142,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that getHash() returns expected value
      *
-     * @dataProvider getHashProvider
      * @psalm-param string|list<string> $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('getHashProvider')]
     public function testGetHash($hash, array $expected): void
     {
         $validator = new Sha1($hash);
@@ -160,10 +156,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that setSha1() returns expected value
      *
-     * @dataProvider getHashProvider
      * @psalm-param string|list<string> $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('getHashProvider')]
     public function testSetSha1($hash, array $expected): void
     {
         $validator = new Sha1('12345');
@@ -175,10 +171,10 @@ final class Sha1Test extends TestCase
     /**
      * Ensures that setHash() returns expected value
      *
-     * @dataProvider getHashProvider
      * @psalm-param string|list<string> $hash
      * @psalm-param array<numeric, string> $expected
      */
+    #[DataProvider('getHashProvider')]
     public function testSetHash($hash, array $expected): void
     {
         $validator = new Sha1('12345');
@@ -223,9 +219,7 @@ final class Sha1Test extends TestCase
         );
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Sha1('12345');

--- a/test/File/SizeTest.php
+++ b/test/File/SizeTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Size;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -14,10 +16,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Size
- */
 final class SizeTest extends TestCase
 {
     /**
@@ -33,7 +31,7 @@ final class SizeTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile = __DIR__ . '/_files/testsize.mo';
         $testData = [
@@ -67,10 +65,10 @@ final class SizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param int|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected): void
     {
         $validator = new Size($options);
@@ -81,10 +79,10 @@ final class SizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param int|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected): void
     {
         if (! is_array($isValidParam)) {
@@ -160,7 +158,7 @@ final class SizeTest extends TestCase
     }
 
     /** @psalm-return array<array{string|int, string}> */
-    public function setMaxProvider(): array
+    public static function setMaxProvider(): array
     {
         return [
             [1_000_000, '976.56kB'],
@@ -179,9 +177,9 @@ final class SizeTest extends TestCase
     /**
      * Ensures that setMax() returns expected value
      *
-     * @dataProvider setMaxProvider
      * @param string|int $max
      */
+    #[DataProvider('setMaxProvider')]
     public function testSetMax($max, string $expected): void
     {
         $validator = new Size(['max' => 0, 'useByteString' => true]);
@@ -215,9 +213,7 @@ final class SizeTest extends TestCase
         self::assertStringContainsString('794', current($messages));
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Size(['min' => 1, 'max' => 10000]);
@@ -249,7 +245,7 @@ final class SizeTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidMinMaxValues(): array
+    public static function invalidMinMaxValues(): array
     {
         return [
             'null'   => [null],
@@ -260,9 +256,7 @@ final class SizeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSetMinWithInvalidArgument(mixed $value): void
     {
         $validator = new Size(['min' => 0, 'max' => 2000]);
@@ -273,9 +267,7 @@ final class SizeTest extends TestCase
         $validator->setMin($value);
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSetMaxWithInvalidArgument(mixed $value): void
     {
         $validator = new Size(['min' => 0, 'max' => 2000]);

--- a/test/File/TestAsset/FileInformation.php
+++ b/test/File/TestAsset/FileInformation.php
@@ -16,10 +16,10 @@ final class FileInformation
     /**
      * Returns array if the procedure is identified
      *
-     * @param  string|array|object $value    Filename to check
-     * @param  null|array          $file     File data (when using legacy Laminas_File_Transfer API)
-     * @param  bool                $hasType  Return with filetype (optional)
-     * @param  bool                $basename Return with basename - is calculated from location path (optional)
+     * @param  string|array|object $value       Filename to check
+     * @param  null|array          $file        File data (when using legacy Laminas_File_Transfer API)
+     * @param  bool                $hasType     Return with filetype (optional)
+     * @param  bool                $hasBasename Return with basename - is calculated from location path (optional)
      */
     public function checkFileInformation(
         $value,

--- a/test/File/UploadTest.php
+++ b/test/File/UploadTest.php
@@ -6,15 +6,14 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\Upload;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 
 use function current;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\Upload
- */
 final class UploadTest extends TestCase
 {
     /**
@@ -139,156 +138,59 @@ final class UploadTest extends TestCase
 
     /**
      * @psalm-return iterable<string, array{
-     *     0: array<string, UploadedFileInterface>,
+     *     0: int,
      *     1: string,
      *     2: string
      * }>
      */
-    public function invalidPsr7UploadedFiles(): iterable
+    public static function invalidPsr7UploadedFiles(): iterable
     {
-        $uploads = [];
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test2');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(1);
-
-        yield 'size' => [['test2' => $upload], 'test2', 'fileUploadErrorIniSize'];
-
-        $uploads['test2'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test3');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(2);
-
-        yield 'form-size' => [['test3' => $upload], 'test3', 'fileUploadErrorFormSize'];
-
-        $uploads['test3'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test4');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(3);
-
-        yield 'partial' => [['test4' => $upload], 'test4', 'fileUploadErrorPartial'];
-
-        $uploads['test4'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test5');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(4);
-
-        yield 'no-file' => [['test5' => $upload], 'test5', 'fileUploadErrorNoFile'];
-
-        $uploads['test5'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test6');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(5);
-
-        yield 'unknown' => [['test6' => $upload], 'test6', 'fileUploadErrorUnknown'];
-
-        $uploads['test6'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test7');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(6);
-
-        yield 'no-tmp-dir' => [['test7' => $upload], 'test7', 'fileUploadErrorNoTmpDir'];
-
-        $uploads['test7'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test8');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(7);
-
-        yield 'cannot write' => [['test8' => $upload], 'test8', 'fileUploadErrorCantWrite'];
-
-        $uploads['test8'] = $upload;
-
-        $upload = $this->createMock(UploadedFileInterface::class);
-        $upload
-            ->expects(self::any())
-            ->method('getClientFilename')
-            ->willReturn('test9');
-
-        $upload
-            ->expects(self::once())
-            ->method('getError')
-            ->willReturn(8);
-
-        yield 'extension' => [['test9' => $upload], 'test9', 'fileUploadErrorExtension'];
-
-        $uploads['test9'] = $upload;
-
-        yield 'not-found' => [$uploads, 'test000', 'fileUploadErrorFileNotFound'];
+        yield 'size' => [1, 'test2', 'fileUploadErrorIniSize'];
+        yield 'form-size' => [2, 'test3', 'fileUploadErrorFormSize'];
+        yield 'partial' => [3, 'test4', 'fileUploadErrorPartial'];
+        yield 'no-file' => [4, 'test5', 'fileUploadErrorNoFile'];
+        yield 'unknown' => [5, 'test6', 'fileUploadErrorUnknown'];
+        yield 'no-tmp-dir' => [6, 'test7', 'fileUploadErrorNoTmpDir'];
+        yield 'cannot write' => [7, 'test8', 'fileUploadErrorCantWrite'];
+        yield 'extension' => [8, 'test9', 'fileUploadErrorExtension'];
     }
 
     /**
      * Validate invalid PSR-7 file uploads
      *
      * Not testing lookup by temp file name since PSR does not expose it.
-     *
-     * @dataProvider invalidPsr7UploadedFiles
-     * @param UploadedFileInterface[] $files
-     * @param string $fileName
-     * @param string $expectedErrorKey
-     * @return void
      */
-    public function testRaisesExpectedErrorsForInvalidPsr7UploadedFileInput($files, $fileName, $expectedErrorKey)
-    {
+    #[DataProvider('invalidPsr7UploadedFiles')]
+    public function testRaisesExpectedErrorsForInvalidPsr7UploadedFileInput(
+        int $errorCode,
+        string $fileName,
+        string $expectedErrorKey
+    ): void {
+        $upload = $this->createMock(UploadedFileInterface::class);
+        $upload
+            ->expects(self::any())
+            ->method('getClientFilename')
+            ->willReturn($fileName);
+
+        $upload
+            ->expects(self::once())
+            ->method('getError')
+            ->willReturn($errorCode);
+
         $validator = new Upload();
-        $validator->setFiles($files);
+        $validator->setFiles([$fileName => $upload]);
 
         self::assertFalse($validator->isValid($fileName));
         self::assertArrayHasKey($expectedErrorKey, $validator->getMessages());
+    }
+
+    public function testFileNotFound(): void
+    {
+        $validator = new Upload();
+        $validator->setFiles([]);
+
+        self::assertFalse($validator->isValid('notThere'));
+        self::assertArrayHasKey('fileUploadErrorFileNotFound', $validator->getMessages());
     }
 
     public function testCanValidateCorrectlyFormedPsr7UploadedFiles(): void
@@ -395,9 +297,7 @@ final class UploadTest extends TestCase
         return $validator;
     }
 
-    /**
-     * @depends testGetFilesReturnsArtifactsFromPsr7UploadedFiles
-     */
+    #[Depends('testGetFilesReturnsArtifactsFromPsr7UploadedFiles')]
     public function testGetFilesRaisesExceptionWhenPsr7UploadedFilesArrayDoesNotContainGivenFilename(
         Upload $validator
     ): void {
@@ -469,9 +369,7 @@ final class UploadTest extends TestCase
         self::assertSame($psrFiles, $validator->getFiles());
     }
 
-    /**
-     * @group Laminas-10738
-     */
+    #[Group('Laminas-10738')]
     public function testGetFilesReturnsEmptyArrayWhenFilesSuperglobalIsNull(): void
     {
         $_FILES    = null;
@@ -481,9 +379,7 @@ final class UploadTest extends TestCase
         self::assertSame([], $validator->getFiles());
     }
 
-    /**
-     * @group Laminas-10738
-     */
+    #[Group('Laminas-10738')]
     public function testGetFilesReturnsEmptyArrayAfterSetFilesIsCalledWithNull(): void
     {
         $validator = new Upload();
@@ -492,9 +388,7 @@ final class UploadTest extends TestCase
         self::assertSame([], $validator->getFiles());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new Upload();
@@ -504,9 +398,7 @@ final class UploadTest extends TestCase
         self::assertStringContainsString("nofile.mo'", current($validator->getMessages()));
     }
 
-    /**
-     * @group Laminas-12128
-     */
+    #[Group('Laminas-12128')]
     public function testErrorMessage(): void
     {
         $_FILES = [

--- a/test/File/WordCountTest.php
+++ b/test/File/WordCountTest.php
@@ -6,6 +6,8 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\WordCount;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
@@ -14,10 +16,6 @@ use function is_array;
 
 use const UPLOAD_ERR_NO_FILE;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\File\WordCount
- */
 final class WordCountTest extends TestCase
 {
     /**
@@ -33,7 +31,7 @@ final class WordCountTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicBehaviorDataProvider(): array
+    public static function basicBehaviorDataProvider(): array
     {
         $testFile = __DIR__ . '/_files/wordcount.txt';
         $testData = [
@@ -62,10 +60,10 @@ final class WordCountTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param int|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testBasic($options, $isValidParam, bool $expected): void
     {
         $validator = new WordCount($options);
@@ -76,10 +74,10 @@ final class WordCountTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
      *
-     * @dataProvider basicBehaviorDataProvider
      * @param int|array $options
      * @param string|array $isValidParam
      */
+    #[DataProvider('basicBehaviorDataProvider')]
     public function testLegacy($options, $isValidParam, bool $expected): void
     {
         if (! is_array($isValidParam)) {
@@ -151,9 +149,7 @@ final class WordCountTest extends TestCase
         self::assertSame(1_000_000, $validator->getMax());
     }
 
-    /**
-     * @group Laminas-11258
-     */
+    #[Group('Laminas-11258')]
     public function testLaminas11258(): void
     {
         $validator = new WordCount(['min' => 1, 'max' => 10000]);
@@ -196,7 +192,7 @@ final class WordCountTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidMinMaxValues(): array
+    public static function invalidMinMaxValues(): array
     {
         return [
             'null'               => [null],
@@ -208,9 +204,7 @@ final class WordCountTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSettingMinValueRaisesExceptionForInvalidType(mixed $value): void
     {
         $validator = new WordCount(['min' => 1000, 'max' => 10000]);
@@ -232,9 +226,7 @@ final class WordCountTest extends TestCase
         self::assertSame($maxValue, $validator->getMax());
     }
 
-    /**
-     * @dataProvider invalidMinMaxValues
-     */
+    #[DataProvider('invalidMinMaxValues')]
     public function testSettingMaxValueRaisesExceptionForInvalidType(mixed $value): void
     {
         $validator = new WordCount(['min' => 1000, 'max' => 10000]);

--- a/test/GPSPointTest.php
+++ b/test/GPSPointTest.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\GpsPoint;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\GpsPoint
- */
 final class GPSPointTest extends TestCase
 {
     private GpsPoint $validator;
@@ -22,17 +19,14 @@ final class GPSPointTest extends TestCase
         $this->validator = new GpsPoint();
     }
 
-    /**
-     * @dataProvider basicDataProvider
-     * @covers \Laminas\Validator\GPSPoint::isValid
-     */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(string $gpsPoint): void
     {
         self::assertTrue($this->validator->isValid($gpsPoint));
     }
 
     /** @psalm-return array<array-key, array{0: string, 1: bool}> */
-    public function boundariesProvider(): array
+    public static function boundariesProvider(): array
     {
         return [
             ['181.8897,-77.0089', false],
@@ -42,19 +36,13 @@ final class GPSPointTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Laminas\Validator\GPSPoint::isValid
-     * @dataProvider boundariesProvider
-     */
+    #[DataProvider('boundariesProvider')]
     public function testBoundariesAreRespected(string $value, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($value));
     }
 
-    /**
-     * @covers \Laminas\Validator\GPSPoint::isValid
-     * @dataProvider errorMessageTestValues
-     */
+    #[DataProvider('errorMessageTestValues')]
     public function testErrorsSetOnOccur(string $value, string $messageKey, string $messageValue): void
     {
         self::assertFalse($this->validator->isValid($value));
@@ -68,7 +56,7 @@ final class GPSPointTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string}>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             ['38° 53\' 23" N, 77° 00\' 32" W'],
@@ -82,7 +70,7 @@ final class GPSPointTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: string, 2: string}>
      */
-    public function errorMessageTestValues(): array
+    public static function errorMessageTestValues(): array
     {
         return [
             ['63 47 24.691 N, 18 2 54.363 W', GpsPoint::OUT_OF_BOUNDS, '63 47 24.691 N'],

--- a/test/GreaterThanTest.php
+++ b/test/GreaterThanTest.php
@@ -5,22 +5,19 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\GreaterThan;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\GreaterThan
- */
 final class GreaterThanTest extends TestCase
 {
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicDataProvider
      * @param int|string $input
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(array $options, $input, bool $expected): void
     {
         $validator = new GreaterThan(...$options);
@@ -35,7 +32,7 @@ final class GreaterThanTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable
@@ -155,9 +152,7 @@ final class GreaterThanTest extends TestCase
         self::assertSame(array_keys($messageVariables), $validator->getMessageVariables());
     }
 
-    /**
-     * @dataProvider correctInclusiveMessageDataProvider
-     */
+    #[DataProvider('correctInclusiveMessageDataProvider')]
     public function testCorrectInclusiveMessageReturn(float $input): void
     {
         $validator = new GreaterThan(10);
@@ -172,7 +167,7 @@ final class GreaterThanTest extends TestCase
      * @psalm-return array{0: array{0: 0}, '0.5': array{0: float}, 5: array{0: 5}, 10: array{0: 10}}
      * @return (float|int)[][]
      */
-    public function correctInclusiveMessageDataProvider(): array
+    public static function correctInclusiveMessageDataProvider(): array
     {
         return [
             '0'   => [0],
@@ -182,9 +177,7 @@ final class GreaterThanTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider correctNotInclusiveMessageDataProvider
-     */
+    #[DataProvider('correctNotInclusiveMessageDataProvider')]
     public function testCorrectNotInclusiveMessageReturn(float $input): void
     {
         $validator = new GreaterThan(['min' => 10, 'inclusive' => true]);
@@ -199,7 +192,7 @@ final class GreaterThanTest extends TestCase
      * @psalm-return array{0: array{0: 0}, '0.5': array{0: float}, 5: array{0: 5}, 9: array{0: 9}}
      * @return (float|int)[][]
      */
-    public function correctNotInclusiveMessageDataProvider(): array
+    public static function correctNotInclusiveMessageDataProvider(): array
     {
         return [
             '0'   => [0],

--- a/test/HexTest.php
+++ b/test/HexTest.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\Hex;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Hex
- */
 final class HexTest extends TestCase
 {
     private Hex $validator;
@@ -27,9 +24,9 @@ final class HexTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicDataProvider
      * @param int|string $input
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic($input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
@@ -41,7 +38,7 @@ final class HexTest extends TestCase
      *     1: bool
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Validator;
 use Laminas\Validator\Hostname;
 use LaminasTest\Validator\TestAsset\ArrayTranslator;
 use LaminasTest\Validator\TestAsset\Translator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_key_exists;
@@ -17,10 +19,6 @@ use function ini_get;
 use function ini_set;
 use function sprintf;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Hostname
- */
 final class HostnameTest extends TestCase
 {
     /**
@@ -50,9 +48,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider basicDataProvider
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(int $option, bool $expected, string $hostname): void
     {
         $validator = new Hostname($option);
@@ -61,7 +58,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             'allow-ip succeeds for 1.2.3.4'                  => [Hostname::ALLOW_IP, true, '1.2.3.4'],
@@ -89,9 +86,7 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider combinationDataProvider
-     */
+    #[DataProvider('combinationDataProvider')]
     public function testCombination(int $option, bool $expected, string $hostname): void
     {
         $validator = new Hostname($option);
@@ -100,7 +95,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
-    public function combinationDataProvider(): array
+    public static function combinationDataProvider(): array
     {
         return [
             'dns or local succeeds for domain.com'      => [Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL, true, 'domain.com'],
@@ -117,9 +112,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure the dash character tests work as expected
-     *
-     * @dataProvider dashesDataProvider
      */
+    #[DataProvider('dashesDataProvider')]
     public function testDashes(int $option, bool $expected, string $hostname): void
     {
         $validator = new Hostname($option);
@@ -128,7 +122,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
-    public function dashesDataProvider(): array
+    public static function dashesDataProvider(): array
     {
         return [
             'allow-dns succeeds for domain.com'  => [Hostname::ALLOW_DNS, true, 'domain.com'],
@@ -142,9 +136,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure the underscore character tests work as expected
-     *
-     * @dataProvider domainsWithUnderscores
      */
+    #[DataProvider('domainsWithUnderscores')]
     public function testValidatorHandlesUnderscoresInDomainsCorrectly(string $input, bool $expected): void
     {
         $validator = new Hostname(Hostname::ALLOW_DNS);
@@ -153,7 +146,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: string, 1: bool}> */
-    public function domainsWithUnderscores(): array
+    public static function domainsWithUnderscores(): array
     {
         return [
             'subdomain with leading underscore'    => ['_subdomain.domain.com', true],
@@ -168,9 +161,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure the underscore character tests work as expected when not using tld check
-     *
-     * @dataProvider domainsWithUnderscores
      */
+    #[DataProvider('domainsWithUnderscores')]
     public function testValidatorHandlesUnderscoresInDomainsWithoutTldCheckCorrectly(string $input, bool $expected): void
     {
         $validator = new Hostname([
@@ -189,16 +181,14 @@ final class HostnameTest extends TestCase
         self::assertSame([], $this->validator->getMessages());
     }
 
-    /**
-     * @dataProvider idnMatchingDataProvider
-     */
+    #[DataProvider('idnMatchingDataProvider')]
     public function testIdnMatching(string $input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
     }
 
     /** @psalm-return array<array-key, array{0: string, 1: bool}> */
-    public function idnMatchingDataProvider(): array
+    public static function idnMatchingDataProvider(): array
     {
         return [
             ['bürger.de', true],
@@ -224,9 +214,7 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider idnNoMatchingDataProvider
-     */
+    #[DataProvider('idnNoMatchingDataProvider')]
     public function testIdnNoMatching(string $input): void
     {
         $this->validator->useIdnCheck(false);
@@ -236,9 +224,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Check setting no IDN matching via constructor
-     *
-     * @dataProvider idnNoMatchingDataProvider
      */
+    #[DataProvider('idnNoMatchingDataProvider')]
     public function testIdnNoMatchingOptionConstructor(string $input): void
     {
         $validator = new Hostname(Hostname::ALLOW_DNS, false);
@@ -247,7 +234,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: string}> */
-    public function idnNoMatchingDataProvider(): array
+    public static function idnNoMatchingDataProvider(): array
     {
         return [
             ['bürger.de'],
@@ -259,16 +246,14 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider tldMatchingDataProvider
-     */
+    #[DataProvider('tldMatchingDataProvider')]
     public function testTldMatching(string $input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
     }
 
     /** @psalm-return array<array-key, array{0: string, 1: bool}> */
-    public function tldMatchingDataProvider(): array
+    public static function tldMatchingDataProvider(): array
     {
         return [
             ['domain.co.uk', true],
@@ -281,9 +266,7 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider tldNoMatchingDataProvider
-     */
+    #[DataProvider('tldNoMatchingDataProvider')]
     public function testTldNoMatching(string $input): void
     {
         $this->validator->useTldCheck(false);
@@ -293,9 +276,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Check setting no TLD matching via constructor
-     *
-     * @dataProvider tldNoMatchingDataProvider
      */
+    #[DataProvider('tldNoMatchingDataProvider')]
     public function testTldNoMatchingOptionConstructor(string $input): void
     {
         $validator = new Hostname(Hostname::ALLOW_DNS, true, false);
@@ -304,7 +286,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: string}> */
-    public function tldNoMatchingDataProvider(): array
+    public static function tldNoMatchingDataProvider(): array
     {
         return [
             ['domain.xx'],
@@ -323,10 +305,9 @@ final class HostnameTest extends TestCase
 
     /**
      * Test changed with Laminas-6676, as IP check is only involved when IP patterns match
-     *
-     * @group Laminas-2861
-     * @group Laminas-6676
      */
+    #[Group('Laminas-2861')]
+    #[Group('Laminas-6676')]
     public function testValidatorMessagesShouldBeTranslated(): void
     {
         if (! extension_loaded('intl')) {
@@ -358,10 +339,8 @@ final class HostnameTest extends TestCase
         self::assertSame($translations[$code], $message);
     }
 
-    /**
-     * @group Laminas-6033
-     * @dataProvider numberNamesDataProvider
-     */
+    #[DataProvider('numberNamesDataProvider')]
+    #[Group('Laminas-6033')]
     public function testNumberNames(string $input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
@@ -370,7 +349,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function numberNamesDataProvider(): array
+    public static function numberNamesDataProvider(): array
     {
         return [
             ['www.danger1.com', true],
@@ -382,10 +361,8 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @group Laminas-6133
-     * @dataProvider punyCodeDecodingDataProvider
-     */
+    #[DataProvider('punyCodeDecodingDataProvider')]
+    #[Group('Laminas-6133')]
     public function testPunycodeDecoding(string $input, bool $expected): void
     {
         self::assertSame($expected, $this->validator->isValid($input));
@@ -394,7 +371,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function punyCodeDecodingDataProvider(): array
+    public static function punyCodeDecodingDataProvider(): array
     {
         return [
             ['xn--brger-kva.com', true],
@@ -414,7 +391,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: string}> */
-    public function invalidLatinSpecialCharsProvider(): array
+    public static function invalidLatinSpecialCharsProvider(): array
     {
         return [
             ['place@yah&oo.com'],
@@ -425,17 +402,15 @@ final class HostnameTest extends TestCase
 
     /**
      * @Laminas-7323
-     * @dataProvider invalidLatinSpecialCharsProvider
      */
+    #[DataProvider('invalidLatinSpecialCharsProvider')]
     public function testLatinSpecialChars(string $input): void
     {
         self::assertFalse($this->validator->isValid($input));
     }
 
-    /**
-     * @group Laminas-7277
-     * @dataProvider differentIconvEncodingDataProvider
-     */
+    #[DataProvider('differentIconvEncodingDataProvider')]
+    #[Group('Laminas-7277')]
     public function testDifferentIconvEncoding(string $input, bool $expected): void
     {
         ini_set('default_charset', 'ISO8859-1');
@@ -446,7 +421,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function differentIconvEncodingDataProvider(): array
+    public static function differentIconvEncodingDataProvider(): array
     {
         return [
             ['bürger.com', true],
@@ -469,10 +444,8 @@ final class HostnameTest extends TestCase
         self::assertFalse($this->validator->isValid('test.com / http://www.test.com'));
     }
 
-    /**
-     * @group Laminas-10267
-     * @dataProvider uriDataProvider
-     */
+    #[DataProvider('uriDataProvider')]
+    #[Group('Laminas-10267')]
     public function testURI(string $input, bool $expected): void
     {
         $validator = new Hostname(Hostname::ALLOW_URI);
@@ -483,7 +456,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function uriDataProvider(): array
+    public static function uriDataProvider(): array
     {
         return [
             ['localhost', true],
@@ -499,10 +472,9 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure that a trailing "." in a local hostname is permitted
-     *
-     * @group Laminas-6363
-     * @dataProvider trailingDotDataProvider
      */
+    #[DataProvider('trailingDotDataProvider')]
+    #[Group('Laminas-6363')]
     public function testTrailingDot(int $option, bool $expected, string $hostname): void
     {
         $validator = new Hostname($option);
@@ -511,7 +483,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<string, array{0: int, 1: bool, 2: string}> */
-    public function trailingDotDataProvider(): array
+    public static function trailingDotDataProvider(): array
     {
         return [
             'allow-all succeeds for example.'       => [Hostname::ALLOW_ALL, true, 'example.'],
@@ -526,9 +498,7 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @group Laminas-11334
-     */
+    #[Group('Laminas-11334')]
     public function testSupportsIpv6AddressesWhichContainHexDigitF(): void
     {
         $validator = new Hostname(Hostname::ALLOW_ALL);
@@ -544,9 +514,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Test extended greek charset
-     *
-     * @group Laminas-11751
      */
+    #[Group('Laminas-11751')]
     public function testExtendedGreek(): void
     {
         $validator = new Hostname(Hostname::ALLOW_ALL);
@@ -555,7 +524,7 @@ final class HostnameTest extends TestCase
     }
 
     /** @psalm-return array<array-key, array{0: string, 1: bool}> */
-    public function idnsiProvider(): array
+    public static function idnsiProvider(): array
     {
         return [
             ['Test123.si', true],
@@ -566,10 +535,8 @@ final class HostnameTest extends TestCase
         ];
     }
 
-    /**
-     * @group Laminas-11796
-     * @dataProvider idnsiProvider
-     */
+    #[DataProvider('idnsiProvider')]
+    #[Group('Laminas-11796')]
     public function testIDNSI(string $value, bool $expected): void
     {
         $validator = new Hostname(Hostname::ALLOW_ALL);
@@ -577,10 +544,8 @@ final class HostnameTest extends TestCase
         self::assertSame($expected, $validator->isValid($value));
     }
 
-    /**
-     * @group Issue #5894 - Add .il IDN domain checking; add new TLDs
-     * @dataProvider idnilDataProvider
-     */
+    #[DataProvider('idnilDataProvider')]
+    #[Group('Issue #5894 - Add .il IDN domain checking; add new TLDs')]
     public function testIDNIL(string $input, bool $expected): void
     {
         $validator = new Hostname(Hostname::ALLOW_ALL);
@@ -591,7 +556,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function idnilDataProvider(): array
+    public static function idnilDataProvider(): array
     {
         return [
             ['xn----zhcbgfhe2aacg8fb5i.org.il', true],
@@ -604,9 +569,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for UTF-8 and Punycoded (ACE) TLDs
-     *
-     * @dataProvider validTLDHostnames
      */
+    #[DataProvider('validTLDHostnames')]
     public function testValidTLDHostnames(string $value): void
     {
         self::assertTrue(
@@ -622,7 +586,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function validTLDHostnames(): array
+    public static function validTLDHostnames(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -636,9 +600,8 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior for invalid UTF-8 and Punycoded (ACE) TLDs
-     *
-     * @dataProvider invalidTLDHostnames
      */
+    #[DataProvider('invalidTLDHostnames')]
     public function testInvalidTLDHostnames(string $value): void
     {
         self::assertFalse($this->validator->isValid($value));
@@ -647,7 +610,7 @@ final class HostnameTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function invalidTLDHostnames(): array
+    public static function invalidTLDHostnames(): array
     {
         // @codingStandardsIgnoreStart
         return [

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -6,22 +6,20 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Iban as IbanValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function array_merge;
 use function implode;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Iban
- */
 final class IbanTest extends TestCase
 {
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function ibanDataProvider(): array
+    public static function ibanDataProvider(): array
     {
         return [
             ['AD1200012030200359100100', true],
@@ -99,9 +97,8 @@ final class IbanTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider ibanDataProvider
      */
+    #[DataProvider('ibanDataProvider')]
     public function testBasic(string $iban, bool $expected): void
     {
         $validator = new IbanValidator();
@@ -160,9 +157,7 @@ final class IbanTest extends TestCase
         self::assertFalse($validator->isValid('US611904300234573201'));
     }
 
-    /**
-     * @group Laminas-10556
-     */
+    #[Group('Laminas-10556')]
     public function testIbanDetectionWithoutCountryCode(): void
     {
         $validator = new IbanValidator();
@@ -197,7 +192,7 @@ final class IbanTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidValues(): array
+    public static function invalidValues(): array
     {
         return [
             'null'       => [null],
@@ -212,9 +207,7 @@ final class IbanTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidValues
-     */
+    #[DataProvider('invalidValues')]
     public function testIsValidReturnsFalseForNonStringValue(mixed $value): void
     {
         $validator = new IbanValidator();

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -219,6 +219,7 @@ final class IbanTest extends TestCase
     {
         $validator = new IbanValidator();
 
-        self::assertFalse($validator->isValid([]));
+        /** @psalm-suppress MixedArgument */
+        self::assertFalse($validator->isValid($value));
     }
 }

--- a/test/IdenticalTest.php
+++ b/test/IdenticalTest.php
@@ -7,15 +7,13 @@ namespace LaminasTest\Validator;
 use Laminas\Stdlib\Parameters;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Identical;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Identical
- */
 final class IdenticalTest extends TestCase
 {
     private Identical $validator;
@@ -85,9 +83,7 @@ final class IdenticalTest extends TestCase
         self::assertTrue($this->validator->isValid('foo'));
     }
 
-    /**
-     * @group Laminas-6953
-     */
+    #[Group('Laminas-6953')]
     public function testValidatingAgainstEmptyToken(): void
     {
         $this->validator->setToken('');
@@ -95,9 +91,7 @@ final class IdenticalTest extends TestCase
         self::assertTrue($this->validator->isValid(''));
     }
 
-    /**
-     * @group Laminas-7128
-     */
+    #[Group('Laminas-7128')]
     public function testValidatingAgainstNonStrings(): void
     {
         $this->validator->setToken(true);
@@ -276,9 +270,7 @@ final class IdenticalTest extends TestCase
         ));
     }
 
-    /**
-     * @dataProvider invalidContextProvider
-     */
+    #[DataProvider('invalidContextProvider')]
     public function testIsValidThrowsExceptionOnInvalidContext(mixed $context): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -289,7 +281,7 @@ final class IdenticalTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function invalidContextProvider(): array
+    public static function invalidContextProvider(): array
     {
         return [
             [false],

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -6,16 +6,14 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\InArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
 use const PHP_MAJOR_VERSION;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\InArray
- */
 final class InArrayTest extends TestCase
 {
     private InArray $validator;
@@ -34,7 +32,7 @@ final class InArrayTest extends TestCase
     /**
      * @return array<string,array{0:list<mixed>,1:mixed,2:mixed}>
      */
-    public function nonStrictValidationSet(): array
+    public static function nonStrictValidationSet(): array
     {
         return [
             'strings'             => [
@@ -63,7 +61,7 @@ final class InArrayTest extends TestCase
     /**
      * @return array<string,array{0:list<mixed>,1:mixed,2:mixed}>
      */
-    public function strictValidationSet(): array
+    public static function strictValidationSet(): array
     {
         return [
             'strings'             => [
@@ -147,9 +145,7 @@ final class InArrayTest extends TestCase
         self::assertSame([1, 'a', 2.3], $this->validator->getHaystack());
     }
 
-    /**
-     * @group Laminas-337
-     */
+    #[Group('Laminas-337')]
     public function testSettingNewStrictMode(): void
     {
         $validator = new InArray(
@@ -443,8 +439,8 @@ final class InArrayTest extends TestCase
      * @link https://github.com/laminas/laminas-validator/issues/81
      *
      * @param list<mixed> $haystack
-     * @dataProvider strictValidationSet
      */
+    #[DataProvider('strictValidationSet')]
     public function testBooleanStrictEnforcesStrictMode(array $haystack, mixed $valid, mixed $invalid): void
     {
         $validator = new InArray([
@@ -460,8 +456,8 @@ final class InArrayTest extends TestCase
      * @link https://github.com/laminas/laminas-validator/issues/81
      *
      * @param list<mixed> $haystack
-     * @dataProvider nonStrictValidationSet
      */
+    #[DataProvider('nonStrictValidationSet')]
     public function testBooleanNotStrictEnforcesNonStrictMode(array $haystack, mixed $valid, mixed $invalid): void
     {
         $validator = new InArray([

--- a/test/IpTest.php
+++ b/test/IpTest.php
@@ -6,14 +6,13 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Ip;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Ip
- */
 final class IpTest extends TestCase
 {
     private Ip $validator;
@@ -114,7 +113,7 @@ final class IpTest extends TestCase
      *     1: bool
      * }>
      */
-    public function ipvFutureProvider(): array
+    public static function ipvFutureProvider(): array
     {
         return [
             'IPvFuture: Version 1 disallowed'  => ['v1.A', true],
@@ -127,10 +126,9 @@ final class IpTest extends TestCase
 
     /**
      * Versions 4 and 6 are not allowed in IPvFuture
-     *
-     * @depends testOnlyIpvfuture
-     * @dataProvider ipvFutureProvider
      */
+    #[DataProvider('ipvFutureProvider')]
+    #[Depends('testOnlyIpvfuture')]
     public function testVersionsAllowedIpvfuture(string $ip, bool $expected): void
     {
         $this->options['allowipvfuture'] = true;
@@ -157,10 +155,8 @@ final class IpTest extends TestCase
         self::assertFalse($this->validator->isValid('192.168.0.2 adfs'));
     }
 
-    /**
-     * @group Laminas-2694
-     * @group Laminas-8253
-     */
+    #[Group('Laminas-2694')]
+    #[Group('Laminas-8253')]
     public function testIPv6addresses(): void
     {
         $ips = [
@@ -261,9 +257,7 @@ final class IpTest extends TestCase
         self::assertFalse($this->validator->isValid("::C0A8:2\n"));
     }
 
-    /**
-     * @group Laminas-10621
-     */
+    #[Group('Laminas-10621')]
     public function testIPv4AddressNotations(): void
     {
         $ips = [
@@ -299,9 +293,7 @@ final class IpTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider iPvFutureAddressesProvider
-     */
+    #[DataProvider('iPvFutureAddressesProvider')]
     public function testIPvFutureAddresses(string $ip, bool $expected): void
     {
         $this->options['allowipvfuture'] = true;
@@ -314,7 +306,7 @@ final class IpTest extends TestCase
     /**
      * @psalm-return array<array-key, array{0: string, 1: bool}>
      */
-    public function iPvFutureAddressesProvider(): array
+    public static function iPvFutureAddressesProvider(): array
     {
         return [
             ["[v1.09azAZ-._~!$&'()*+,;=:]:80", false],
@@ -381,7 +373,7 @@ final class IpTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function invalidIpV4Addresses(): array
+    public static function invalidIpV4Addresses(): array
     {
         return [
             'all-numeric'          => ['111111111111'],
@@ -394,9 +386,7 @@ final class IpTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidIpV4Addresses
-     */
+    #[DataProvider('invalidIpV4Addresses')]
     public function testIpV4ValidationShouldFailForIpV4AddressesMissingQuartets(string $address): void
     {
         self::assertFalse($this->validator->isValid($address));

--- a/test/IsCountableTest.php
+++ b/test/IsCountableTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception;
 use Laminas\Validator\IsCountable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SplQueue;
 use stdClass;
@@ -14,13 +15,12 @@ use function json_encode;
 
 use const JSON_THROW_ON_ERROR;
 
-/** @covers \Laminas\Validator\IsCountable */
 final class IsCountableTest extends TestCase
 {
     /**
      * @psalm-return array<string, array{0: array<string, mixed>}>
      */
-    public function conflictingOptionsProvider(): array
+    public static function conflictingOptionsProvider(): array
     {
         return [
             'count-min' => [['count' => 10, 'min' => 1]],
@@ -28,9 +28,7 @@ final class IsCountableTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider conflictingOptionsProvider
-     */
+    #[DataProvider('conflictingOptionsProvider')]
     public function testConstructorRaisesExceptionWhenProvidedConflictingOptions(array $options): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -42,7 +40,7 @@ final class IsCountableTest extends TestCase
     /**
      * @psalm-return array<string, array{0: array<string, mixed>, 1: array<string, mixed>}>
      */
-    public function conflictingSecondaryOptionsProvider(): array
+    public static function conflictingSecondaryOptionsProvider(): array
     {
         return [
             'count-min' => [['count' => 10], ['min' => 1]],
@@ -50,9 +48,7 @@ final class IsCountableTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider conflictingSecondaryOptionsProvider
-     */
+    #[DataProvider('conflictingSecondaryOptionsProvider')]
     public function testSetOptionsRaisesExceptionWhenProvidedOptionConflictingWithCurrentSettings(
         array $originalOptions,
         array $secondaryOptions

--- a/test/IsInstanceOfTest.php
+++ b/test/IsInstanceOfTest.php
@@ -66,7 +66,6 @@ final class IsInstanceOfTest extends TestCase
         $reflection = new ReflectionClass($validator);
 
         $property = $reflection->getProperty('messageTemplates');
-        $property->setAccessible(true);
 
         self::assertSame(
             $property->getValue($validator),
@@ -80,7 +79,6 @@ final class IsInstanceOfTest extends TestCase
         $reflection = new ReflectionClass($validator);
 
         $property = $reflection->getProperty('messageVariables');
-        $property->setAccessible(true);
 
         self::assertSame(
             $property->getValue($validator),

--- a/test/IsInstanceOfTest.php
+++ b/test/IsInstanceOfTest.php
@@ -12,10 +12,6 @@ use Laminas\Validator\IsInstanceOf;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-/**
- * @covers \Laminas\Validator\IsInstanceOf
- * @group Laminas_Validator
- */
 final class IsInstanceOfTest extends TestCase
 {
     /**

--- a/test/IsJsonStringTest.php
+++ b/test/IsJsonStringTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Validator;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\IsJsonString;
 use Laminas\Validator\ValidatorPluginManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function json_encode;
@@ -21,7 +22,7 @@ class IsJsonStringTest extends TestCase
      *     3: IsJsonString::ERROR_*|null,
      * }>
      */
-    public function allowProvider(): array
+    public static function allowProvider(): array
     {
         // phpcs:disable Generic.Files.LineLength
         return [
@@ -46,8 +47,8 @@ class IsJsonStringTest extends TestCase
     /**
      * @param int-mask-of<IsJsonString::ALLOW_*> $allowed
      * @param IsJsonString::ERROR_*|null $expectedErrorKey
-     * @dataProvider allowProvider
      */
+    #[DataProvider('allowProvider')]
     public function testBasicBehaviour(int $allowed, string $input, bool $expect, string|null $expectedErrorKey): void
     {
         $validator = new IsJsonString();
@@ -60,7 +61,7 @@ class IsJsonStringTest extends TestCase
     }
 
     /** @return list<array{0: mixed}> */
-    public function provideThingsThatAreNotStrings(): array
+    public static function provideThingsThatAreNotStrings(): array
     {
         return [
             [true],
@@ -76,7 +77,7 @@ class IsJsonStringTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideThingsThatAreNotStrings */
+    #[DataProvider('provideThingsThatAreNotStrings')]
     public function testThatNonStringsAreInvalid(mixed $input): void
     {
         $validator = new IsJsonString();
@@ -101,14 +102,14 @@ class IsJsonStringTest extends TestCase
     }
 
     /** @return array<array-key, array{0: string}> */
-    public function pluginManagerNameProvider(): array
+    public static function pluginManagerNameProvider(): array
     {
         return [
             [IsJsonString::class],
         ];
     }
 
-    /** @dataProvider pluginManagerNameProvider */
+    #[DataProvider('pluginManagerNameProvider')]
     public function testThatTheValidatorCanBeRetrievedFromThePluginManagerWithDefaultConfiguration(string $name): void
     {
         $pluginManager = new ValidatorPluginManager(new ServiceManager());
@@ -117,7 +118,7 @@ class IsJsonStringTest extends TestCase
     }
 
     /** @return array<string, array{0: string}> */
-    public function invalidStringProvider(): array
+    public static function invalidStringProvider(): array
     {
         return [
             'Empty String'     => [''],
@@ -127,7 +128,7 @@ class IsJsonStringTest extends TestCase
         ];
     }
 
-    /** @dataProvider invalidStringProvider */
+    #[DataProvider('invalidStringProvider')]
     public function testInvalidStrings(string $input): void
     {
         $validator = new IsJsonString();

--- a/test/IsbnTest.php
+++ b/test/IsbnTest.php
@@ -6,14 +6,12 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Isbn;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Isbn
- */
 final class IsbnTest extends TestCase
 {
     /**
@@ -22,7 +20,7 @@ final class IsbnTest extends TestCase
      *     1: bool
      * }>
      */
-    public function basicProvider(): array
+    public static function basicProvider(): array
     {
         return [
             'Brave New World by Aldous Huxley - True'                       => ['0060929871', true],
@@ -40,9 +38,8 @@ final class IsbnTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider basicProvider
      */
+    #[DataProvider('basicProvider')]
     public function testBasic(string $value, bool $expected): void
     {
         $validator = new Isbn();
@@ -209,9 +206,7 @@ final class IsbnTest extends TestCase
         self::assertTrue($validator->isValid('978 0 555023 40 2'));
     }
 
-    /**
-     * @group Laminas-9605
-     */
+    #[Group('Laminas-9605')]
     public function testInvalidTypeGiven(): void
     {
         $validator = new Isbn();

--- a/test/LessThanTest.php
+++ b/test/LessThanTest.php
@@ -5,22 +5,19 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\LessThan;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\LessThan
- */
 final class LessThanTest extends TestCase
 {
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @dataProvider basicDataProvider
      * @param int|string $input
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(array $options, $input, bool $expected): void
     {
         $validator = new LessThan(...$options);
@@ -35,7 +32,7 @@ final class LessThanTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -6,14 +6,13 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\StringLength;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function current;
 
-/**
- * @group Laminas_Validator
- */
+#[Group('Laminas_Validator')]
 final class MessageTest extends TestCase
 {
     private StringLength $validator;

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -7,13 +7,11 @@ namespace LaminasTest\Validator;
 use ArrayObject;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\NotEmpty;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\NotEmpty
- */
 final class NotEmptyTest extends TestCase
 {
     private NotEmpty $validator;
@@ -30,8 +28,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param array $types Array of type strings or constants
      * @param integer $expected Expected value of calculated type
-     * @dataProvider constructorWithTypeArrayProvider
      */
+    #[DataProvider('constructorWithTypeArrayProvider')]
     public function testConstructorWithTypeArray(array $types, int $expected): void
     {
         $validator = new NotEmpty($types);
@@ -42,7 +40,7 @@ final class NotEmptyTest extends TestCase
     /**
      * @psalm-return array<array-key, array{list<string|int>, int}>
      */
-    public function constructorWithTypeArrayProvider(): array
+    public static function constructorWithTypeArrayProvider(): array
     {
         return [
             [['php', 'boolean'], NotEmpty::PHP],
@@ -60,9 +58,9 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @group Laminas-6708
-     * @dataProvider basicProvider
      */
+    #[DataProvider('basicProvider')]
+    #[Group('Laminas-6708')]
     public function testBasic(mixed $value, bool $valid): void
     {
         $this->checkValidationValue($value, $valid);
@@ -73,7 +71,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<int>|stdClass|null, bool}>
      */
-    public function basicProvider(): array
+    public static function basicProvider(): array
     {
         return [
             ['word', true],
@@ -99,8 +97,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider booleanProvider
      */
+    #[DataProvider('booleanProvider')]
     public function testOnlyBoolean(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::BOOLEAN);
@@ -113,7 +111,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function booleanProvider(): array
+    public static function booleanProvider(): array
     {
         return [
             [false, false],
@@ -137,8 +135,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider integerOnlyProvider
      */
+    #[DataProvider('integerOnlyProvider')]
     public function testOnlyInteger(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::INTEGER);
@@ -151,7 +149,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function integerOnlyProvider(): array
+    public static function integerOnlyProvider(): array
     {
         return [
             [false, true],
@@ -175,8 +173,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider floatOnlyProvider
      */
+    #[DataProvider('floatOnlyProvider')]
     public function testOnlyFloat(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::FLOAT);
@@ -189,7 +187,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function floatOnlyProvider(): array
+    public static function floatOnlyProvider(): array
     {
         return [
             [false, true],
@@ -213,8 +211,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider stringOnlyProvider
      */
+    #[DataProvider('stringOnlyProvider')]
     public function testOnlyString(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::STRING);
@@ -227,7 +225,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function stringOnlyProvider(): array
+    public static function stringOnlyProvider(): array
     {
         return [
             [false, true],
@@ -251,8 +249,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider zeroOnlyProvider
      */
+    #[DataProvider('zeroOnlyProvider')]
     public function testOnlyZero(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::ZERO);
@@ -265,7 +263,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function zeroOnlyProvider(): array
+    public static function zeroOnlyProvider(): array
     {
         return [
             [false, true],
@@ -289,8 +287,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider arrayOnlyProvider
      */
+    #[DataProvider('arrayOnlyProvider')]
     public function testOnlyArray(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::EMPTY_ARRAY);
@@ -303,7 +301,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function arrayOnlyProvider(): array
+    public static function arrayOnlyProvider(): array
     {
         return [
             [false, true],
@@ -327,8 +325,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider nullOnlyProvider
      */
+    #[DataProvider('nullOnlyProvider')]
     public function testOnlyNull(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::NULL);
@@ -341,7 +339,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function nullOnlyProvider(): array
+    public static function nullOnlyProvider(): array
     {
         return [
             [false, true],
@@ -365,8 +363,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider phpOnlyProvider
      */
+    #[DataProvider('phpOnlyProvider')]
     public function testOnlyPHP(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::PHP);
@@ -379,7 +377,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function phpOnlyProvider(): array
+    public static function phpOnlyProvider(): array
     {
         return [
             [false, false],
@@ -403,8 +401,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider spaceOnlyProvider
      */
+    #[DataProvider('spaceOnlyProvider')]
     public function testOnlySpace(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::SPACE);
@@ -417,7 +415,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function spaceOnlyProvider(): array
+    public static function spaceOnlyProvider(): array
     {
         return [
             [false, true],
@@ -441,8 +439,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider onlyAllProvider
      */
+    #[DataProvider('onlyAllProvider')]
     public function testOnlyAll(mixed $value, bool $valid): void
     {
         $this->validator->setType(NotEmpty::ALL);
@@ -455,7 +453,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function onlyAllProvider(): array
+    public static function onlyAllProvider(): array
     {
         return [
             [false, false],
@@ -479,8 +477,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider arrayConstantNotationProvider
      */
+    #[DataProvider('arrayConstantNotationProvider')]
     public function testArrayConstantNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty([
@@ -499,7 +497,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function arrayConstantNotationProvider(): array
+    public static function arrayConstantNotationProvider(): array
     {
         return [
             [false, false],
@@ -523,8 +521,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider arrayConfigNotationProvider
      */
+    #[DataProvider('arrayConfigNotationProvider')]
     public function testArrayConfigNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty([
@@ -544,7 +542,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function arrayConfigNotationProvider(): array
+    public static function arrayConfigNotationProvider(): array
     {
         return [
             [false, false],
@@ -568,8 +566,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider multiConstantNotationProvider
      */
+    #[DataProvider('multiConstantNotationProvider')]
     public function testMultiConstantNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty(
@@ -584,8 +582,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider multiConstantNotationProvider
      */
+    #[DataProvider('multiConstantNotationProvider')]
     public function testMultiConstantBooleanOrNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty(
@@ -600,7 +598,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function multiConstantNotationProvider(): array
+    public static function multiConstantNotationProvider(): array
     {
         return [
             [false, false],
@@ -624,8 +622,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider stringNotationProvider
      */
+    #[DataProvider('stringNotationProvider')]
     public function testStringNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty([
@@ -640,7 +638,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function stringNotationProvider(): array
+    public static function stringNotationProvider(): array
     {
         return [
             [false, false],
@@ -665,8 +663,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param string  $string   Array of string type values
      * @param integer $expected Expected type setting value
-     * @dataProvider duplicateStringSettingProvider
      */
+    #[DataProvider('duplicateStringSettingProvider')]
     public function testStringNotationWithDuplicate(string $string, int $expected): void
     {
         $type = [$string, $string];
@@ -681,7 +679,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{string, int}>
      */
-    public function duplicateStringSettingProvider(): array
+    public static function duplicateStringSettingProvider(): array
     {
         return [
             ['boolean',      NotEmpty::BOOLEAN],
@@ -705,8 +703,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider singleStringNotationProvider
      */
+    #[DataProvider('singleStringNotationProvider')]
     public function testSingleStringConstructorNotation(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty(
@@ -721,8 +719,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider singleStringNotationProvider
      */
+    #[DataProvider('singleStringNotationProvider')]
     public function testSingleStringSetTypeNotation(mixed $value, bool $valid): void
     {
         $this->validator->setType('boolean');
@@ -735,7 +733,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function singleStringNotationProvider(): array
+    public static function singleStringNotationProvider(): array
     {
         return [
             [false, false],
@@ -759,8 +757,8 @@ final class NotEmptyTest extends TestCase
      *
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider configObjectProvider
      */
+    #[DataProvider('configObjectProvider')]
     public function testTraversableObject(mixed $value, bool $valid): void
     {
         $options = ['type' => 'all'];
@@ -778,7 +776,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function configObjectProvider(): array
+    public static function configObjectProvider(): array
     {
         return [
             [false, false],
@@ -816,9 +814,7 @@ final class NotEmptyTest extends TestCase
         self::assertSame($this->validator->getDefaultType(), $this->validator->getType());
     }
 
-    /**
-     * @group Laminas-3236
-     */
+    #[Group('Laminas-3236')]
     public function testStringWithZeroShouldNotBeTreatedAsEmpty(): void
     {
         self::assertTrue($this->validator->isValid('0'));
@@ -873,39 +869,33 @@ final class NotEmptyTest extends TestCase
     {
         $valid = new NotEmpty(NotEmpty::STRING);
 
-        $object = $this->getMockBuilder(stdClass::class)
-            ->addMethods(['__toString'])
-            ->getMock();
-
-        $object
-            ->expects(self::atLeastOnce())
-            ->method('__toString')
-            ->willReturn('Test');
-
+        $object = new class () {
+            public function __toString(): string
+            {
+                return 'Test';
+            }
+        };
         self::assertFalse($valid->isValid($object));
 
         $valid = new NotEmpty(NotEmpty::OBJECT_STRING);
-
         self::assertTrue($valid->isValid($object));
 
-        $object = $this->getMockBuilder(stdClass::class)
-            ->addMethods(['__toString'])
-            ->getMock();
-
-        $object
-            ->expects(self::atLeastOnce())
-            ->method('__toString')
-            ->willReturn('');
+        $object = new class () {
+            public function __toString(): string
+            {
+                return '';
+            }
+        };
 
         self::assertFalse($valid->isValid($object));
     }
 
     /**
-     * @group Laminas-11566
      * @param mixed $value Value to test
      * @param boolean $valid Expected validity of value
-     * @dataProvider arrayConfigNotationWithoutKeyProvider
      */
+    #[DataProvider('arrayConfigNotationWithoutKeyProvider')]
+    #[Group('Laminas-11566')]
     public function testArrayConfigNotationWithoutKey(mixed $value, bool $valid): void
     {
         $this->validator = new NotEmpty(
@@ -920,7 +910,7 @@ final class NotEmptyTest extends TestCase
      *
      * @psalm-return array<array{scalar|list<string>|null, bool}>
      */
-    public function arrayConfigNotationWithoutKeyProvider(): array
+    public static function arrayConfigNotationWithoutKeyProvider(): array
     {
         return [
             [false, false],

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -202,7 +202,6 @@ final class RegexTest extends TestCase
         $pattern   = '/';
 
         $r = new ReflectionProperty($validator, 'pattern');
-        $r->setAccessible(true);
         $r->setValue($validator, $pattern);
 
         self::assertFalse($validator->isValid('test'));

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -6,23 +6,19 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Regex;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 use function array_keys;
 use function implode;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Regex
- */
 final class RegexTest extends TestCase
 {
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider basicDataProvider
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(array $options, string $input, bool $expected): void
     {
         $validator = new Regex(...$options);
@@ -37,7 +33,7 @@ final class RegexTest extends TestCase
      *     2: bool
      * }>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable
@@ -103,8 +99,8 @@ final class RegexTest extends TestCase
 
     /**
      * @Laminas-11863
-     * @dataProvider specialCharValidationProvider
      */
+    #[DataProvider('specialCharValidationProvider')]
     public function testSpecialCharValidation(bool $expected, string $input): void
     {
         $validator = new Regex('/^[[:alpha:]\']+$/iu');
@@ -123,7 +119,7 @@ final class RegexTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: bool, 1: string}>
      */
-    public function specialCharValidationProvider(): array
+    public static function specialCharValidationProvider(): array
     {
         return [
             [true, 'test'],
@@ -164,7 +160,7 @@ final class RegexTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidConstructorArgumentsProvider(): array
+    public static function invalidConstructorArgumentsProvider(): array
     {
         return [
             'true'       => [true],
@@ -177,9 +173,7 @@ final class RegexTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidConstructorArgumentsProvider
-     */
+    #[DataProvider('invalidConstructorArgumentsProvider')]
     public function testConstructorRaisesExceptionWhenProvidedInvalidArguments(mixed $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/test/Sitemap/ChangefreqTest.php
+++ b/test/Sitemap/ChangefreqTest.php
@@ -10,10 +10,6 @@ use stdClass;
 
 use function current;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Sitemap\Changefreq
- */
 final class ChangefreqTest extends TestCase
 {
     private Changefreq $validator;

--- a/test/Sitemap/LastmodTest.php
+++ b/test/Sitemap/LastmodTest.php
@@ -10,10 +10,6 @@ use stdClass;
 
 use function current;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Sitemap\Lastmod
- */
 final class LastmodTest extends TestCase
 {
     private Lastmod $validator;

--- a/test/Sitemap/LocTest.php
+++ b/test/Sitemap/LocTest.php
@@ -61,7 +61,6 @@ final class LocTest extends TestCase
      *
      * @todo A change in the URI API has led to most of these now validating
      * @dataProvider invalidLocs
-     * @psalm-suppress UnevaluatedCode
      */
     public function testInvalidLocs(string $url): void
     {

--- a/test/Sitemap/LocTest.php
+++ b/test/Sitemap/LocTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace LaminasTest\Validator\Sitemap;
 
 use Laminas\Validator\Sitemap\Loc;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function current;
 
-/** @covers \Laminas\Validator\Sitemap\Loc */
 final class LocTest extends TestCase
 {
     private Loc $validator;
@@ -60,8 +60,8 @@ final class LocTest extends TestCase
      * Tests invalid locations
      *
      * @todo A change in the URI API has led to most of these now validating
-     * @dataProvider invalidLocs
      */
+    #[DataProvider('invalidLocs')]
     public function testInvalidLocs(string $url): void
     {
         self::markTestIncomplete('Test must be reworked');

--- a/test/Sitemap/PriorityTest.php
+++ b/test/Sitemap/PriorityTest.php
@@ -10,10 +10,6 @@ use stdClass;
 
 use function current;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Sitemap\Priority
- */
 final class PriorityTest extends TestCase
 {
     private Priority $validator;

--- a/test/StaticAnalysis/PluginManager.php
+++ b/test/StaticAnalysis/PluginManager.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\StaticAnalysis;
+
+use Laminas\Validator\Uuid;
+use Laminas\Validator\ValidatorInterface;
+use Laminas\Validator\ValidatorPluginManager;
+
+/** @psalm-suppress UnusedClass */
+final class PluginManager
+{
+    public function validateAssertsPluginType(mixed $input): ValidatorInterface
+    {
+        (new ValidatorPluginManager())->validate($input);
+
+        return $input;
+    }
+
+    public function getWithClassStringReturnsCorrectInstanceType(): ValidatorInterface
+    {
+        return (new ValidatorPluginManager())->get(Uuid::class);
+    }
+}

--- a/test/StaticValidatorTest.php
+++ b/test/StaticValidatorTest.php
@@ -15,16 +15,14 @@ use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\Validator\TestAsset\ArrayTranslator;
 use LaminasTest\Validator\TestAsset\Translator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function current;
 use function extension_loaded;
 use function strlen;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\StaticValidator
- */
 final class StaticValidatorTest extends TestCase
 {
     private Alpha $validator;
@@ -161,7 +159,7 @@ final class StaticValidatorTest extends TestCase
      *     3: bool
      * }>
      */
-    public function parameterizedData(): array
+    public static function parameterizedData(): array
     {
         return [
             'valid-positive-range'   => [5, Between::class, ['min' => 1, 'max' => 10], true],
@@ -172,9 +170,9 @@ final class StaticValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider parameterizedData
      * @param class-string<ValidatorInterface> $validator
      */
+    #[DataProvider('parameterizedData')]
     public function testExecuteValidWithParameters(
         int $value,
         string $validator,
@@ -187,7 +185,7 @@ final class StaticValidatorTest extends TestCase
     /**
      * @psalm-return array<string, array{0: int, 1: class-string<ValidatorInterface>, 2: int[]}>
      */
-    public function invalidParameterizedData(): array
+    public static function invalidParameterizedData(): array
     {
         return [
             'positive-range' => [5, Between::class, [1, 10]],
@@ -196,9 +194,9 @@ final class StaticValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider invalidParameterizedData
      * @param class-string<ValidatorInterface> $validator
      */
+    #[DataProvider('invalidParameterizedData')]
     public function testExecuteRaisesExceptionForIndexedOptionsArray(
         int $value,
         string $validator,
@@ -215,9 +213,8 @@ final class StaticValidatorTest extends TestCase
      * exist in the namespace, is() throws an exception.
      *
      * Refactored to conform with Laminas-2724.
-     *
-     * @group Laminas-2724
      */
+    #[Group('Laminas-2724')]
     public function testStaticFactoryClassNotFound(): void
     {
         $this->expectException(ServiceNotFoundException::class);

--- a/test/StepTest.php
+++ b/test/StepTest.php
@@ -256,7 +256,6 @@ final class StepTest extends TestCase
         $validator = new Step();
 
         $r = new ReflectionMethod($validator, 'fmod');
-        $r->setAccessible(true);
 
         self::assertSame(1.0, $r->invoke($validator, 0, 0));
     }

--- a/test/StepTest.php
+++ b/test/StepTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\Step;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
-/** @covers \Laminas\Validator\Step */
 final class StepTest extends TestCase
 {
     private Step $validator;
@@ -26,7 +26,7 @@ final class StepTest extends TestCase
     /**
      * @psalm-return array<string, array{0: float|int|string, 1: bool}>
      */
-    public function valuesToValidate(): array
+    public static function valuesToValidate(): array
     {
         return [
             'float'              => [1.00, true],
@@ -44,9 +44,8 @@ final class StepTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider valuesToValidate
      */
+    #[DataProvider('valuesToValidate')]
     public function testBasic(mixed $value, bool $expected): void
     {
         // By default, baseValue == 0 and step == 1
@@ -59,7 +58,7 @@ final class StepTest extends TestCase
     /**
      * @psalm-return array<string, array{0: float|string, 1: bool}>
      */
-    public function decimalValues(): array
+    public static function decimalValues(): array
     {
         return [
             'between-step'        => [1.1, false],
@@ -73,9 +72,7 @@ final class StepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider decimalValues
-     */
+    #[DataProvider('decimalValues')]
     public function testDecimalBaseValue(mixed $value, bool $expected): void
     {
         $validator = new Step([
@@ -89,7 +86,7 @@ final class StepTest extends TestCase
     /**
      * @psalm-return array<string, array{0: float|string, 1: bool}>
      */
-    public function decimalStepValues(): array
+    public static function decimalStepValues(): array
     {
         return [
             'between-0.1'        => [0.1, false],
@@ -112,9 +109,7 @@ final class StepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider decimalStepValues
-     */
+    #[DataProvider('decimalStepValues')]
     public function testDecimalStep(mixed $value, bool $expected): void
     {
         $validator = new Step([
@@ -128,7 +123,7 @@ final class StepTest extends TestCase
     /**
      * @psalm-return array<string, array{0: int, 1: float, 2: bool}>
      */
-    public function decimalStepSubstractionBugValues(): array
+    public static function decimalStepSubstractionBugValues(): array
     {
         return [
             'base-value-20' => [20, 20.06, true],
@@ -137,9 +132,7 @@ final class StepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider decimalStepSubstractionBugValues
-     */
+    #[DataProvider('decimalStepSubstractionBugValues')]
     public function testDecimalStepSubstractionBug(int $baseValue, float $value, bool $expected): void
     {
         $validator = new Step([
@@ -153,7 +146,7 @@ final class StepTest extends TestCase
     /**
      * @psalm-return array<string, array{0: float, 1: bool}>
      */
-    public function decimalHundredthStepValues(): array
+    public static function decimalHundredthStepValues(): array
     {
         return [
             'first-step'       => [0.01, true],
@@ -177,9 +170,7 @@ final class StepTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider decimalHundredthStepValues
-     */
+    #[DataProvider('decimalHundredthStepValues')]
     public function testdecimalHundredthStep(float $value, bool $expected): void
     {
         $validator = new Step([

--- a/test/StringLengthTest.php
+++ b/test/StringLengthTest.php
@@ -6,15 +6,12 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\StringLength;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function ini_set;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\StringLength
- */
 final class StringLengthTest extends TestCase
 {
     private StringLength $validator;
@@ -31,9 +28,8 @@ final class StringLengthTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
-     *
-     * @dataProvider basicDataProvider
      */
+    #[DataProvider('basicDataProvider')]
     public function testBasic(array $options, bool $expected, string $input): void
     {
         ini_set('default_charset', 'UTF-8');
@@ -46,7 +42,7 @@ final class StringLengthTest extends TestCase
     /**
      * @psalm-return array<string, array{0: array, 1: bool, 2: string}>
      */
-    public function basicDataProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
             // phpcs:disable

--- a/test/TestAsset/InMemoryContainer.php
+++ b/test/TestAsset/InMemoryContainer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\TestAsset;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
+
+use function array_key_exists;
+
+final class InMemoryContainer implements ContainerInterface
+{
+    /** @var array<string, mixed> */
+    private array $services = [];
+
+    /** @inheritDoc */
+    public function get($id): mixed
+    {
+        if (! array_key_exists($id, $this->services)) {
+            throw new class ($id . ' was not found') extends RuntimeException implements NotFoundExceptionInterface {
+            };
+        }
+
+        return $this->services[$id];
+    }
+
+    /** @inheritDoc */
+    public function has($id): bool
+    {
+        return array_key_exists($id, $this->services);
+    }
+
+    public function set(string $id, mixed $item): void
+    {
+        $this->services[$id] = $item;
+    }
+}

--- a/test/TimezoneTest.php
+++ b/test/TimezoneTest.php
@@ -6,14 +6,10 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\Timezone;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Tests for {@see \Laminas\Validator\Timezone}
- *
- * @covers \Laminas\Validator\Timezone
- */
 final class TimezoneTest extends TestCase
 {
     private Timezone $validator;
@@ -27,9 +23,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test locations
-     *
-     * @dataProvider locationProvider
      */
+    #[DataProvider('locationProvider')]
     public function testLocations(?string $value, bool $valid): void
     {
         $this->validator->setType(Timezone::LOCATION);
@@ -39,9 +34,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test locations by type is string
-     *
-     * @dataProvider locationProvider
      */
+    #[DataProvider('locationProvider')]
     public function testLocationsByTypeAsString(?string $value, bool $valid): void
     {
         $this->validator->setType('location');
@@ -54,7 +48,7 @@ final class TimezoneTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: string|null, 1: bool}>
      */
-    public function locationProvider(): array
+    public static function locationProvider(): array
     {
         return [
             ['America/Anguilla', true],
@@ -76,9 +70,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test abbreviations
-     *
-     * @dataProvider abbreviationProvider
      */
+    #[DataProvider('abbreviationProvider')]
     public function testAbbreviations(?string $value, bool $valid): void
     {
         $this->validator->setType(Timezone::ABBREVIATION);
@@ -88,9 +81,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test abbreviations byTypeAsString
-     *
-     * @dataProvider abbreviationProvider
      */
+    #[DataProvider('abbreviationProvider')]
     public function testAbbreviationsByTypeAsString(?string $value, bool $valid): void
     {
         $this->validator->setType('abbreviation');
@@ -103,7 +95,7 @@ final class TimezoneTest extends TestCase
      *
      * @return array<array-key, array{0: null|string, 1: bool}>
      */
-    public function abbreviationProvider(): array
+    public static function abbreviationProvider(): array
     {
         return [
             ['cest', true], // Central European Summer Time
@@ -119,9 +111,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test locations and abbreviations
-     *
-     * @dataProvider locationAndAbbreviationProvider
      */
+    #[DataProvider('locationAndAbbreviationProvider')]
     public function testlocationsAndAbbreviationsWithAllTypeAsString(?string $value, bool $valid): void
     {
         $this->validator->setType(Timezone::ALL);
@@ -131,9 +122,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test locations and abbreviations
-     *
-     * @dataProvider locationAndAbbreviationProvider
      */
+    #[DataProvider('locationAndAbbreviationProvider')]
     public function testlocationsAndAbbreviationsWithAllTypeAsArray(?string $value, bool $valid): void
     {
         $this->validator->setType([Timezone::LOCATION, Timezone::ABBREVIATION]);
@@ -143,9 +133,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test locations and abbreviations
-     *
-     * @dataProvider locationAndAbbreviationProvider
      */
+    #[DataProvider('locationAndAbbreviationProvider')]
     public function testLocationsAndAbbreviationsWithAllTypeAsArrayWithStrings(?string $value, bool $valid): void
     {
         $this->validator->setType(['location', 'abbreviation']);
@@ -158,7 +147,7 @@ final class TimezoneTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: string|null, 1: bool}>
      */
-    public function locationAndAbbreviationProvider(): array
+    public static function locationAndAbbreviationProvider(): array
     {
         return [
             ['America/Anguilla', true],
@@ -178,9 +167,8 @@ final class TimezoneTest extends TestCase
 
     /**
      * Test wrong type
-     *
-     * @dataProvider wrongTypesProvider
      */
+    #[DataProvider('wrongTypesProvider')]
     public function testWrongType(mixed $value): void
     {
         $this->checkExpectedException($value);
@@ -191,7 +179,7 @@ final class TimezoneTest extends TestCase
      *
      * @psalm-return array<array-key, array{0: mixed}>
      */
-    public function wrongTypesProvider(): array
+    public static function wrongTypesProvider(): array
     {
         return [
             [null],
@@ -249,9 +237,7 @@ final class TimezoneTest extends TestCase
         self::assertTrue($timezone8->isValid('sast'));
     }
 
-    /**
-     * @dataProvider getInvalidTypes
-     */
+    #[DataProvider('getInvalidTypes')]
     public function testRejectsInvalidIntType(mixed $invalidType): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -294,7 +280,7 @@ final class TimezoneTest extends TestCase
      * @return mixed[][]
      * @psalm-return array<list<stdClass|array|int|string>>
      */
-    public function getInvalidTypes(): array
+    public static function getInvalidTypes(): array
     {
         return [
             [new stdClass()],

--- a/test/UndisclosedPasswordTest.php
+++ b/test/UndisclosedPasswordTest.php
@@ -120,12 +120,15 @@ final class UndisclosedPasswordTest extends TestCase
             ->willReturnCallback(function (): string {
                 $hash = sha1('laminas-validator');
 
+                $constant = $this->getConstant(
+                    'HIBP_K_ANONYMITY_HASH_RANGE_LENGTH',
+                    UndisclosedPassword::class
+                );
+                self::assertIsInt($constant);
+
                 return sprintf(
                     '%s:%d',
-                    strtoupper(substr($hash, $this->getConstant(
-                        'HIBP_K_ANONYMITY_HASH_RANGE_LENGTH',
-                        UndisclosedPassword::class
-                    ))),
+                    strtoupper(substr($hash, $constant)),
                     random_int(0, 100000)
                 );
             });
@@ -154,12 +157,16 @@ final class UndisclosedPasswordTest extends TestCase
             ->willReturnCallback(function () use ($password): string {
                 $hash = sha1($password);
 
+                $constant = $this->getConstant(
+                    'HIBP_K_ANONYMITY_HASH_RANGE_LENGTH',
+                    UndisclosedPassword::class
+                );
+
+                self::assertIsInt($constant);
+
                 return sprintf(
                     '%s:%d',
-                    strtoupper(substr($hash, $this->getConstant(
-                        'HIBP_K_ANONYMITY_HASH_RANGE_LENGTH',
-                        UndisclosedPassword::class
-                    ))),
+                    strtoupper(substr($hash, $constant)),
                     random_int(0, 100000)
                 );
             });

--- a/test/UndisclosedPasswordTest.php
+++ b/test/UndisclosedPasswordTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Validator;
 use Exception;
 use Laminas\Validator\UndisclosedPassword;
 use LaminasTest\Validator\TestAsset\HttpClientException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -22,7 +24,6 @@ use function sprintf;
 use function strtoupper;
 use function substr;
 
-/** @covers \Laminas\Validator\UndisclosedPassword */
 final class UndisclosedPasswordTest extends TestCase
 {
     /** @var ClientInterface&MockObject */
@@ -65,7 +66,7 @@ final class UndisclosedPasswordTest extends TestCase
      *
      * @psalm-return array<array{string}>
      */
-    public function goodPasswordProvider(): array
+    public static function goodPasswordProvider(): array
     {
         return [
             ['ABi$B47es.Pfg3n9PjPi'],
@@ -80,7 +81,7 @@ final class UndisclosedPasswordTest extends TestCase
      *
      * @psalm-return array<array{string}>
      */
-    public function seenPasswordProvider(): array
+    public static function seenPasswordProvider(): array
     {
         return [
             ['123456'],
@@ -94,8 +95,6 @@ final class UndisclosedPasswordTest extends TestCase
     /**
      * Testing that we reject invalid password types
      *
-     * @covers \Laminas\Validator\UndisclosedPassword
-     * @covers \Laminas\Validator\AbstractValidator
      * @todo Can be replaced by a \TypeError being thrown in PHP 7.0 or up
      */
     public function testValidationFailsForInvalidInput(): void
@@ -108,10 +107,8 @@ final class UndisclosedPasswordTest extends TestCase
     /**
      * Test that a given password was not found in the HIBP
      * API service.
-     *
-     * @covers \Laminas\Validator\UndisclosedPassword
-     * @dataProvider goodPasswordProvider
      */
+    #[DataProvider('goodPasswordProvider')]
     public function testStrongUnseenPasswordsPassValidation(string $password): void
     {
         $this->httpResponse
@@ -144,11 +141,8 @@ final class UndisclosedPasswordTest extends TestCase
     /**
      * Test that a given password was already seen in the HIBP
      * AP service.
-     *
-     * @dataProvider seenPasswordProvider
-     * @covers \Laminas\Validator\UndisclosedPassword
-     * @covers \Laminas\Validator\AbstractValidator
      */
+    #[DataProvider('seenPasswordProvider')]
     public function testBreachedPasswordsDoNotPassValidation(string $password): void
     {
         $this->httpResponse
@@ -182,11 +176,9 @@ final class UndisclosedPasswordTest extends TestCase
     /**
      * Testing we are setting error messages when a password was found
      * in the breach database.
-     *
-     * @depends testBreachedPasswordsDoNotPassValidation
-     * @dataProvider seenPasswordProvider
-     * @covers \Laminas\Validator\UndisclosedPassword
      */
+    #[DataProvider('seenPasswordProvider')]
+    #[Depends('testBreachedPasswordsDoNotPassValidation')]
     public function testBreachedPasswordReturnErrorMessages(string $password): void
     {
         $this->httpClient
@@ -213,11 +205,9 @@ final class UndisclosedPasswordTest extends TestCase
     /**
      * Testing that we capture any failures when trying to connect with
      * the HIBP web service.
-     *
-     * @depends testBreachedPasswordsDoNotPassValidation
-     * @dataProvider seenPasswordProvider
-     * @covers \Laminas\Validator\UndisclosedPassword
      */
+    #[DataProvider('seenPasswordProvider')]
+    #[Depends('testBreachedPasswordsDoNotPassValidation')]
     public function testValidationDegradesGracefullyWhenNoConnectionCanBeMade(string $password): void
     {
         $clientException = $this->createMock(HttpClientException::class);

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -10,15 +10,12 @@ use Laminas\Uri\Uri as UriHandler;
 use Laminas\Validator\Exception\InvalidArgumentException as ValidatorInvalidArgumentException;
 use Laminas\Validator\Uri;
 use LaminasTest\Validator\TestAsset\CustomTraversable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function array_keys;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\Uri
- */
 final class UriTest extends TestCase
 {
     private Uri $validator;
@@ -103,7 +100,7 @@ final class UriTest extends TestCase
      *     5: bool
      * }>
      */
-    public function allowOptionsDataProvider(): array
+    public static function allowOptionsDataProvider(): array
     {
         return [
             //    allowAbsolute allowRelative isAbsolute isRelative isValid expects
@@ -119,9 +116,7 @@ final class UriTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider allowOptionsDataProvider
-     */
+    #[DataProvider('allowOptionsDataProvider')]
     public function testUriHandlerBehaviorWithAllowSettings(
         bool $allowAbsolute,
         bool $allowRelative,
@@ -230,7 +225,7 @@ final class UriTest extends TestCase
     /**
      * @psalm-return array<string, array{0: mixed}>
      */
-    public function invalidValueTypes(): array
+    public static function invalidValueTypes(): array
     {
         return [
             'null'       => [null],
@@ -245,9 +240,7 @@ final class UriTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidValueTypes
-     */
+    #[DataProvider('invalidValueTypes')]
     public function testIsValidReturnsFalseWhenProvidedUnsupportedType(mixed $value): void
     {
         self::assertFalse($this->validator->isValid($value));

--- a/test/UuidTest.php
+++ b/test/UuidTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\Validator\Uuid;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * Uuid test cases based on https://github.com/beberlei/assert/blob/master/tests/Assert/Tests/AssertTest.php
- *
- * @covers \Laminas\Validator\Uuid
  */
 final class UuidTest extends TestCase
 {
@@ -24,9 +23,7 @@ final class UuidTest extends TestCase
         $this->validator = new Uuid();
     }
 
-    /**
-     * @dataProvider validUuidProvider
-     */
+    #[DataProvider('validUuidProvider')]
     public function testValidUuid(string $uuid): void
     {
         self::assertTrue($this->validator->isValid($uuid));
@@ -36,9 +33,7 @@ final class UuidTest extends TestCase
         self::assertCount(0, $messages);
     }
 
-    /**
-     * @dataProvider invalidUuidProvider
-     */
+    #[DataProvider('invalidUuidProvider')]
     public function testInvalidUuid(mixed $uuid, string $expectedMessageKey): void
     {
         self::assertFalse($this->validator->isValid($uuid));
@@ -53,7 +48,7 @@ final class UuidTest extends TestCase
     /**
      * @psalm-return array<string, array{string}>
      */
-    public function validUuidProvider(): array
+    public static function validUuidProvider(): array
     {
         return [
             'zero-fill' => ['00000000-0000-0000-0000-000000000000'],
@@ -69,7 +64,7 @@ final class UuidTest extends TestCase
     /**
      * @psalm-return array<string, array{string|int|stdClass, string}>
      */
-    public function invalidUuidProvider(): array
+    public static function invalidUuidProvider(): array
     {
         return [
             'invalid-characters' => ['laminas6f8cb0-c57d-11e1-9b21-0800200c9a66', Uuid::INVALID],

--- a/test/ValidatorChainTest.php
+++ b/test/ValidatorChainTest.php
@@ -11,6 +11,8 @@ use Laminas\Validator\NotEmpty;
 use Laminas\Validator\Timezone;
 use Laminas\Validator\ValidatorChain;
 use Laminas\Validator\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -20,10 +22,6 @@ use function serialize;
 use function strstr;
 use function unserialize;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\ValidatorChain
- */
 final class ValidatorChainTest extends TestCase
 {
     private ValidatorChain $validator;
@@ -125,10 +123,8 @@ final class ValidatorChainTest extends TestCase
         self::assertArrayHasKey('isEmpty', $messages);
     }
 
-    /**
-     * @group 6386
-     * @group 6496
-     */
+    #[Group('6386')]
+    #[Group('6496')]
     public function testValidatorsAreExecutedAccordingToPriority(): void
     {
         $this->validator
@@ -142,10 +138,8 @@ final class ValidatorChainTest extends TestCase
         self::assertArrayHasKey('error', $messages);
     }
 
-    /**
-     * @group 6386
-     * @group 6496
-     */
+    #[Group('6386')]
+    #[Group('6496')]
     public function testPrependValidatorsAreExecutedAccordingToPriority(): void
     {
         $this->validator
@@ -159,10 +153,8 @@ final class ValidatorChainTest extends TestCase
         self::assertArrayHasKey('error', $messages);
     }
 
-    /**
-     * @group 6386
-     * @group 6496
-     */
+    #[Group('6386')]
+    #[Group('6496')]
     public function testMergeValidatorChains(): void
     {
         $mergedValidatorChain = new ValidatorChain();
@@ -175,10 +167,8 @@ final class ValidatorChainTest extends TestCase
         self::assertCount(2, $this->validator->getValidators());
     }
 
-    /**
-     * @group 6386
-     * @group 6496
-     */
+    #[Group('6386')]
+    #[Group('6496')]
     public function testValidatorChainIsCloneable(): void
     {
         $this->validator->attach(new NotEmpty());
@@ -204,9 +194,8 @@ final class ValidatorChainTest extends TestCase
 
     /**
      * Handle file not found errors
-     *
-     * @group  Laminas-2724
      */
+    #[Group('Laminas-2724')]
     public function handleNotFoundError(int $errnum, string $errstr): void
     {
         if (strstr($errstr, 'No such file')) {
@@ -247,9 +236,7 @@ final class ValidatorChainTest extends TestCase
         return $validator;
     }
 
-    /**
-     * @group Laminas-412
-     */
+    #[Group('Laminas-412')]
     public function testCanAttachMultipleValidatorsOfTheSameTypeAsDiscreteInstances(): void
     {
         $this->validator->attachByName('Callback', [
@@ -298,7 +285,7 @@ final class ValidatorChainTest extends TestCase
     /**
      * @psalm-return array<string, array{0: string}>
      */
-    public function breakChainFlags(): array
+    public static function breakChainFlags(): array
     {
         return [
             'underscores'    => ['break_chain_on_failure'],
@@ -308,9 +295,8 @@ final class ValidatorChainTest extends TestCase
 
     /**
      * @see https://github.com/zfcampus/zf-apigility-admin/issues/89
-     *
-     * @dataProvider breakChainFlags
      */
+    #[DataProvider('breakChainFlags')]
     public function testAttachByNameAllowsSpecifyingBreakChainOnFailureFlagViaOptions(string $option): void
     {
         $this->validator->attachByName('GreaterThan', [

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -1,4 +1,6 @@
-<?php // phpcs:disable SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
+<?php
+
+declare(strict_types=1);
 
 namespace LaminasTest\Validator;
 
@@ -10,6 +12,8 @@ use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+use function assert;
+use function is_string;
 use function method_exists;
 use function strpos;
 
@@ -32,18 +36,21 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         return ValidatorInterface::class;
     }
 
-    /**
-     * @psalm-return iterable<string, array{0: string, 1: string}>
-     */
-    public function aliasProvider(): iterable
+    /** @return array<string, array{0: string, 1: string}> */
+    public static function aliasProvider(): array
     {
-        $pluginManager     = $this->getPluginManager();
+        $out               = [];
+        $pluginManager     = self::getPluginManager();
         $isV2PluginManager = method_exists($pluginManager, 'validatePlugin');
 
         $r       = new ReflectionProperty($pluginManager, 'aliases');
         $aliases = $r->getValue($pluginManager);
+        self::assertIsArray($aliases);
 
         foreach ($aliases as $alias => $target) {
+            assert(is_string($target));
+            assert(is_string($alias));
+
             // Skipping due to required options
             if (strpos($target, '\\Barcode')) {
                 continue;
@@ -84,15 +91,9 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
                 continue;
             }
 
-            yield $alias => [$alias, $target];
+            $out[$alias] = [$alias, $target];
         }
-    }
 
-    /**
-     * Provided only for compatibility with the lowest integration tests from Laminas\ServiceManager (v2)
-     */
-    private function setExpectedException(string $exceptionClassName): void
-    {
-        $this->expectException($exceptionClassName);
+        return $out;
     }
 }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -17,7 +17,7 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected function getPluginManager(): ValidatorPluginManager
+    protected static function getPluginManager(): ValidatorPluginManager
     {
         return new ValidatorPluginManager(new ServiceManager());
     }
@@ -40,8 +40,7 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         $pluginManager     = $this->getPluginManager();
         $isV2PluginManager = method_exists($pluginManager, 'validatePlugin');
 
-        $r = new ReflectionProperty($pluginManager, 'aliases');
-        $r->setAccessible(true);
+        $r       = new ReflectionProperty($pluginManager, 'aliases');
         $aliases = $r->getValue($pluginManager);
 
         foreach ($aliases as $alias => $target) {

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -10,9 +10,9 @@ use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use Laminas\Validator\ValidatorPluginManagerFactory;
 use LaminasTest\Validator\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
-/** @covers \Laminas\Validator\ValidatorPluginManagerFactory */
 final class ValidatorPluginManagerFactoryTest extends TestCase
 {
     public function testFactoryReturnsPluginManager(): void
@@ -23,9 +23,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
     }
 
-    /**
-     * @depends testFactoryReturnsPluginManager
-     */
+    #[Depends('testFactoryReturnsPluginManager')]
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);
@@ -40,9 +38,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
         self::assertSame($validator, $validators->get('test'));
     }
 
-    /**
-     * @depends testFactoryReturnsPluginManager
-     */
+    #[Depends('testFactoryReturnsPluginManager')]
     public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -11,7 +11,6 @@ use Laminas\Validator\ValidatorPluginManager;
 use Laminas\Validator\ValidatorPluginManagerFactory;
 use LaminasTest\Validator\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 
 /** @covers \Laminas\Validator\ValidatorPluginManagerFactory */
 final class ValidatorPluginManagerFactoryTest extends TestCase

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -13,6 +13,7 @@ use Laminas\Validator\Explode;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
+use LaminasTest\Validator\TestAsset\InMemoryContainer;
 use LaminasTest\Validator\TestAsset\Translator;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -20,10 +21,6 @@ use Psr\Container\ContainerInterface;
 use function assert;
 use function sprintf;
 
-/**
- * @group Laminas_Validator
- * @covers \Laminas\Validator\ValidatorPluginManager
- */
 final class ValidatorPluginManagerTest extends TestCase
 {
     private ValidatorPluginManager $validators;
@@ -101,10 +98,11 @@ final class ValidatorPluginManagerTest extends TestCase
 
     public function testLoadingInvalidValidatorRaisesException(): void
     {
-        $this->validators->setInvokableClass('test', static::class);
+        $this->validators->setInvokableClass('test', InMemoryContainer::class);
 
         try {
             $this->validators->get('test');
+            self::fail('An exception should have been thrown');
         } catch (InvalidServiceException | RuntimeException $e) {
             self::assertStringContainsString(ValidatorInterface::class, $e->getMessage());
         } catch (Exception $e) {


### PR DESCRIPTION
Closes #175

- Bumps Service Manager to ^3.21 for plugin manager tests that are compatible with PHPUnit 10
- Fixes quite a few psalm issues that are eclipsed by the UnusedMethod baseline additions
- Enables MX checks that hit the network by default