### PR TITLE
Hotfix for IANA TLD List Updater workflow

### DIFF
--- a/.github/workflows/iana-hostname-list-updater.yml
+++ b/.github/workflows/iana-hostname-list-updater.yml
@@ -42,9 +42,19 @@ jobs:
         run: |
           set -e
           
-          echo "$SIGNING_SECRET_KEY" > gpg -q --import
+          SIGNING_KEY_ID=$(echo "$SIGNING_SECRET_KEY" | gpg --import -q --import-options import-show --with-colons | awk -F: '$1=="sec" {print $5; exit}')
+          if [ -z "$SIGNING_KEY_ID" ]
+          then
+            echo "GPG signing key not found in SIGNING_SECRET_KEY"
+            exit 1
+          fi
+
+          echo "Using gpg key $SIGNING_KEY_ID"
+          
           git config --local user.email "$GIT_AUTHOR_EMAIL"
           git config --local user.name "$GIT_AUTHOR_NAME"
+          git config --local user.signingkey "$SIGNING_KEY_ID"
+          git config --local commit.gpgsign true
         env:
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/iana-hostname-list-updater.yml
+++ b/.github/workflows/iana-hostname-list-updater.yml
@@ -14,7 +14,9 @@ jobs:
         id: default-branch
         shell: bash
         run: |
-          echo "branch-name=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')" >> $GITHUB_OUTPUT
+          set -e
+
+          echo "branch-name=$(gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq '.defaultBranchRef.name')" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
@@ -71,7 +73,7 @@ jobs:
           
           git push --force origin "${USE_BRANCH_NAME}"
           
-          PR_STATE=$(gh pr view --json state --jq ".state" "${USE_BRANCH_NAME}" 2>/dev/null || echo "NONE")
+          PR_STATE=$(gh pr view --repo "$GITHUB_REPOSITORY" --json state --jq ".state" "${USE_BRANCH_NAME}" 2>/dev/null || echo "NONE")
           
           if [[ "$PR_STATE" == "OPEN" ]]
           then
@@ -79,7 +81,8 @@ jobs:
             exit 0
           fi
           
-          gh pr create --title "Update IANA TLDs for Hostname validator" \
+          gh pr create --repo "$GITHUB_REPOSITORY" \
+              --title "Update IANA TLDs for Hostname validator" \
               --body "Automated update of TLDs from IANA list available at https://data.iana.org/TLD/tlds-alpha-by-domain.txt" \
               --label "Enhancement"
         env:


### PR DESCRIPTION
Workflow post merge uncovered problem with git not using imported key.
This updates gpg and git setup to explicitly set signing key id.

Also minor improvement for gh cli calls.

See #186
Workflow run with these changes https://github.com/laminas/laminas-validator/actions/runs/5136590953/jobs/9243526747