### PR TITLE
prevent warnings when using Puny encoded Hostnames

### DIFF
--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -2212,6 +2212,10 @@ class Hostname extends AbstractValidator
 
         for ($indexe = $separator ? $separator + 1 : 0; $indexe < $lengthe; ++$lengthd) {
             for ($oldIndex = $index, $pos = 1, $key = 36; 1; $key += 36) {
+                if (! isset($encoded[$indexe])) {
+                    break 2;
+                }
+
                 $hex   = ord($encoded[$indexe++]);
                 $digit = $hex - 48 < 10 ? $hex - 22
                        : ($hex - 65 < 26 ? $hex - 65

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -686,8 +686,13 @@ final class HostnameTest extends TestCase
         self::assertFalse($this->validator->isValid('.com'));
     }
 
-    public function testHostnameWithPunyEncodedDomainPart(): void
+    public function testInvalidHostnameWithPunyEncodedDomainPart(): void
     {
         self::assertFalse($this->validator->isValid('xn--k.dk'));
+    }
+
+    public function testValidHostnameWithPunyEncodedDomainPart(): void
+    {
+        self::assertTrue($this->validator->isValid('xn--gld-sna.de'));
     }
 }

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -685,4 +685,9 @@ final class HostnameTest extends TestCase
     {
         self::assertFalse($this->validator->isValid('.com'));
     }
+
+    public function testHostnameWithPunyEncodedDomainPart(): void
+    {
+        self::assertFalse($this->validator->isValid('xn--k.dk'));
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR wants do prevent warings when using Puny encoded hostnames. This is related to #207 
