### PR TITLE
Remove dependency on laminas-filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^2.5",
-        "laminas/laminas-filter": "^2.35.2",
         "laminas/laminas-i18n": "^2.26.0",
         "laminas/laminas-session": "^2.20",
         "laminas/laminas-uri": "^2.11.0",
@@ -49,7 +48,6 @@
         "vimeo/psalm": "^5.24.0"
     },
     "suggest": {
-        "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
         "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
         "laminas/laminas-i18n-resources": "Translations of validator messages",
         "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2280150bdc202cc85b5945d029fc54d8",
+    "content-hash": "e01a1d2372c9ad11a9fb46917a36014c",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1168,85 +1168,6 @@
                 }
             ],
             "time": "2024-01-03T17:43:50+00:00"
-        },
-        {
-            "name": "laminas/laminas-filter",
-            "version": "2.35.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "3e821b33a787253d56046f9258174a22de1bd267"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/3e821b33a787253d56046f9258174a22de1bd267",
-                "reference": "3e821b33a787253d56046f9258174a22de1bd267",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.13.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "laminas/laminas-validator": "<2.10.1",
-                "zendframework/zend-filter": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-crypt": "^3.11",
-                "laminas/laminas-i18n": "^2.26.0",
-                "laminas/laminas-uri": "^2.11",
-                "pear/archive_tar": "^1.4.14",
-                "phpunit/phpunit": "^10.5.11",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "psr/http-factory": "^1.0.2",
-                "vimeo/psalm": "^5.22.2"
-            },
-            "suggest": {
-                "laminas/laminas-crypt": "Laminas\\Crypt component, for encryption filters",
-                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "laminas/laminas-uri": "Laminas\\Uri component, for the UriNormalize filter",
-                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Filter",
-                    "config-provider": "Laminas\\Filter\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Filter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Programmatically filter and normalize data and files",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "filter",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-filter/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-filter/issues",
-                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
-                "source": "https://github.com/laminas/laminas-filter"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-04-11T08:13:56+00:00"
         },
         {
             "name": "laminas/laminas-i18n",

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -2,11 +2,10 @@
 
 namespace Laminas\Validator;
 
-use Laminas\Filter\Digits as DigitsFilter;
-
 use function is_float;
 use function is_int;
 use function is_string;
+use function preg_replace;
 
 class Digits extends AbstractValidator
 {
@@ -15,16 +14,9 @@ class Digits extends AbstractValidator
     public const INVALID      = 'digitsInvalid';
 
     /**
-     * Digits filter used for validation
-     *
-     * @var DigitsFilter|null
-     */
-    protected static $filter;
-
-    /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::NOT_DIGITS   => 'The input must contain only digits',
@@ -34,11 +26,8 @@ class Digits extends AbstractValidator
 
     /**
      * Returns true if and only if $value only contains digit characters
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value) && ! is_int($value) && ! is_float($value)) {
             $this->error(self::INVALID);
@@ -52,11 +41,9 @@ class Digits extends AbstractValidator
             return false;
         }
 
-        if (null === static::$filter) {
-            static::$filter = new DigitsFilter();
-        }
+        $digits = preg_replace('/[^0-9]/', '', (string) $value);
 
-        if ($this->getValue() !== static::$filter->filter($this->getValue())) {
+        if ($value !== $digits) {
             $this->error(self::NOT_DIGITS);
             return false;
         }


### PR DESCRIPTION
This dependency was always pretty unnecessary. It will make the digits validator usable without installing an optional dependency and make migration to SMv4 easier too.