### PR TITLE
Allow use of `TranslatorInterface` as Translator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1907,6 +1907,11 @@
       <code><![CDATA[gettype($type)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="src/Translator/DummyTranslator.php">
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $number]]></code>
+    </RedundantCastGivenDocblockType>
+  </file>
   <file src="src/Translator/TranslatorAwareInterface.php">
     <PossiblyUnusedReturnValue>
       <code><![CDATA[TranslatorAwareInterface]]></code>
@@ -2004,10 +2009,6 @@
       <code><![CDATA[$configOrContainerInstance]]></code>
       <code><![CDATA[$container->get('MvcTranslator')]]></code>
     </MixedArgument>
-    <MixedMethodCall>
-      <code><![CDATA[get]]></code>
-      <code><![CDATA[has]]></code>
-    </MixedMethodCall>
     <PossiblyUnusedMethod>
       <code><![CDATA[validatePlugin]]></code>
     </PossiblyUnusedMethod>
@@ -2018,7 +2019,6 @@
       <code><![CDATA[$container === $this && method_exists($container, 'getServiceLocator')]]></code>
     </RedundantCondition>
     <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$container]]></code>
       <code><![CDATA[$container->getServiceLocator()]]></code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -25,12 +25,14 @@ class ConfigProvider
     {
         return [
             'aliases'   => [
-                'ValidatorManager' => ValidatorPluginManager::class,
+                Translator\TranslatorInterface::class => Translator\Translator::class,
+                'ValidatorManager'                    => ValidatorPluginManager::class,
 
                 // Legacy Zend Framework aliases
                 'Zend\Validator\ValidatorPluginManager' => ValidatorPluginManager::class,
             ],
             'factories' => [
+                Translator\Translator::class  => Translator\TranslatorFactory::class,
                 ValidatorPluginManager::class => ValidatorPluginManagerFactory::class,
             ],
         ];

--- a/src/Translator/DummyTranslator.php
+++ b/src/Translator/DummyTranslator.php
@@ -6,7 +6,7 @@ namespace Laminas\Validator\Translator;
 
 use Laminas\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
 
-class DummyTranslator implements I18nTranslatorInterface
+final class DummyTranslator implements I18nTranslatorInterface
 {
     /** @inheritDoc */
     public function translate($message, $textDomain = 'default', $locale = null)

--- a/src/Translator/DummyTranslator.php
+++ b/src/Translator/DummyTranslator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator\Translator;
+
+use Laminas\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
+
+class DummyTranslator implements I18nTranslatorInterface
+{
+    /** @inheritDoc */
+    public function translate($message, $textDomain = 'default', $locale = null)
+    {
+        return $message;
+    }
+
+    /** @inheritDoc */
+    public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
+    {
+        // phpcs:disable SlevomatCodingStandard.Operators.DisallowEqualOperators
+        return $number == 1 ? $singular : $plural;
+    }
+}

--- a/src/Translator/DummyTranslator.php
+++ b/src/Translator/DummyTranslator.php
@@ -6,6 +6,9 @@ namespace Laminas\Validator\Translator;
 
 use Laminas\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
 
+/**
+ * @internal
+ */
 final class DummyTranslator implements I18nTranslatorInterface
 {
     /** @inheritDoc */

--- a/src/Translator/DummyTranslator.php
+++ b/src/Translator/DummyTranslator.php
@@ -17,7 +17,6 @@ final class DummyTranslator implements I18nTranslatorInterface
     /** @inheritDoc */
     public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
     {
-        // phpcs:disable SlevomatCodingStandard.Operators.DisallowEqualOperators
-        return $number == 1 ? $singular : $plural;
+        return (int) $number === 1 ? $singular : $plural;
     }
 }

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -7,20 +7,12 @@ namespace Laminas\Validator\Translator;
 use Laminas\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
 use Laminas\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
 
-class Translator implements
+final class Translator implements
     I18nTranslatorInterface,
     ValidatorTranslatorInterface
 {
     public function __construct(protected I18nTranslatorInterface $translator)
     {
-    }
-
-    /**
-     * @return I18nTranslatorInterface
-     */
-    public function getTranslator()
-    {
-        return $this->translator;
     }
 
     /**

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator\Translator;
+
+use Laminas\I18n\Translator\TranslatorInterface as I18nTranslatorInterface;
+use Laminas\Validator\Translator\TranslatorInterface as ValidatorTranslatorInterface;
+
+class Translator implements
+    I18nTranslatorInterface,
+    ValidatorTranslatorInterface
+{
+    public function __construct(protected I18nTranslatorInterface $translator)
+    {
+    }
+
+    /**
+     * @return I18nTranslatorInterface
+     */
+    public function getTranslator()
+    {
+        return $this->translator;
+    }
+
+    /**
+     * Translate a message using the given text domain and locale
+     *
+     * @param string $message
+     * @param string $textDomain
+     * @param string $locale
+     * @return string
+     */
+    public function translate($message, $textDomain = 'default', $locale = null)
+    {
+        return $this->translator->translate($message, $textDomain, $locale);
+    }
+
+    /**
+     * Provide a pluralized translation of the given string using the given text domain and locale
+     *
+     * @param string $singular
+     * @param string $plural
+     * @param int $number
+     * @param string $textDomain
+     * @param string $locale
+     * @return string
+     */
+    public function translatePlural($singular, $plural, $number, $textDomain = 'default', $locale = null)
+    {
+        return $this->translator->translatePlural($singular, $plural, $number, $textDomain, $locale);
+    }
+}

--- a/src/Translator/Translator.php
+++ b/src/Translator/Translator.php
@@ -11,7 +11,7 @@ final class Translator implements
     I18nTranslatorInterface,
     ValidatorTranslatorInterface
 {
-    public function __construct(protected I18nTranslatorInterface $translator)
+    public function __construct(private readonly I18nTranslatorInterface $translator)
     {
     }
 

--- a/src/Translator/TranslatorFactory.php
+++ b/src/Translator/TranslatorFactory.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator\Translator;
+
+// phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
+
+use Laminas\I18n\Translator\LoaderPluginManager;
+use Laminas\I18n\Translator\Translator as I18nTranslator;
+use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
+use Traversable;
+
+use function array_key_exists;
+use function assert;
+use function extension_loaded;
+use function is_array;
+
+/**
+ * Overrides the translator factory from the i18n component in order to
+ * replace it with the bridge class from this namespace.
+ */
+class TranslatorFactory implements FactoryInterface
+{
+    /**
+     * @param  string $requestedName
+     * @return Translator
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    {
+        // Assume that if a user has registered a service for the
+        // TranslatorInterface, it must be valid
+        if ($container->has(TranslatorInterface::class)) {
+            return new Translator($container->get(TranslatorInterface::class));
+        }
+
+        return $this->marshalTranslator($container);
+    }
+
+    /**
+     * Marshal an Translator.
+     *
+     * If configuration exists, will pass it to the I18nTranslator::factory,
+     * decorating the returned instance in an MvcTranslator.
+     *
+     * Otherwise:
+     *
+     * - returns an Translator decorating a DummyTranslator instance if
+     *   ext/intl is not loaded.
+     * - returns an Translator decorating an empty I18nTranslator instance.
+     *
+     * @return Translator
+     */
+    private function marshalTranslator(ContainerInterface $container)
+    {
+        // Load a translator from configuration, if possible
+        $translator = $this->marshalTranslatorFromConfig($container);
+        if ($translator) {
+            return $translator;
+        }
+
+        // If ext/intl is not loaded, return a dummy translator
+        if (! extension_loaded('intl')) {
+            return new Translator(new DummyTranslator());
+        }
+
+        return new Translator(new I18nTranslator());
+    }
+
+    /**
+     * Attempt to marshal a translator from configuration.
+     *
+     * Returns:
+     * - an Translator seeded with a DummyTranslator if "translator"
+     *   configuration is available, and evaluates to boolean false.
+     * - an Translator seed with an I18nTranslator if "translator"
+     *   configuration is available, and is a non-empty array or a Traversable
+     *   instance.
+     * - null in all other cases, including absence of a configuration service.
+     *
+     * @return void|Translator
+     */
+    private function marshalTranslatorFromConfig(ContainerInterface $container)
+    {
+        if (! $container->has('config')) {
+            return;
+        }
+
+        $config = $container->get('config');
+
+        if (! is_array($config) || ! array_key_exists('translator', $config)) {
+            return;
+        }
+
+        // 'translator' => false
+        if ($config['translator'] === false) {
+            return new Translator(new DummyTranslator());
+        }
+
+        // Empty translator configuration
+        if (is_array($config['translator']) && empty($config['translator'])) {
+            return;
+        }
+
+        // Unusable translator configuration
+        if (! is_array($config['translator']) && ! $config['translator'] instanceof Traversable) {
+            return;
+        }
+
+        // Create translator from configuration
+        $i18nTranslator = I18nTranslator::factory($config['translator']);
+
+        // Inject plugins, if present
+        if ($container->has('TranslatorPluginManager')) {
+            $loaderManager = $container->get('TranslatorPluginManager');
+
+            assert($loaderManager instanceof LoaderPluginManager);
+
+            $i18nTranslator->setPluginManager($loaderManager);
+        }
+
+        // Inject into service manager instances
+        if ($container instanceof ServiceManager) {
+            $container->setService(TranslatorInterface::class, $i18nTranslator);
+        }
+
+        return new Translator($i18nTranslator);
+    }
+}

--- a/src/Translator/TranslatorFactory.php
+++ b/src/Translator/TranslatorFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\Translator;
 
-// phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
-
 use Laminas\I18n\Translator\LoaderPluginManager;
 use Laminas\I18n\Translator\Translator as I18nTranslator;
 use Laminas\I18n\Translator\TranslatorInterface;

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator;
 
+use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
@@ -592,7 +593,7 @@ class ValidatorPluginManager extends AbstractPluginManager
         if ($validator instanceof Translator\TranslatorAwareInterface && $container instanceof ContainerInterface) {
             if ($container->has('MvcTranslator')) {
                 $validator->setTranslator($container->get('MvcTranslator'));
-            } elseif ($container->has(Translator\TranslatorInterface::class)) {
+            } elseif ($container->has(TranslatorInterface::class)) {
                 $validator->setTranslator($container->get(Translator\TranslatorInterface::class));
             }
         }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -585,17 +585,27 @@ class ValidatorPluginManager extends AbstractPluginManager
             $validator = $first;
         }
 
+        if (! $validator instanceof Translator\TranslatorAwareInterface) {
+            return;
+        }
+
         // V2 means we pull it from the parent container
         if ($container === $this && method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
             $container = $container->getServiceLocator();
         }
 
-        if ($validator instanceof Translator\TranslatorAwareInterface && $container instanceof ContainerInterface) {
-            if ($container->has('MvcTranslator')) {
-                $validator->setTranslator($container->get('MvcTranslator'));
-            } elseif ($container->has(TranslatorInterface::class)) {
-                $validator->setTranslator($container->get(Translator\TranslatorInterface::class));
-            }
+        if (! $container instanceof ContainerInterface) {
+            return;
+        }
+
+        if ($container->has('MvcTranslator')) {
+            $validator->setTranslator($container->get('MvcTranslator'));
+
+            return;
+        }
+
+        if ($container->has(TranslatorInterface::class)) {
+            $validator->setTranslator($container->get(Translator\TranslatorInterface::class));
         }
     }
 

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator;
 
+use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
@@ -589,9 +590,11 @@ class ValidatorPluginManager extends AbstractPluginManager
             $container = $container->getServiceLocator();
         }
 
-        if ($validator instanceof Translator\TranslatorAwareInterface) {
-            if ($container && $container->has('MvcTranslator')) {
+        if ($validator instanceof Translator\TranslatorAwareInterface && $container) {
+            if ($container->has('MvcTranslator')) {
                 $validator->setTranslator($container->get('MvcTranslator'));
+            } elseif ($container->has(TranslatorInterface::class)) {
+                $validator->setTranslator($container->get(TranslatorInterface::class));
             }
         }
     }

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -2,7 +2,6 @@
 
 namespace Laminas\Validator;
 
-use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\I18n\Validator as I18nValidator;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
@@ -590,11 +589,11 @@ class ValidatorPluginManager extends AbstractPluginManager
             $container = $container->getServiceLocator();
         }
 
-        if ($validator instanceof Translator\TranslatorAwareInterface && $container) {
+        if ($validator instanceof Translator\TranslatorAwareInterface && $container instanceof ContainerInterface) {
             if ($container->has('MvcTranslator')) {
                 $validator->setTranslator($container->get('MvcTranslator'));
-            } elseif ($container->has(TranslatorInterface::class)) {
-                $validator->setTranslator($container->get(TranslatorInterface::class));
+            } elseif ($container->has(Translator\TranslatorInterface::class)) {
+                $validator->setTranslator($container->get(Translator\TranslatorInterface::class));
             }
         }
     }

--- a/test/Translator/TranslatorFactoryTest.php
+++ b/test/Translator/TranslatorFactoryTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\Translator;
+
+// phpcs:disable WebimpressCodingStandard.PHP.CorrectClassNameCase
+
+use ArrayAccess;
+use ArrayObject;
+use Interop\Container\ContainerInterface;
+use Laminas\I18n\Translator\LoaderPluginManager;
+use Laminas\I18n\Translator\Translator as I18nTranslator;
+use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Validator\Translator\DummyTranslator;
+use Laminas\Validator\Translator\Translator;
+use Laminas\Validator\Translator\TranslatorFactory;
+use Locale;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+use PHPUnit\Framework\TestCase;
+
+use function extension_loaded;
+
+class TranslatorFactoryTest extends TestCase
+{
+    public function testFactoryReturnsTranslatorDecoratingTranslatorInterfaceServiceWhenPresent(): void
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::once())
+            ->method('has')
+            ->with(TranslatorInterface::class)
+            ->willReturn(true);
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with(TranslatorInterface::class)
+            ->willReturn($translator);
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertSame($translator, $test->getTranslator());
+    }
+
+    /** @psalm-return array<string, array{0: class-string}> */
+    public static function expectedTranslatorProvider(): array
+    {
+        return extension_loaded('intl')
+            ? ['intl-loaded' => [I18nTranslator::class]]
+            : ['no-intl-loaded' => [DummyTranslator::class]];
+    }
+
+    /**
+     * @dataProvider expectedTranslatorProvider
+     * @psalm-param class-string $expected
+     */
+    public function testFactoryReturnsTranslatorDecoratingDefaultTranslatorWhenNoConfigPresent(
+        string $expected
+    ): void {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['config', false],
+                ]
+            );
+        $container
+            ->expects(self::never())
+            ->method('get');
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertInstanceOf($expected, $test->getTranslator());
+    }
+
+    /**
+     * @dataProvider expectedTranslatorProvider
+     * @psalm-param class-string $expected
+     */
+    public function testFactoryReturnsMvcDecoratorDecoratingDefaultTranslatorWhenNoTranslatorConfigPresent(
+        string $expected
+    ): void {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn([]);
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertInstanceOf($expected, $test->getTranslator());
+    }
+
+    public function testFactoryReturnsMvcDecoratorDecoratingDummyTranslatorWhenTranslatorConfigIsFalse(): void
+    {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['translator' => false]);
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertInstanceOf(DummyTranslator::class, $test->getTranslator());
+    }
+
+    /**
+     * @dataProvider expectedTranslatorProvider
+     * @psalm-param class-string $expected
+     */
+    public function testFactoryReturnsMvcDecoratorDecoratingDefaultTranslatorWhenEmptyTranslatorConfigPresent(
+        string $expected
+    ): void {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['translator' => []]);
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertInstanceOf($expected, $test->getTranslator());
+    }
+
+    /** @psalm-return array<string, array{0: array<string, mixed>, 1: class-string}> */
+    public static function invalidTranslatorConfig(): array
+    {
+        $expectedTranslator = extension_loaded('intl')
+            ? I18nTranslator::class
+            : DummyTranslator::class;
+
+        return [
+            'null'    => [['translator' => null], $expectedTranslator],
+            'true'    => [['translator' => true], $expectedTranslator],
+            'zero'    => [['translator' => 0], $expectedTranslator],
+            'int'     => [['translator' => 1], $expectedTranslator],
+            'float-0' => [['translator' => 0.0], $expectedTranslator],
+            'float'   => [['translator' => 1.1], $expectedTranslator],
+            'string'  => [['translator' => 'invalid'], $expectedTranslator],
+            'object'  => [['translator' => (object) ['translator' => 'invalid']], $expectedTranslator],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @psalm-param class-string $expected
+     * @dataProvider invalidTranslatorConfig
+     */
+    public function testFactoryReturnsDecoratorDecoratingDefaultTranslatorWithInvalidTranslatorConfig(
+        $config,
+        $expected
+    ): void {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(2))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+        $this->assertInstanceOf($expected, $test->getTranslator());
+    }
+
+    /**
+     * @psalm-return array<non-empty-string,array{0:array<string,mixed>|ArrayAccess<string,mixed>}>
+     */
+    public static function validTranslatorConfig(): array
+    {
+        $locale = Locale::getDefault() === 'en-US' ? 'de-DE' : Locale::getDefault();
+        $config = [
+            'locale'                => $locale,
+            'event_manager_enabled' => true,
+        ];
+
+        return [
+            'array'       => [$config],
+            'traversable' => [new ArrayObject($config)],
+        ];
+    }
+
+    /**
+     * @requires extension intl
+     * @dataProvider validTranslatorConfig
+     * @param array<string,mixed>|ArrayAccess<string,mixed> $config
+     */
+    public function testFactoryReturnsConfiguredTranslatorWhenValidConfigIsPresent($config): void
+    {
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(3))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                    ['TranslatorPluginManager', false],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['translator' => $config]);
+        $container
+            ->expects(self::once())
+            ->method('setService')
+            ->with(TranslatorInterface::class, new IsInstanceOf(I18nTranslator::class));
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+
+        $decorated = $test->getTranslator();
+        $this->assertInstanceOf(I18nTranslator::class, $decorated);
+        $locale = $config['locale'] ?? null;
+        self::assertIsString($locale);
+        $this->assertEquals($locale, $decorated->getLocale());
+        $this->assertTrue($decorated->isEventManagerEnabled());
+    }
+
+    /**
+     * @param array<string,mixed>|ArrayAccess<string,mixed> $config
+     * @requires extension intl
+     * @dataProvider validTranslatorConfig
+     */
+    public function testFactoryReturnsConfiguredTranslatorInjectedWithTranslatorPluginManagerWhenValidConfigIsPresent(
+        $config
+    ): void {
+        $loaders = $this->createMock(LoaderPluginManager::class);
+
+        $container = $this->createMock(ServiceManager::class);
+        $container
+            ->expects(self::exactly(3))
+            ->method('has')
+            ->willReturnMap(
+                [
+                    [TranslatorInterface::class, false],
+                    ['Zend\I18n\Translator\TranslatorInterface', false],
+                    ['config', true],
+                    ['TranslatorPluginManager', true],
+                ]
+            );
+        $container
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['config', ['translator' => $config]],
+                    ['TranslatorPluginManager', $loaders],
+                ]
+            );
+        $container
+            ->expects(self::once())
+            ->method('setService')
+            ->with(TranslatorInterface::class, new IsInstanceOf(I18nTranslator::class));
+
+        self::assertInstanceOf(ContainerInterface::class, $container);
+
+        $factory = new TranslatorFactory();
+        $test    = $factory($container, TranslatorInterface::class);
+
+        $this->assertInstanceOf(Translator::class, $test);
+
+        $decorated = $test->getTranslator();
+        $this->assertInstanceOf(I18nTranslator::class, $decorated);
+        $this->assertEquals($config['locale'], $decorated->getLocale());
+        $this->assertTrue($decorated->isEventManagerEnabled());
+        $this->assertSame($loaders, $decorated->getPluginManager());
+    }
+}

--- a/test/Translator/TranslatorFactoryTest.php
+++ b/test/Translator/TranslatorFactoryTest.php
@@ -44,7 +44,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -84,7 +84,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -119,7 +119,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -149,7 +149,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -184,7 +184,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -240,7 +240,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -297,7 +297,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 
@@ -350,7 +350,7 @@ class TranslatorFactoryTest extends TestCase
         self::assertInstanceOf(ContainerInterface::class, $container);
 
         $factory = new TranslatorFactory();
-        $test    = $factory($container, TranslatorInterface::class);
+        $test    = $factory($container);
 
         $this->assertInstanceOf(Translator::class, $test);
 

--- a/test/Translator/TranslatorFactoryTest.php
+++ b/test/Translator/TranslatorFactoryTest.php
@@ -19,6 +19,7 @@ use Laminas\Validator\Translator\TranslatorFactory;
 use Locale;
 use PHPUnit\Framework\Constraint\IsInstanceOf;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 use function extension_loaded;
 
@@ -46,7 +47,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertSame($translator, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertSame($translator, $prop->getValue($test));
     }
 
     /** @psalm-return array<string, array{0: class-string}> */
@@ -84,7 +87,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertInstanceOf($expected, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertInstanceOf($expected, $prop->getValue($test));
     }
 
     /**
@@ -117,7 +122,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertInstanceOf($expected, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertInstanceOf($expected, $prop->getValue($test));
     }
 
     public function testFactoryReturnsMvcDecoratorDecoratingDummyTranslatorWhenTranslatorConfigIsFalse(): void
@@ -145,7 +152,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertInstanceOf(DummyTranslator::class, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertInstanceOf(DummyTranslator::class, $prop->getValue($test));
     }
 
     /**
@@ -178,7 +187,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertInstanceOf($expected, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertInstanceOf($expected, $prop->getValue($test));
     }
 
     /** @psalm-return array<string, array{0: array<string, mixed>, 1: class-string}> */
@@ -232,7 +243,9 @@ class TranslatorFactoryTest extends TestCase
         $test    = $factory($container, TranslatorInterface::class);
 
         $this->assertInstanceOf(Translator::class, $test);
-        $this->assertInstanceOf($expected, $test->getTranslator());
+
+        $prop = new ReflectionProperty($test, 'translator');
+        $this->assertInstanceOf($expected, $prop->getValue($test));
     }
 
     /**
@@ -288,7 +301,9 @@ class TranslatorFactoryTest extends TestCase
 
         $this->assertInstanceOf(Translator::class, $test);
 
-        $decorated = $test->getTranslator();
+        $prop      = new ReflectionProperty($test, 'translator');
+        $decorated = $prop->getValue($test);
+
         $this->assertInstanceOf(I18nTranslator::class, $decorated);
         $locale = $config['locale'] ?? null;
         self::assertIsString($locale);
@@ -339,7 +354,9 @@ class TranslatorFactoryTest extends TestCase
 
         $this->assertInstanceOf(Translator::class, $test);
 
-        $decorated = $test->getTranslator();
+        $prop      = new ReflectionProperty($test, 'translator');
+        $decorated = $prop->getValue($test);
+
         $this->assertInstanceOf(I18nTranslator::class, $decorated);
         $this->assertEquals($config['locale'], $decorated->getLocale());
         $this->assertTrue($decorated->isEventManagerEnabled());

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -9,6 +9,8 @@ use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Validator\Translator\Translator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
+use ReflectionProperty;
 
 class TranslatorTest extends TestCase
 {
@@ -34,8 +36,13 @@ class TranslatorTest extends TestCase
         $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function testCanRetrieveComposedTranslator(): void
     {
-        $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());
+        $prop = new ReflectionProperty($this->translator, 'translator');
+
+        $this->assertSame($this->i18nTranslator, $prop->getValue($this->translator));
     }
 }

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\Translator;
+
+use Laminas\I18n\Translator\Translator as I18nTranslator;
+use Laminas\I18n\Translator\TranslatorInterface;
+use Laminas\Validator\Translator\Translator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TranslatorTest extends TestCase
+{
+    /** @var Translator */
+    protected $translator;
+
+    /** @var TranslatorInterface|MockObject */
+    protected $i18nTranslator;
+
+    public function setUp(): void
+    {
+        $this->i18nTranslator = $this->createMock(I18nTranslator::class);
+        $this->translator     = new Translator($this->i18nTranslator);
+    }
+
+    public function testIsAnI18nTranslator(): void
+    {
+        $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
+    }
+
+    public function testIsAValidatorTranslator(): void
+    {
+        $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
+    }
+
+    public function testCanRetrieveComposedTranslator(): void
+    {
+        $this->assertSame($this->i18nTranslator, $this->translator->getTranslator());
+    }
+}

--- a/test/Translator/TranslatorTest.php
+++ b/test/Translator/TranslatorTest.php
@@ -9,15 +9,13 @@ use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Validator\Translator\Translator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ReflectionException;
-use ReflectionProperty;
 
 class TranslatorTest extends TestCase
 {
     /** @var Translator */
     protected $translator;
 
-    /** @var TranslatorInterface|MockObject */
+    /** @var TranslatorInterface&MockObject */
     protected $i18nTranslator;
 
     public function setUp(): void
@@ -26,23 +24,55 @@ class TranslatorTest extends TestCase
         $this->translator     = new Translator($this->i18nTranslator);
     }
 
-    public function testIsAnI18nTranslator(): void
+    public function testTranslate(): void
     {
-        $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
+        $message    = 'This is the message';
+        $textDomain = 'default';
+        $locale     = 'en_US';
+
+        $this->i18nTranslator->expects($this->once())
+            ->method('translate')
+            ->with($message, $textDomain, $locale)
+            ->willReturn($message);
+
+        $this->assertEquals(
+            $message,
+            $this->translator->translate(
+                $message,
+                $textDomain,
+                $locale
+            )
+        );
     }
 
-    public function testIsAValidatorTranslator(): void
+    public function testTranslatePlural(): void
     {
-        $this->assertInstanceOf(TranslatorInterface::class, $this->translator);
-    }
+        $singular   = 'singular';
+        $plural     = 'plural';
+        $number     = 2;
+        $textDomain = 'default';
+        $locale     = 'en_US';
 
-    /**
-     * @throws ReflectionException
-     */
-    public function testCanRetrieveComposedTranslator(): void
-    {
-        $prop = new ReflectionProperty($this->translator, 'translator');
+        $this->i18nTranslator->expects($this->once())
+            ->method('translatePlural')
+            ->with(
+                $singular,
+                $plural,
+                $number,
+                $textDomain,
+                $locale
+            )
+            ->willReturn($singular);
 
-        $this->assertSame($this->i18nTranslator, $prop->getValue($this->translator));
+        $this->assertEquals(
+            $singular,
+            $this->translator->translatePlural(
+                $singular,
+                $plural,
+                $number,
+                $textDomain,
+                $locale
+            )
+        );
     }
 }

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -71,7 +71,7 @@ final class ValidatorPluginManagerTest extends TestCase
             ->willReturnMap(
                 [
                     ['MvcTranslator', false],
-                    [TranslatorInterface::class, true],
+                    [\Laminas\I18n\Translator\TranslatorInterface::class, true],
                 ]
             );
 

--- a/test/ValidatorPluginManagerTest.php
+++ b/test/ValidatorPluginManagerTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Exception;
-use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\Explode;
 use Laminas\Validator\NotEmpty;
+use Laminas\Validator\Translator\TranslatorInterface;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use LaminasTest\Validator\TestAsset\InMemoryContainer;


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR wants to allow the use of `Laminas\I18n\Translator\TranslatorInterface` if 'MvcTranslator' is not available.
This is related to #194.