### PR TITLE
Add `throwExceptions` option to Callback validator

### DIFF
--- a/docs/book/validators/callback.md
+++ b/docs/book/validators/callback.md
@@ -10,6 +10,7 @@ The following options are supported for `Laminas\Validator\Callback`:
 - `callback`: Sets the callback which will be called for the validation.
 - `callbackOptions`: Sets the additional options which will be given to the validator
   and/or callback.
+- `throwExceptions`: When true, [allows exceptions thrown inside of callbacks to propagate](#exceptions-within-callbacks).
 
 ## Basic usage
 

--- a/docs/book/validators/callback.md
+++ b/docs/book/validators/callback.md
@@ -204,7 +204,7 @@ which can be used is not limited.
 
 ## Exceptions within Callbacks
 
-By default, the callback validator will catch any `Throwable` thrown inside the callback and return false.
+By default, the callback validator will catch any `Exception` thrown inside the callback and return false.
 The error message will indicate callback failure as opposed to invalid input.
 
 There is a third option `throwExceptions` that when `true` will re-throw exceptions that occur inside the callback.

--- a/docs/book/validators/callback.md
+++ b/docs/book/validators/callback.md
@@ -214,8 +214,6 @@ This is primarily useful in a development environment when you are testing callb
 For example:
 
 ```php
-use Laminas\Validator\Callback;
-
 $callback = static function (mixed $value): bool {
     if ($value === true) {
         return true;
@@ -224,7 +222,7 @@ $callback = static function (mixed $value): bool {
     throw new ApplicationException('Bad news');
 }
 
-$validator = new Callback([
+$validator = new Laminas\Validator\Callback([
     'callback' => $callback,
     'throwExceptions' => true,
 ]);

--- a/docs/book/validators/callback.md
+++ b/docs/book/validators/callback.md
@@ -201,3 +201,33 @@ When making the call to the callback, the value to be validated will always be
 passed as the first argument to the callback followed by all other values given
 to `isValid()`; all other options will follow it. The amount and type of options
 which can be used is not limited.
+
+## Exceptions within Callbacks
+
+By default, the callback validator will catch any `Throwable` thrown inside the callback and return false.
+The error message will indicate callback failure as opposed to invalid input.
+
+There is a third option `throwExceptions` that when `true` will re-throw exceptions that occur inside the callback.
+
+This is primarily useful in a development environment when you are testing callbacks and need to catch and verify exceptions thrown by your own application.
+
+For example:
+
+```php
+use Laminas\Validator\Callback;
+
+$callback = static function (mixed $value): bool {
+    if ($value === true) {
+        return true;
+    }
+    
+    throw new ApplicationException('Bad news');
+}
+
+$validator = new Callback([
+    'callback' => $callback,
+    'throwExceptions' => true,
+]);
+
+$validator->isValid('Nope'); // An exception is thrown
+```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -402,22 +402,23 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Callback.php">
-    <MixedArgument>
-      <code><![CDATA[$options]]></code>
-      <code><![CDATA[$options]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$args[]]]></code>
       <code><![CDATA[$args[]]]></code>
-      <code><![CDATA[$callback]]></code>
-      <code><![CDATA[$options]]></code>
     </MixedAssignment>
-    <MixedFunctionCall>
-      <code><![CDATA[call_user_func_array($callback, $args)]]></code>
-    </MixedFunctionCall>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
+    <MixedInferredReturnType>
+      <code><![CDATA[array<array-key, mixed>]]></code>
+      <code><![CDATA[callable|null]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['callback'] ?? null]]></code>
+      <code><![CDATA[$this->options['callback'] ?? null]]></code>
+      <code><![CDATA[$this->options['callbackOptions'] ?? []]]></code>
+      <code><![CDATA[$this->options['callbackOptions'] ?? []]]></code>
+    </MixedReturnStatement>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $options]]></code>
+    </RedundantCastGivenDocblockType>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[empty($context)]]></code>
       <code><![CDATA[empty($context)]]></code>
@@ -2128,12 +2129,6 @@
       <code><![CDATA[$v]]></code>
       <code><![CDATA[$v]]></code>
     </MissingClosureParamType>
-    <MixedArrayAssignment>
-      <code><![CDATA[$options['callback']]]></code>
-    </MixedArrayAssignment>
-    <MixedAssignment>
-      <code><![CDATA[$options]]></code>
-    </MixedAssignment>
     <PossiblyUnusedMethod>
       <code><![CDATA[optionsCallback]]></code>
     </PossiblyUnusedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -411,10 +411,8 @@
       <code><![CDATA[callable|null]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code><![CDATA[$this->options['callback'] ?? null]]></code>
-      <code><![CDATA[$this->options['callback'] ?? null]]></code>
-      <code><![CDATA[$this->options['callbackOptions'] ?? []]]></code>
-      <code><![CDATA[$this->options['callbackOptions'] ?? []]]></code>
+      <code><![CDATA[$this->options['callback']]]></code>
+      <code><![CDATA[$this->options['callbackOptions']]]></code>
     </MixedReturnStatement>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(array) $options]]></code>

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -19,7 +19,8 @@ use function is_callable;
  *     callback: callable,
  *     callbackOptions?: array<array-key, mixed>,
  *     throwExceptions?: bool,
- * }&array<string, mixed>
+ *     ...<string, mixed>
+ * }
  */
 class Callback extends AbstractValidator
 {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -10,11 +10,16 @@ use function call_user_func_array;
 use function is_callable;
 
 /**
- * @psalm-type Options = array{
- *     callback?: callable|null,
+ * @psalm-type OptionsProperty = array{
+ *     callback: callable|null,
+ *     callbackOptions: array<array-key, mixed>,
+ *     throwExceptions: bool,
+ * }
+ * @psalm-type OptionsArgument = array{
+ *     callback: callable,
  *     callbackOptions?: array<array-key, mixed>,
  *     throwExceptions?: bool,
- * }
+ * }&array<string, mixed>
  */
 class Callback extends AbstractValidator
 {
@@ -41,7 +46,7 @@ class Callback extends AbstractValidator
     /**
      * Default options to set for the validator
      *
-     * @var Options
+     * @var OptionsProperty
      */
     protected $options = [
         'callback'        => null, // Callback in a call_user_func format, string || array
@@ -49,7 +54,7 @@ class Callback extends AbstractValidator
         'throwExceptions' => false, // Whether to throw exceptions raised within the callback or not
     ];
 
-    /** @param Options|callable $options */
+    /** @param OptionsArgument|callable $options */
     public function __construct($options = null)
     {
         if (is_callable($options)) {
@@ -66,7 +71,7 @@ class Callback extends AbstractValidator
      */
     public function getCallback()
     {
-        return $this->options['callback'] ?? null;
+        return $this->options['callback'];
     }
 
     /**
@@ -93,7 +98,7 @@ class Callback extends AbstractValidator
      */
     public function getCallbackOptions()
     {
-        return $this->options['callbackOptions'] ?? [];
+        return $this->options['callbackOptions'];
     }
 
     /**

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -149,11 +149,14 @@ class Callback extends AbstractValidator
                 $this->error(self::INVALID_VALUE);
                 return false;
             }
-        } catch (Exception $error) {
+        } catch (Exception $exception) {
+            /**
+             * Intentionally excluding catchable \Error as they are indicative of a bug and should not be suppressed
+             */
             $this->error(self::INVALID_CALLBACK);
 
             if ($this->options['throwExceptions'] === true) {
-                throw $error;
+                throw $exception;
             }
 
             return false;

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -2,8 +2,8 @@
 
 namespace Laminas\Validator;
 
+use Exception;
 use Laminas\Validator\Exception\InvalidArgumentException;
-use Throwable;
 
 use function array_merge;
 use function call_user_func_array;
@@ -144,7 +144,7 @@ class Callback extends AbstractValidator
                 $this->error(self::INVALID_VALUE);
                 return false;
             }
-        } catch (Throwable $error) {
+        } catch (Exception $error) {
             $this->error(self::INVALID_CALLBACK);
 
             if ($this->options['throwExceptions'] === true) {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

This is a handy option for the callback validator that stops it from swallowing exceptions thrown in your callback. Off by default preserves existing behaviour.

Why? particularly in development, if you have a complex callback, can't figure out why it's failing and step debugging isn't helping you either

The Psalm baseline is mostly improved but there are still issues with the options array - this is mainly because of an `@property array $options` doc block on `AbstractValidator`