### PR TITLE
Mark all classes as soft `@final` where possible

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,14 +16,6 @@
     </MixedArgument>
   </file>
   <file src="src/AbstractValidator.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-      <code><![CDATA[$this]]></code>
-    </LessSpecificReturnStatement>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>
     </MixedArgumentTypeCoercion>
@@ -367,15 +359,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Bitwise.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[self::OP_AND === $this->operator]]></code>
-      <code><![CDATA[self::OP_AND === $this->operator]]></code>
-      <code><![CDATA[self::OP_XOR === $this->operator]]></code>
-      <code><![CDATA[self::OP_XOR === $this->operator]]></code>
-    </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$operator]]></code>
-    </InvalidPropertyAssignmentValue>
     <MixedAssignment>
       <code><![CDATA[$temp['control']]]></code>
       <code><![CDATA[$temp['operator']]]></code>
@@ -474,6 +457,9 @@
       <code><![CDATA[is_array($options)]]></code>
       <code><![CDATA[null === $this->session]]></code>
     </DocblockTypeContradiction>
+    <ImpureByReferenceAssignment>
+      <code><![CDATA[$session->tokenList]]></code>
+    </ImpureByReferenceAssignment>
     <MixedArgument>
       <code><![CDATA[$key]]></code>
       <code><![CDATA[$session->tokenList[$tokenId]]]></code>
@@ -1657,9 +1643,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Ip.php">
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[AbstractValidator]]></code>
-    </LessSpecificImplementedReturnType>
     <MixedArgument>
       <code><![CDATA[$regex]]></code>
       <code><![CDATA[$regex]]></code>
@@ -1803,25 +1786,14 @@
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($options)]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code><![CDATA[$value]]></code>
-    </InvalidArgument>
     <MixedArgument>
-      <code><![CDATA[$this->baseValue]]></code>
-      <code><![CDATA[$this->step]]></code>
+      <code><![CDATA[$options['baseValue']]]></code>
+      <code><![CDATA[$options['step']]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$temp['baseValue']]]></code>
       <code><![CDATA[$temp['step']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[string]]></code>
-      <code><![CDATA[string]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->baseValue]]></code>
-      <code><![CDATA[$this->step]]></code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyInvalidArgument>

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -153,7 +153,7 @@ abstract class AbstractValidator implements
      * Sets one or multiple options
      *
      * @param  array<string, mixed>|Traversable<string, mixed> $options Options to set
-     * @return $this Provides fluid interface
+     * @return self Provides fluid interface
      * @throws Exception\InvalidArgumentException If $options is not an array or Traversable.
      */
     public function setOptions($options = [])

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -17,6 +17,7 @@ use function strtolower;
 use function substr;
 use function ucfirst;
 
+/** @final */
 class Barcode extends AbstractValidator
 {
     public const INVALID        = 'barcodeInvalid';

--- a/src/Barcode/Codabar.php
+++ b/src/Barcode/Codabar.php
@@ -5,6 +5,7 @@ namespace Laminas\Validator\Barcode;
 use function strpbrk;
 use function substr;
 
+/** @final */
 class Codabar extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code128.php
+++ b/src/Barcode/Code128.php
@@ -10,6 +10,7 @@ use function chr;
 use function is_string;
 use function ord;
 
+/** @final */
 class Code128 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code25.php
+++ b/src/Barcode/Code25.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Code25 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code25interleaved.php
+++ b/src/Barcode/Code25interleaved.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Code25interleaved extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code39.php
+++ b/src/Barcode/Code39.php
@@ -5,6 +5,7 @@ namespace Laminas\Validator\Barcode;
 use function str_split;
 use function substr;
 
+/** @final */
 class Code39 extends AbstractAdapter
 {
     /** @var array */

--- a/src/Barcode/Code39ext.php
+++ b/src/Barcode/Code39ext.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Code39ext extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code93.php
+++ b/src/Barcode/Code93.php
@@ -7,6 +7,7 @@ use function count;
 use function str_split;
 use function substr;
 
+/** @final */
 class Code93 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Code93ext.php
+++ b/src/Barcode/Code93ext.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Code93ext extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean12.php
+++ b/src/Barcode/Ean12.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean12 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean13.php
+++ b/src/Barcode/Ean13.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean13 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean14.php
+++ b/src/Barcode/Ean14.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean14 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean18.php
+++ b/src/Barcode/Ean18.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean18 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean2.php
+++ b/src/Barcode/Ean2.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean2 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean5.php
+++ b/src/Barcode/Ean5.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Ean5 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Ean8.php
+++ b/src/Barcode/Ean8.php
@@ -4,6 +4,7 @@ namespace Laminas\Validator\Barcode;
 
 use function strlen;
 
+/** @final */
 class Ean8 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Gtin12.php
+++ b/src/Barcode/Gtin12.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Gtin12 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Gtin13.php
+++ b/src/Barcode/Gtin13.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Gtin13 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Gtin14.php
+++ b/src/Barcode/Gtin14.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Gtin14 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Identcode.php
+++ b/src/Barcode/Identcode.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Identcode extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Intelligentmail.php
+++ b/src/Barcode/Intelligentmail.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Intelligentmail extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Issn.php
+++ b/src/Barcode/Issn.php
@@ -7,6 +7,7 @@ use function str_split;
 use function strlen;
 use function substr;
 
+/** @final */
 class Issn extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Itf14.php
+++ b/src/Barcode/Itf14.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Itf14 extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Leitcode.php
+++ b/src/Barcode/Leitcode.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Leitcode extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Planet.php
+++ b/src/Barcode/Planet.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Planet extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Postnet.php
+++ b/src/Barcode/Postnet.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Postnet extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Royalmail.php
+++ b/src/Barcode/Royalmail.php
@@ -9,6 +9,7 @@ use function str_split;
 use function strlen;
 use function substr;
 
+/** @final */
 class Royalmail extends AbstractAdapter
 {
     /** @var array<array-key, int> */

--- a/src/Barcode/Sscc.php
+++ b/src/Barcode/Sscc.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Sscc extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Upca.php
+++ b/src/Barcode/Upca.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Barcode;
 
+/** @final */
 class Upca extends AbstractAdapter
 {
     /**

--- a/src/Barcode/Upce.php
+++ b/src/Barcode/Upce.php
@@ -4,6 +4,7 @@ namespace Laminas\Validator\Barcode;
 
 use function strlen;
 
+/** @final */
 class Upce extends AbstractAdapter
 {
     /**

--- a/src/Between.php
+++ b/src/Between.php
@@ -14,6 +14,7 @@ use function is_string;
 
 use const PHP_INT_MAX;
 
+/** @final */
 class Between extends AbstractValidator
 {
     public const NOT_BETWEEN        = 'notBetween';

--- a/src/Bitwise.php
+++ b/src/Bitwise.php
@@ -9,6 +9,7 @@ use function func_get_args;
 use function is_array;
 use function iterator_to_array;
 
+/** @final */
 class Bitwise extends AbstractValidator
 {
     public const OP_AND = 'and';
@@ -43,7 +44,7 @@ class Bitwise extends AbstractValidator
         'control' => 'control',
     ];
 
-    /** @var null|int */
+    /** @var null|string */
     protected $operator;
 
     /** @var bool */
@@ -96,7 +97,7 @@ class Bitwise extends AbstractValidator
     /**
      * Returns the operator parameter.
      *
-     * @return null|int
+     * @return null|string
      */
     public function getOperator()
     {

--- a/src/BusinessIdentifierCode.php
+++ b/src/BusinessIdentifierCode.php
@@ -7,6 +7,7 @@ use function is_string;
 use function preg_match;
 use function strtoupper;
 
+/** @final */
 class BusinessIdentifierCode extends AbstractValidator
 {
     public const INVALID           = 'valueNotBic';

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -21,6 +21,7 @@ use function is_callable;
  *     throwExceptions?: bool,
  *     ...<string, mixed>
  * }
+ * @final
  */
 class Callback extends AbstractValidator
 {

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator;
 
+/** @final */
 class ConfigProvider
 {
     /**

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -24,6 +24,7 @@ use function str_starts_with;
 use function strlen;
 use function strtoupper;
 
+/** @final */
 class CreditCard extends AbstractValidator
 {
     /**

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -16,6 +16,7 @@ use function str_replace;
 use function strtolower;
 use function strtr;
 
+/** @final */
 class Csrf extends AbstractValidator
 {
     /**

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -31,6 +31,7 @@ use function str_starts_with;
 
 use const PHP_INT_MAX;
 
+/** @final */
 class DateStep extends Date
 {
     /**

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -8,6 +8,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 
+/** @final */
 class Digits extends AbstractValidator
 {
     public const NOT_DIGITS   = 'notDigits';

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -28,6 +28,7 @@ use function trim;
 
 use const INTL_IDNA_VARIANT_UTS46;
 
+/** @final */
 class EmailAddress extends AbstractValidator
 {
     public const INVALID            = 'emailAddressInvalid';

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Exception;
 
+/** @final */
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Exception;
 
+/** @final */
 class ExtensionNotLoadedException extends RuntimeException
 {
 }

--- a/src/Exception/InvalidMagicMimeFileException.php
+++ b/src/Exception/InvalidMagicMimeFileException.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Exception;
 
+/** @final */
 class InvalidMagicMimeFileException extends InvalidArgumentException
 {
 }

--- a/src/Explode.php
+++ b/src/Explode.php
@@ -13,6 +13,7 @@ use function sprintf;
 
 /**
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
+ * @final
  */
 class Explode extends AbstractValidator implements ValidatorPluginManagerAwareInterface
 {

--- a/src/File/Count.php
+++ b/src/File/Count.php
@@ -21,6 +21,8 @@ use const DIRECTORY_SEPARATOR;
 
 /**
  * Validator for counting all given files
+ *
+ * @final
  */
 class Count extends AbstractValidator
 {

--- a/src/File/Crc32.php
+++ b/src/File/Crc32.php
@@ -9,6 +9,8 @@ use function is_readable;
 
 /**
  * Validator for the crc32 hash of given files
+ *
+ * @final
  */
 class Crc32 extends Hash
 {

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -10,6 +10,8 @@ use function substr;
 
 /**
  * Validator for the excluding file extensions
+ *
+ * @final
  */
 class ExcludeExtension extends Extension
 {

--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -17,6 +17,8 @@ use const FILEINFO_MIME_TYPE;
 
 /**
  * Validator for the mime type of a file
+ *
+ * @final
  */
 class ExcludeMimeType extends MimeType
 {

--- a/src/File/FilesSize.php
+++ b/src/File/FilesSize.php
@@ -20,6 +20,8 @@ use function is_string;
 
 /**
  * Validator for the size of all files which will be validated in sum
+ *
+ * @final
  */
 class FilesSize extends Size
 {

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -16,6 +16,8 @@ use function is_readable;
 
 /**
  * Validator for the image size of an image file
+ *
+ * @final
  */
 class ImageSize extends AbstractValidator
 {

--- a/src/File/IsCompressed.php
+++ b/src/File/IsCompressed.php
@@ -7,6 +7,8 @@ use Traversable;
 
 /**
  * Validator which checks if the file already exists in the directory
+ *
+ * @final
  */
 class IsCompressed extends MimeType
 {

--- a/src/File/IsImage.php
+++ b/src/File/IsImage.php
@@ -7,6 +7,8 @@ use Traversable;
 
 /**
  * Validator which checks if the file is an image
+ *
+ * @final
  */
 class IsImage extends MimeType
 {

--- a/src/File/Md5.php
+++ b/src/File/Md5.php
@@ -9,6 +9,8 @@ use function is_readable;
 
 /**
  * Validator for the md5 hash of given files
+ *
+ * @final
  */
 class Md5 extends Hash
 {

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -196,7 +196,7 @@ class MimeType extends AbstractValidator
      * @throws Exception\RuntimeException When finfo can not read the magicfile.
      * @throws Exception\InvalidArgumentException
      * @throws Exception\InvalidMagicMimeFileException
-     * @return $this Provides fluid interface
+     * @return self Provides fluid interface
      */
     public function setMagicFile($file)
     {
@@ -266,7 +266,7 @@ class MimeType extends AbstractValidator
      * Note that this is unsafe and therefor the default value is false
      *
      * @param  bool $headerCheck
-     * @return $this Provides fluid interface
+     * @return self Provides fluid interface
      */
     public function enableHeaderCheck($headerCheck = true)
     {
@@ -296,7 +296,7 @@ class MimeType extends AbstractValidator
      * Sets the mimetypes
      *
      * @param  string|list<string> $mimetype The mimetypes to validate
-     * @return $this Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function setMimeType($mimetype)
     {
@@ -310,7 +310,7 @@ class MimeType extends AbstractValidator
      *
      * @param  string|list<string> $mimetype The mimetypes to add for validation
      * @throws Exception\InvalidArgumentException
-     * @return $this Provides a fluent interface
+     * @return self Provides a fluent interface
      */
     public function addMimeType($mimetype)
     {

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -8,6 +8,8 @@ use const DIRECTORY_SEPARATOR;
 
 /**
  * Validator which checks if the destination file does not exist
+ *
+ * @final
  */
 class NotExists extends Exists
 {

--- a/src/File/Sha1.php
+++ b/src/File/Sha1.php
@@ -9,6 +9,8 @@ use function is_readable;
 
 /**
  * Validator for the sha1 hash of given files
+ *
+ * @final
  */
 class Sha1 extends Hash
 {

--- a/src/File/Upload.php
+++ b/src/File/Upload.php
@@ -17,6 +17,8 @@ use function is_uploaded_file;
 
 /**
  * Validator for the maximum size of a file up to a max of 2GB
+ *
+ * @final
  */
 class Upload extends AbstractValidator
 {

--- a/src/File/UploadFile.php
+++ b/src/File/UploadFile.php
@@ -23,6 +23,8 @@ use const UPLOAD_ERR_PARTIAL;
 
 /**
  * Validator for the maximum size of a file up to a max of 2GB
+ *
+ * @final
  */
 class UploadFile extends AbstractValidator
 {

--- a/src/File/WordCount.php
+++ b/src/File/WordCount.php
@@ -18,6 +18,8 @@ use function str_word_count;
 
 /**
  * Validator for counting all words in a file
+ *
+ * @final
  */
 class WordCount extends AbstractValidator
 {

--- a/src/GreaterThan.php
+++ b/src/GreaterThan.php
@@ -10,6 +10,7 @@ use function array_shift;
 use function func_get_args;
 use function is_array;
 
+/** @final */
 class GreaterThan extends AbstractValidator
 {
     public const NOT_GREATER           = 'notGreaterThan';

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -6,6 +6,7 @@ use function ctype_xdigit;
 use function is_int;
 use function is_string;
 
+/** @final */
 class Hex extends AbstractValidator
 {
     public const INVALID = 'hexInvalid';

--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -46,6 +46,7 @@ use function substr;
  *    useTldCheck?: bool,
  *    ipValidator?: null|ValidatorInterface,
  * }
+ * @final
  */
 class Hostname extends AbstractValidator
 {

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -17,6 +17,8 @@ use function substr;
 
 /**
  * Validates IBAN Numbers (International Bank Account Numbers)
+ *
+ * @final
  */
 class Iban extends AbstractValidator
 {

--- a/src/Identical.php
+++ b/src/Identical.php
@@ -15,6 +15,7 @@ use function key;
 use function sprintf;
 use function var_export;
 
+/** @final */
 class Identical extends AbstractValidator
 {
     /**

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -11,6 +11,7 @@ use function is_float;
 use function is_int;
 use function is_string;
 
+/** @final */
 class InArray extends AbstractValidator
 {
     public const NOT_IN_ARRAY = 'notInArray';

--- a/src/Ip.php
+++ b/src/Ip.php
@@ -17,6 +17,7 @@ use function strrpos;
 use function substr;
 use function substr_count;
 
+/** @final */
 class Ip extends AbstractValidator
 {
     public const INVALID        = 'ipInvalid';

--- a/src/IsCountable.php
+++ b/src/IsCountable.php
@@ -36,6 +36,7 @@ use function is_numeric;
  * }&array<string, mixed>
  * @property Options&array<string, mixed> $options Required to stop Psalm getting confused about the declaration
  *                                                 on AbstractValidator
+ * @final
  */
 class IsCountable extends AbstractValidator
 {

--- a/src/IsInstanceOf.php
+++ b/src/IsInstanceOf.php
@@ -10,6 +10,7 @@ use function func_get_args;
 use function is_array;
 use function iterator_to_array;
 
+/** @final */
 class IsInstanceOf extends AbstractValidator
 {
     public const NOT_INSTANCE_OF = 'notInstanceOf';

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -11,6 +11,7 @@ use function str_replace;
 use function strlen;
 use function substr;
 
+/** @final */
 class Isbn extends AbstractValidator
 {
     public const AUTO    = 'auto';

--- a/src/Isbn/Isbn10.php
+++ b/src/Isbn/Isbn10.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Isbn;
 
+/** @final */
 class Isbn10
 {
     /**

--- a/src/Isbn/Isbn13.php
+++ b/src/Isbn/Isbn13.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\Validator\Isbn;
 
+/** @final */
 class Isbn13
 {
     /**

--- a/src/LessThan.php
+++ b/src/LessThan.php
@@ -10,6 +10,7 @@ use function array_shift;
 use function func_get_args;
 use function is_array;
 
+/** @final */
 class LessThan extends AbstractValidator
 {
     public const NOT_LESS           = 'notLessThan';

--- a/src/NotEmpty.php
+++ b/src/NotEmpty.php
@@ -20,6 +20,7 @@ use function is_string;
 use function method_exists;
 use function preg_match;
 
+/** @final */
 class NotEmpty extends AbstractValidator
 {
     public const BOOLEAN       = 0b000000000001;

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -13,6 +13,7 @@ use function is_int;
 use function is_string;
 use function preg_match;
 
+/** @final */
 class Regex extends AbstractValidator
 {
     public const INVALID   = 'regexInvalid';

--- a/src/Sitemap/Changefreq.php
+++ b/src/Sitemap/Changefreq.php
@@ -11,6 +11,8 @@ use function is_string;
  * Validates whether a given value is valid as a sitemap <changefreq> value
  *
  * @link       http://www.sitemaps.org/protocol.php Sitemaps XML format
+ *
+ * @final
  */
 class Changefreq extends AbstractValidator
 {

--- a/src/Sitemap/Lastmod.php
+++ b/src/Sitemap/Lastmod.php
@@ -12,6 +12,8 @@ use function preg_match;
  * Validates whether a given value is valid as a sitemap <lastmod> value
  *
  * @link       http://www.sitemaps.org/protocol.php Sitemaps XML format
+ *
+ * @final
  */
 class Lastmod extends AbstractValidator
 {

--- a/src/Sitemap/Loc.php
+++ b/src/Sitemap/Loc.php
@@ -12,6 +12,8 @@ use function is_string;
  *
  * @link       http://www.sitemaps.org/protocol.php Sitemaps XML format
  * @see        Laminas\Uri\Uri
+ *
+ * @final
  */
 class Loc extends AbstractValidator
 {

--- a/src/Sitemap/Priority.php
+++ b/src/Sitemap/Priority.php
@@ -10,6 +10,8 @@ use function is_numeric;
  * Validates whether a given value is valid as a sitemap <priority> value
  *
  * @link       http://www.sitemaps.org/protocol.php Sitemaps XML format
+ *
+ * @final
  */
 class Priority extends AbstractValidator
 {

--- a/src/StaticValidator.php
+++ b/src/StaticValidator.php
@@ -7,6 +7,7 @@ use Laminas\ServiceManager\ServiceManager;
 use function array_values;
 use function method_exists;
 
+/** @final */
 class StaticValidator
 {
     /** @var ValidatorPluginManager|null */

--- a/src/Step.php
+++ b/src/Step.php
@@ -15,6 +15,7 @@ use function strlen;
 use function strpos;
 use function substr;
 
+/** @final */
 class Step extends AbstractValidator
 {
     public const INVALID  = 'typeInvalid';
@@ -26,10 +27,10 @@ class Step extends AbstractValidator
         self::NOT_STEP => 'The input is not a valid step',
     ];
 
-    /** @var mixed */
+    /** @var numeric */
     protected $baseValue = 0;
 
-    /** @var mixed */
+    /** @var numeric */
     protected $step = 1;
 
     /**
@@ -64,6 +65,7 @@ class Step extends AbstractValidator
     /**
      * Sets the base value from which the step should be computed
      *
+     * @param numeric $baseValue
      * @return $this
      */
     public function setBaseValue(mixed $baseValue)
@@ -75,7 +77,7 @@ class Step extends AbstractValidator
     /**
      * Returns the base value from which the step should be computed
      *
-     * @return string
+     * @return numeric
      */
     public function getBaseValue()
     {
@@ -85,6 +87,7 @@ class Step extends AbstractValidator
     /**
      * Sets the step value
      *
+     * @param numeric $step
      * @return $this
      */
     public function setStep(mixed $step)
@@ -96,7 +99,7 @@ class Step extends AbstractValidator
     /**
      * Returns the step value
      *
-     * @return string
+     * @return numeric
      */
     public function getStep()
     {
@@ -133,8 +136,8 @@ class Step extends AbstractValidator
     /**
      * replaces the internal fmod function which give wrong results on many cases
      *
-     * @param int|float $x
-     * @param int|float $y
+     * @param numeric $x
+     * @param numeric $y
      * @return float
      */
     protected function fmod($x, $y)
@@ -152,8 +155,8 @@ class Step extends AbstractValidator
     /**
      * replaces the internal substraction operation which give wrong results on some cases
      *
-     * @param float $x
-     * @param float $y
+     * @param numeric $x
+     * @param numeric $y
      * @return float
      */
     private function sub($x, $y)
@@ -163,7 +166,7 @@ class Step extends AbstractValidator
     }
 
     /**
-     * @param float $float
+     * @param numeric $float
      */
     private function getPrecision($float): int
     {

--- a/src/StringLength.php
+++ b/src/StringLength.php
@@ -13,6 +13,7 @@ use function is_array;
 use function is_string;
 use function max;
 
+/** @final */
 class StringLength extends AbstractValidator
 {
     public const INVALID   = 'stringLengthInvalid';

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -13,6 +13,7 @@ use function is_int;
 use function is_string;
 use function sprintf;
 
+/** @final */
 class Timezone extends AbstractValidator
 {
     public const INVALID                       = 'invalidTimezone';

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -17,6 +17,7 @@ use function is_string;
 use function iterator_to_array;
 use function sprintf;
 
+/** @final */
 class Uri extends AbstractValidator
 {
     public const INVALID = 'uriInvalid';

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -17,6 +17,7 @@ use function sprintf;
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @extends AbstractPluginManager<ValidatorInterface>
+ * @final
  */
 class ValidatorPluginManager extends AbstractPluginManager
 {

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -14,6 +14,8 @@ use function is_array;
  * @link ServiceManager
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ *
+ * @final
  */
 class ValidatorPluginManagerFactory implements FactoryInterface
 {


### PR DESCRIPTION
To signal intent to make all validators final in v3, this patch adds `@final` to all classes where possible.

A number of suspect documented types have been altered because psalm found them…