### PR TITLE
Add `UploadedFileInterface` to valid types of `$value` parameter of `MimeType::isValid()`

### DIFF
--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -36,8 +36,8 @@ class ExcludeMimeType extends MimeType
      * of mimetypes can be checked. If you give for example "image" all image
      * mime types will not be accepted like "image/gif", "image/jpeg" and so on.
      *
-     * @param  string|array $value Real file to check for mimetype
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
+     * @param  string|array|object $value Real file to check for mimetype
+     * @param  array               $file  File data from \Laminas\File\Transfer\Transfer (optional)
      * @return bool
      */
     public function isValid($value, $file = null)

--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -2,6 +2,8 @@
 
 namespace Laminas\Validator\File;
 
+use Psr\Http\Message\UploadedFileInterface;
+
 use function array_merge;
 use function class_exists;
 use function explode;

--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -36,8 +36,8 @@ class ExcludeMimeType extends MimeType
      * of mimetypes can be checked. If you give for example "image" all image
      * mime types will not be accepted like "image/gif", "image/jpeg" and so on.
      *
-     * @param  string|array|object $value Real file to check for mimetype
-     * @param  array               $file  File data from \Laminas\File\Transfer\Transfer (optional)
+     * @param  string|array|UploadedFileInterface $value Real file to check for mimetype
+     * @param  array                              $file  File data from \Laminas\File\Transfer\Transfer (optional)
      * @return bool
      */
     public function isValid($value, $file = null)

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -346,8 +346,8 @@ class MimeType extends AbstractValidator
      * of mimetypes can be checked. If you give for example "image" all image
      * mime types will be accepted like "image/gif", "image/jpeg" and so on.
      *
-     * @param  string|array $value Real file to check for mimetype
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
+     * @param  string|array|object $value Real file to check for mimetype
+     * @param  array               $file  File data from \Laminas\File\Transfer\Transfer (optional)
      * @return bool
      */
     public function isValid($value, $file = null)

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -7,6 +7,7 @@ use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\ErrorHandler;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception;
+use Psr\Http\Message\UploadedFileInterface;
 use Traversable;
 
 use function array_filter;

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -346,7 +346,7 @@ class MimeType extends AbstractValidator
      * of mimetypes can be checked. If you give for example "image" all image
      * mime types will be accepted like "image/gif", "image/jpeg" and so on.
      *
-     * @param  string|array|object $value Real file to check for mimetype
+     * @param  string|array|UploadedFileInterface $value Real file to check for mimetype
      * @param  array               $file  File data from \Laminas\File\Transfer\Transfer (optional)
      * @return bool
      */


### PR DESCRIPTION
The `$value` parameter of `MimeType::isValid()` is passed to [`FileInformationTrait::getFileInfo()`](https://github.com/laminas/laminas-validator/blob/2.51.x/src/File/FileInformationTrait.php#L17) which takes `string|array|object`, so `isValid()`'s `$value` should accept the same types.