### PR TITLE
Deprecate `laminas-db` related validators

### DIFF
--- a/docs/book/validators/db.md
+++ b/docs/book/validators/db.md
@@ -4,8 +4,11 @@
 a means to test whether a record exists in a given table of a database, with a
 given value.
 
-<!-- markdownlint-disable-next-line MD001 -->
-> ### Installation requirements
+> ## Deprecated
+>
+> `laminas-db` has been marked as security only [since July 2022](https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2022-02-07-TSC-Minutes.md), as such, these validators have been deprecated for removal in version 3.0 of `laminas-validator`
+
+> ## Installation requirements
 >
 > `Laminas\Validator\Db\NoRecordExists` and `Laminas\Validator\Db\RecordExists`
 > depends on the laminas-db component, so be sure to have it installed before

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1990,6 +1990,20 @@
     </TooManyArguments>
   </file>
   <file src="src/ValidatorPluginManager.php">
+    <DeprecatedClass>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\NoRecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+      <code>Db\RecordExists::class</code>
+    </DeprecatedClass>
     <DeprecatedMethod>
       <code>getServiceLocator</code>
       <code>getServiceLocator</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -26,4 +26,13 @@
     <stubs>
         <file name=".psr-container.php.stub" preloadClasses="true" />
     </stubs>
+
+    <issueHandlers>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <directory name="src/Db" />
+                <directory name="test/Db" />
+            </errorLevel>
+        </DeprecatedClass>
+    </issueHandlers>
 </psalm>

--- a/src/Db/AbstractDb.php
+++ b/src/Db/AbstractDb.php
@@ -23,6 +23,8 @@ use function is_array;
 
 /**
  * Class for Database record validation
+ *
+ * @deprecated This class will be removed in version 3.0 of this component. There is no replacement.
  */
 abstract class AbstractDb extends AbstractValidator implements AdapterAwareInterface
 {

--- a/src/Db/NoRecordExists.php
+++ b/src/Db/NoRecordExists.php
@@ -6,6 +6,8 @@ use Laminas\Validator\Exception;
 
 /**
  * Confirms a record does not exist in a table.
+ *
+ * @deprecated This class will be removed in version 3.0 of this component. There is no replacement.
  */
 class NoRecordExists extends AbstractDb
 {

--- a/src/Db/RecordExists.php
+++ b/src/Db/RecordExists.php
@@ -6,6 +6,8 @@ use Laminas\Validator\Exception;
 
 /**
  * Confirms a record exists in a table.
+ *
+ * @deprecated This class will be removed in version 3.0 of this component. There is no replacement.
  */
 class RecordExists extends AbstractDb
 {


### PR DESCRIPTION
Related to #220

Deprecating the `laminas-db` related validators paves the way for removal in 3.0