### PR TITLE
Refactor URI Validator, Drop dependency on Laminas\Uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "laminas/laminas-coding-standard": "^2.5",
         "laminas/laminas-i18n": "^2.26.0",
         "laminas/laminas-session": "^2.20",
-        "laminas/laminas-uri": "^2.11.0",
         "phpunit/phpunit": "^10.5.20",
         "psalm/plugin-phpunit": "^0.19.0",
         "psr/http-client": "^1.0.3",
@@ -52,7 +51,6 @@
         "laminas/laminas-i18n-resources": "Translations of validator messages",
         "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
         "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
-        "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
         "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e01a1d2372c9ad11a9fb46917a36014c",
+    "content-hash": "22047dfceb20a25acd17db3b830e22a3",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1040,68 +1040,6 @@
             "time": "2023-01-05T15:53:40+00:00"
         },
         {
-            "name": "laminas/laminas-escaper",
-            "version": "2.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/af459883f4018d0f8a0c69c7a209daef3bf973ba",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-escaper": "*"
-            },
-            "require-dev": {
-                "infection/infection": "^0.27.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "maglnet/composer-require-checker": "^3.8.0",
-                "phpunit/phpunit": "^9.6.7",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "escaper",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-escaper/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-escaper/issues",
-                "rss": "https://github.com/laminas/laminas-escaper/releases.atom",
-                "source": "https://github.com/laminas/laminas-escaper"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-10-10T08:35:13+00:00"
-        },
-        {
             "name": "laminas/laminas-eventmanager",
             "version": "3.13.0",
             "source": {
@@ -1335,64 +1273,6 @@
                 }
             ],
             "time": "2024-03-08T11:02:36+00:00"
-        },
-        {
-            "name": "laminas/laminas-uri",
-            "version": "2.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "e662c685125061d3115906e5eb30f966842cc226"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/e662c685125061d3115906e5eb30f966842cc226",
-                "reference": "e662c685125061d3115906e5eb30f966842cc226",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-escaper": "^2.9",
-                "laminas/laminas-validator": "^2.39",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-uri": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Uri\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "uri"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-uri/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-uri/issues",
-                "rss": "https://github.com/laminas/laminas-uri/releases.atom",
-                "source": "https://github.com/laminas/laminas-uri"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2023-10-18T09:56:55+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2211,16 +2091,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.20",
+            "version": "10.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
+                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
-                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ac837816fa52078f7a5e17ed774f256a72a51af6",
+                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6",
                 "shasum": ""
             },
             "require": {
@@ -2292,7 +2172,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.21"
             },
             "funding": [
                 {
@@ -2308,7 +2188,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-24T06:32:35+00:00"
+            "time": "2024-06-15T09:13:15+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -71,7 +71,6 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode.php">
@@ -1621,14 +1620,6 @@
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="src/Sitemap/Loc.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-  </file>
   <file src="src/Sitemap/Priority.php">
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
@@ -1746,55 +1737,6 @@
       <code><![CDATA[TranslatorAwareInterface]]></code>
       <code><![CDATA[self]]></code>
     </PossiblyUnusedReturnValue>
-  </file>
-  <file src="src/Uri.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($options)]]></code>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidCatch>
-      <code><![CDATA[try {
-            $uriHandler->parse($value);
-            if ($uriHandler->isValid()) {
-                // It will either be a valid absolute or relative URI
-                if (
-                    ($this->allowRelative && $this->allowAbsolute)
-                    || ($this->allowAbsolute && $uriHandler->isAbsolute())
-                    || ($this->allowRelative && $uriHandler->isValidRelative())
-                ) {
-                    return true;
-                }
-            }
-        } catch (UriException) {
-            // Error parsing URI, it must be invalid
-        }]]></code>
-    </InvalidCatch>
-    <MixedArgument>
-      <code><![CDATA[$options['allowAbsolute']]]></code>
-      <code><![CDATA[$options['allowRelative']]]></code>
-      <code><![CDATA[$options['uriHandler']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$temp['allowAbsolute']]]></code>
-      <code><![CDATA[$temp['allowRelative']]]></code>
-      <code><![CDATA[$temp['uriHandler']]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $allowAbsolute]]></code>
-      <code><![CDATA[(bool) $allowRelative]]></code>
-    </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation>
-      <code><![CDATA[new $this->uriHandler()]]></code>
-    </UnsafeInstantiation>
   </file>
   <file src="src/ValidatorChain.php">
     <MixedPropertyTypeCoercion>
@@ -2543,14 +2485,9 @@
     </PossiblyInvalidCast>
   </file>
   <file src="test/Sitemap/LocTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$value]]></code>
-    </InvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$value]]></code>
-    </PossiblyInvalidCast>
     <PossiblyUnusedMethod>
       <code><![CDATA[invalidLocs]]></code>
+      <code><![CDATA[validLocs]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Sitemap/PriorityTest.php">
@@ -2626,13 +2563,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/UriTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$uriMock]]></code>
-      <code><![CDATA[new stdClass()]]></code>
-    </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[allowOptionsDataProvider]]></code>
       <code><![CDATA[invalidValueTypes]]></code>

--- a/src/Sitemap/Loc.php
+++ b/src/Sitemap/Loc.php
@@ -4,57 +4,92 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\Sitemap;
 
-use Laminas\Uri;
 use Laminas\Validator\AbstractValidator;
+use Laminas\Validator\Uri;
 
+use function html_entity_decode;
+use function htmlentities;
 use function is_string;
+use function str_replace;
+use function strlen;
 
 /**
  * Validates whether a given value is valid as a sitemap <loc> value
  *
- * @link       http://www.sitemaps.org/protocol.php Sitemaps XML format
- * @see        Laminas\Uri\Uri
+ * @link https://www.sitemaps.org/protocol.html Sitemaps XML format
  */
 final class Loc extends AbstractValidator
 {
-    /**
-     * Validation key for not valid
-     */
+    private const URI_MAX_LENGTH = 2048;
+
     public const NOT_VALID = 'sitemapLocNotValid';
     public const INVALID   = 'sitemapLocInvalid';
+    public const TOO_LONG  = 'sitemapLocTooLong';
 
     /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $messageTemplates = [
         self::NOT_VALID => 'The input is not a valid sitemap location',
         self::INVALID   => 'Invalid type given. String expected',
+        self::TOO_LONG  => 'Sitemap URIs cannot be greater than 2048 characters',
     ];
 
     /**
      * Validates if a string is valid as a sitemap location
      *
-     * @link http://www.sitemaps.org/protocol.php#locdef <loc>
-     *
-     * @param  string  $value  value to validate
-     * @return bool
+     * @link https://www.sitemaps.org/protocol.php#locdef
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
-        if (! is_string($value)) {
+        if (! is_string($value) || $value === '') {
             $this->error(self::INVALID);
             return false;
         }
 
-        $this->setValue($value);
-        $uri = Uri\UriFactory::factory($value);
-        if (! $uri->isValid()) {
+        $validator = new Uri([
+            'allowAbsolute' => true,
+            'allowRelative' => false,
+        ]);
+
+        if (! $validator->isValid($value)) {
             $this->error(self::NOT_VALID);
+
+            return false;
+        }
+
+        if ($this->containsUnEncodedHtmlEntities($value)) {
+            $this->error(self::NOT_VALID);
+
+            return false;
+        }
+
+        if ($this->containsHtmlEncodedEntities($value)) {
+            $this->error(self::NOT_VALID);
+
+            return false;
+        }
+
+        if (strlen($value) > self::URI_MAX_LENGTH) {
+            $this->error(self::TOO_LONG);
+
             return false;
         }
 
         return true;
+    }
+
+    private function containsUnEncodedHtmlEntities(string $uri): bool
+    {
+        $test = str_replace('&', '', $uri);
+
+        return htmlentities($test) !== $test;
+    }
+
+    private function containsHtmlEncodedEntities(string $uri): bool
+    {
+        return html_entity_decode($uri) !== $uri;
     }
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -4,187 +4,84 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\Uri\Exception\ExceptionInterface as UriException;
-use Laminas\Uri\Uri as UriHandler;
 use Laminas\Validator\Exception\InvalidArgumentException;
-use Traversable;
 
-use function array_shift;
-use function assert;
-use function class_exists;
-use function func_get_args;
-use function is_a;
 use function is_array;
 use function is_string;
-use function iterator_to_array;
-use function sprintf;
+use function parse_url;
 
+/**
+ * @psalm-type Options = array{
+ *     allowRelative?: bool,
+ *     allowAbsolute?: bool,
+ * }
+ */
 final class Uri extends AbstractValidator
 {
-    public const INVALID = 'uriInvalid';
-    public const NOT_URI = 'notUri';
+    public const INVALID      = 'uriInvalid';
+    public const NOT_URI      = 'notUri';
+    public const NOT_ABSOLUTE = 'notAbsoluteUri';
+    public const NOT_RELATIVE = 'notRelativeUri';
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
-        self::INVALID => 'Invalid type given. String expected',
-        self::NOT_URI => 'The input does not appear to be a valid Uri',
+    protected array $messageTemplates = [
+        self::INVALID      => 'Invalid type given. String expected',
+        self::NOT_URI      => 'The input does not appear to be a valid Uri',
+        self::NOT_ABSOLUTE => 'Expected an absolute uri but a relative uri was received',
+        self::NOT_RELATIVE => 'Expected a relative uri but an absolute uri was received',
     ];
 
-    /** @var UriHandler|null|class-string<UriHandler> */
-    protected $uriHandler;
+    private readonly bool $allowRelative;
+    private readonly bool $allowAbsolute;
 
-    /** @var bool */
-    protected $allowRelative = true;
-
-    /** @var bool */
-    protected $allowAbsolute = true;
-
-    /**
-     * Sets default option values for this instance
-     *
-     * @param array|Traversable $options
-     */
-    public function __construct($options = [])
+    /** @param Options $options */
+    public function __construct(array $options = [])
     {
-        if ($options instanceof Traversable) {
-            $options = iterator_to_array($options);
-        } elseif (! is_array($options)) {
-            $options            = func_get_args();
-            $temp['uriHandler'] = array_shift($options);
-            if (! empty($options)) {
-                $temp['allowRelative'] = array_shift($options);
-            }
-            if (! empty($options)) {
-                $temp['allowAbsolute'] = array_shift($options);
-            }
+        $this->allowRelative = $options['allowRelative'] ?? true;
+        $this->allowAbsolute = $options['allowAbsolute'] ?? true;
 
-            $options = $temp;
-        }
-
-        if (isset($options['uriHandler'])) {
-            $this->setUriHandler($options['uriHandler']);
-        }
-        if (isset($options['allowRelative'])) {
-            $this->setAllowRelative($options['allowRelative']);
-        }
-        if (isset($options['allowAbsolute'])) {
-            $this->setAllowAbsolute($options['allowAbsolute']);
+        if ($this->allowRelative === false && $this->allowAbsolute === false) {
+            throw new InvalidArgumentException(
+                'Disallowing both relative and absolute uris means that no uris will be valid',
+            );
         }
 
         parent::__construct($options);
     }
 
     /**
-     * @throws InvalidArgumentException
-     * @return UriHandler
-     */
-    public function getUriHandler()
-    {
-        if (null === $this->uriHandler) {
-            // Lazy load the base Uri handler
-            $this->uriHandler = new UriHandler();
-        } elseif (is_string($this->uriHandler) && class_exists($this->uriHandler)) {
-            // Instantiate string Uri handler that references a class
-            $this->uriHandler = new $this->uriHandler();
-        }
-        assert($this->uriHandler !== null && ! is_string($this->uriHandler));
-
-        return $this->uriHandler;
-    }
-
-    /**
-     * @param  UriHandler|class-string<UriHandler> $uriHandler
-     * @throws InvalidArgumentException
-     * @return $this
-     */
-    public function setUriHandler($uriHandler)
-    {
-        if (! is_a($uriHandler, UriHandler::class, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Expecting a subclass name or instance of %s as $uriHandler',
-                UriHandler::class
-            ));
-        }
-
-        $this->uriHandler = $uriHandler;
-        return $this;
-    }
-
-    /**
-     * Returns the allowAbsolute option
-     *
-     * @return bool
-     */
-    public function getAllowAbsolute()
-    {
-        return $this->allowAbsolute;
-    }
-
-    /**
-     * Sets the allowAbsolute option
-     *
-     * @param  bool $allowAbsolute
-     * @return $this
-     */
-    public function setAllowAbsolute($allowAbsolute)
-    {
-        $this->allowAbsolute = (bool) $allowAbsolute;
-        return $this;
-    }
-
-    /**
-     * Returns the allowRelative option
-     *
-     * @return bool
-     */
-    public function getAllowRelative()
-    {
-        return $this->allowRelative;
-    }
-
-    /**
-     * Sets the allowRelative option
-     *
-     * @param  bool $allowRelative
-     * @return $this
-     */
-    public function setAllowRelative($allowRelative)
-    {
-        $this->allowRelative = (bool) $allowRelative;
-        return $this;
-    }
-
-    /**
      * Returns true if and only if $value validates as a Uri
-     *
-     * @param  string $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
-        if (! is_string($value)) {
+        if (! is_string($value) || $value === '') {
             $this->error(self::INVALID);
             return false;
         }
 
-        $uriHandler = $this->getUriHandler();
-        try {
-            $uriHandler->parse($value);
-            if ($uriHandler->isValid()) {
-                // It will either be a valid absolute or relative URI
-                if (
-                    ($this->allowRelative && $this->allowAbsolute)
-                    || ($this->allowAbsolute && $uriHandler->isAbsolute())
-                    || ($this->allowRelative && $uriHandler->isValidRelative())
-                ) {
-                    return true;
-                }
-            }
-        } catch (UriException) {
-            // Error parsing URI, it must be invalid
+        $parts = parse_url($value);
+        if (! is_array($parts)) {
+            $this->error(self::NOT_URI);
+
+            return false;
         }
 
-        $this->error(self::NOT_URI);
-        return false;
+        if (! $this->allowRelative && $this->allowAbsolute) {
+            if (! isset($parts['host'])) {
+                $this->error(self::NOT_ABSOLUTE);
+
+                return false;
+            }
+        }
+
+        if (! $this->allowAbsolute && $this->allowRelative) {
+            if (isset($parts['host'])) {
+                $this->error(self::NOT_RELATIVE);
+
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

Refactors the URI validator to use `parse_url` internally instead of `Laminas\Uri` which is in security-only mode. URL validation is likely more lenient now but due to the lack of existing tests, it's difficult to say how much of an impact this might have.

Also refactors the `Sitemap\Loc` validator - this validator has been improved to check the max length of the URI according to the sitemap spec, and now rejects URIs that are not correctly URL encoded - i.e. they'd cause problems in an XML file.
