### PR TITLE
Upgrade to Service Manager v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "laminas/laminas-servicemanager": "^3.21.0",
+        "laminas/laminas-servicemanager": "^4.1.0",
         "laminas/laminas-stdlib": "^3.13",
         "laminas/laminas-translator": "^1.0",
         "psr/http-message": "^1.0.1 || ^2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,63 +4,111 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f60ed8d25850730dee1fed5ebbac79cf",
+    "content-hash": "c10f21b01db899d9f7f49c4c08869a0c",
     "packages": [
         {
-            "name": "laminas/laminas-servicemanager",
-            "version": "3.22.1",
+            "name": "brick/varexporter",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328"
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/de98d297d4743956a0558a6d71616979ff779328",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.17",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "ext-psr": "*",
-                "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
-            },
-            "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "composer/package-versions-deprecated": "^1.11.99.5",
-                "friendsofphp/proxy-manager-lts": "^1.0.14",
-                "laminas/laminas-code": "^4.10.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpbench/phpbench": "^1.2.9",
-                "phpunit/phpunit": "^10.4",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.8.0"
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "5.15.0"
             },
-            "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-01T21:10:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "ae01570ecdf4559aef2f15d4e79e8c36874f7416"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/ae01570ecdf4559aef2f15d4e79e8c36874f7416",
+                "reference": "ae01570ecdf4559aef2f15d4e79e8c36874f7416",
+                "shasum": ""
+            },
+            "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "conflict": {
+                "laminas/laminas-code": "<4.10.0",
+                "zendframework/zend-code": "<3.3.1"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "boesing/psalm-plugin-stringf": "^1.4",
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "friendsofphp/proxy-manager-lts": "^1",
+                "laminas/laminas-cli": "^1.8",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-container-config-test": "^1.0",
+                "lctrs/psalm-psr-container-plugin": "^1.9",
+                "mikey179/vfsstream": "^1.6.11@alpha",
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^10.4",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "symfony/console": "^6.0",
+                "vimeo/psalm": "^5.22"
+            },
+            "suggest": {
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider",
+                    "module": "Laminas\\ServiceManager"
+                }
+            },
+            "autoload": {
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -82,11 +130,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.1.0"
             },
             "funding": [
                 {
@@ -94,7 +140,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-24T11:19:47+00:00"
+            "time": "2024-04-03T20:39:36+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -156,76 +202,84 @@
             "time": "2024-01-19T12:39:49+00:00"
         },
         {
-            "name": "laminas/laminas-translator",
-            "version": "1.0.0",
+            "name": "nikic/php-parser",
+            "version": "v4.19.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-translator.git",
-                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/86d176c01a96b0ef205192b776cb69e8d4ca06b1",
-                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "ext-tokenizer": "*",
+                "php": ">=7.1"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "vimeo/psalm": "^5.24.0"
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
+            "bin": [
+                "bin/php-parse"
+            ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Laminas\\Translator\\": "src/"
+                    "PhpParser\\": "lib/PhpParser"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Interfaces for the Translator component of laminas-i18n",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-translator/issues",
-                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
-                "source": "https://github.com/laminas/laminas-translator"
-            },
-            "funding": [
+            "authors": [
                 {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
+                    "name": "Nikita Popov"
                 }
             ],
-            "time": "2024-06-18T15:09:24+00:00"
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+            },
+            "time": "2024-03-17T08:10:35+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -252,9 +306,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1093,6 +1147,77 @@
             "time": "2023-01-05T15:53:40+00:00"
         },
         {
+            "name": "laminas/laminas-i18n",
+            "version": "dev-relax-sm-constraint",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-i18n.git",
+                "reference": "b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b",
+                "reference": "b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^4.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "conflict": {
+                "laminas/laminas-view": "<2.20.0",
+                "zendframework/zend-i18n": "*"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "You should install this package to cache the translations",
+                "laminas/laminas-config": "You should install this package to use the INI translation format",
+                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
+                "laminas/laminas-filter": "You should install this package to use the provided filters",
+                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
+                "laminas/laminas-validator": "You should install this package to use the provided validators",
+                "laminas/laminas-view": "You should install this package to use the provided view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\I18n",
+                    "config-provider": "Laminas\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provide translations for your application, and filter and validate internationalized values",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-i18n/issues",
+                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
+                "source": "https://github.com/laminas/laminas-i18n"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-06-17T16:18:54+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.12.0",
             "source": {
@@ -1202,62 +1327,6 @@
                 "source": "https://github.com/cweiske/jsonmapper/tree/v4.4.1"
             },
             "time": "2024-01-31T06:18:54+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.19.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
-            },
-            "time": "2024-03-17T08:10:35+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1588,16 +1657,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.15",
+            "version": "10.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae"
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
-                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
                 "shasum": ""
             },
             "require": {
@@ -1654,7 +1723,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
             },
             "funding": [
                 {
@@ -1662,7 +1731,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-29T08:25:15+00:00"
+            "time": "2024-03-12T15:33:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1909,16 +1978,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.24",
+            "version": "10.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
+                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ac837816fa52078f7a5e17ed774f256a72a51af6",
+                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6",
                 "shasum": ""
             },
             "require": {
@@ -1990,7 +2059,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.21"
             },
             "funding": [
                 {
@@ -2006,7 +2075,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T13:09:54+00:00"
+            "time": "2024-06-15T09:13:15+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3352,16 +3421,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.9",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
+                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
-                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/be5854cee0e8c7b110f00d695d11debdfa1a2a91",
+                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91",
                 "shasum": ""
             },
             "require": {
@@ -3426,7 +3495,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.9"
+                "source": "https://github.com/symfony/console/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -3442,7 +3511,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:49:33+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3513,16 +3582,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.9",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463"
+                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b51ef8059159330b74a4d52f68e671033c0fe463",
-                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4d37529150e7081c51b3c5d5718c55a04a9503f3",
+                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3",
                 "shasum": ""
             },
             "require": {
@@ -3559,7 +3628,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -3575,20 +3644,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:49:33+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
                 "shasum": ""
             },
             "require": {
@@ -3638,7 +3707,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3654,20 +3723,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.30.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
                 "shasum": ""
             },
             "require": {
@@ -3716,7 +3785,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3732,20 +3801,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.30.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
+                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
                 "shasum": ""
             },
             "require": {
@@ -3797,7 +3866,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3813,20 +3882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.30.0",
+            "version": "v1.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
                 "shasum": ""
             },
             "require": {
@@ -3877,7 +3946,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
             },
             "funding": [
                 {
@@ -3893,7 +3962,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T12:30:46+00:00"
+            "time": "2024-01-29T20:11:03+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3980,16 +4049,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.9",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7"
+                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/76792dbd99690a5ebef8050d9206c60c59e681d7",
-                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a147c0f826c4a1f3afb763ab8e009e37c877a44d",
+                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d",
                 "shasum": ""
             },
             "require": {
@@ -4046,7 +4115,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.9"
+                "source": "https://github.com/symfony/string/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -4062,7 +4131,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:25:38+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4116,16 +4185,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.25.0",
+            "version": "5.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505"
+                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
-                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/462c80e31c34e58cc4f750c656be3927e80e550e",
+                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e",
                 "shasum": ""
             },
             "require": {
@@ -4222,7 +4291,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-06-16T15:08:35+00:00"
+            "time": "2024-05-01T19:32:08+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4340,7 +4409,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "laminas/laminas-i18n": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1978,16 +1978,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.21",
+            "version": "10.5.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6"
+                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ac837816fa52078f7a5e17ed774f256a72a51af6",
-                "reference": "ac837816fa52078f7a5e17ed774f256a72a51af6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
                 "shasum": ""
             },
             "require": {
@@ -2059,7 +2059,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.21"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
             },
             "funding": [
                 {
@@ -2075,7 +2075,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-15T09:13:15+00:00"
+            "time": "2024-06-20T13:09:54+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3648,16 +3648,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
                 "shasum": ""
             },
             "require": {
@@ -3707,7 +3707,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3723,20 +3723,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
-                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
                 "shasum": ""
             },
             "require": {
@@ -3785,7 +3785,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3801,20 +3801,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
-                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
                 "shasum": ""
             },
             "require": {
@@ -3866,7 +3866,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3882,20 +3882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -3946,7 +3946,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -3962,7 +3962,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4185,16 +4185,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.24.0",
+            "version": "5.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e"
+                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/462c80e31c34e58cc4f750c656be3927e80e550e",
-                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
+                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
                 "shasum": ""
             },
             "require": {
@@ -4291,7 +4291,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-05-01T19:32:08+00:00"
+            "time": "2024-06-16T15:08:35+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c10f21b01db899d9f7f49c4c08869a0c",
+    "content-hash": "dd63fffe59f6f41b7e195b18b10dc733",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -200,6 +200,59 @@
                 }
             ],
             "time": "2024-01-19T12:39:49+00:00"
+        },
+        {
+            "name": "laminas/laminas-translator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-translator.git",
+                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-translator/zipball/86d176c01a96b0ef205192b776cb69e8d4ca06b1",
+                "reference": "86d176c01a96b0ef205192b776cb69e8d4ca06b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "vimeo/psalm": "^5.24.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Translator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Interfaces for the Translator component of laminas-i18n",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-translator/issues",
+                "rss": "https://github.com/laminas/laminas-translator/releases.atom",
+                "source": "https://github.com/laminas/laminas-translator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-06-18T15:09:24+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1147,77 +1200,6 @@
             "time": "2023-01-05T15:53:40+00:00"
         },
         {
-            "name": "laminas/laminas-i18n",
-            "version": "dev-relax-sm-constraint",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b",
-                "reference": "b14f1fbe09a7d37e0ce075e2b12d8ea67dc9026b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^4.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "laminas/laminas-view": "<2.20.0",
-                "zendframework/zend-i18n": "*"
-            },
-            "suggest": {
-                "laminas/laminas-cache": "You should install this package to cache the translations",
-                "laminas/laminas-config": "You should install this package to use the INI translation format",
-                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
-                "laminas/laminas-filter": "You should install this package to use the provided filters",
-                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
-                "laminas/laminas-validator": "You should install this package to use the provided validators",
-                "laminas/laminas-view": "You should install this package to use the provided view helpers"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\I18n",
-                    "config-provider": "Laminas\\I18n\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\I18n\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provide translations for your application, and filter and validate internationalized values",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-i18n/issues",
-                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
-                "source": "https://github.com/laminas/laminas-i18n"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-06-17T16:18:54+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
             "version": "1.12.0",
             "source": {
@@ -1657,16 +1639,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.14",
+            "version": "10.1.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
+                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
+                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
                 "shasum": ""
             },
             "require": {
@@ -1723,7 +1705,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.15"
             },
             "funding": [
                 {
@@ -1731,7 +1713,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-12T15:33:41+00:00"
+            "time": "2024-06-29T08:25:15+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3421,16 +3403,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91"
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/be5854cee0e8c7b110f00d695d11debdfa1a2a91",
-                "reference": "be5854cee0e8c7b110f00d695d11debdfa1a2a91",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
+                "reference": "6edb5363ec0c78ad4d48c5128ebf4d083d89d3a9",
                 "shasum": ""
             },
             "require": {
@@ -3495,7 +3477,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.8"
+                "source": "https://github.com/symfony/console/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -3511,7 +3493,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3582,16 +3564,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3"
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4d37529150e7081c51b3c5d5718c55a04a9503f3",
-                "reference": "4d37529150e7081c51b3c5d5718c55a04a9503f3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b51ef8059159330b74a4d52f68e671033c0fe463",
+                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463",
                 "shasum": ""
             },
             "require": {
@@ -3628,7 +3610,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.8"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -3644,7 +3626,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4049,16 +4031,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.8",
+            "version": "v6.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d"
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a147c0f826c4a1f3afb763ab8e009e37c877a44d",
-                "reference": "a147c0f826c4a1f3afb763ab8e009e37c877a44d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/76792dbd99690a5ebef8050d9206c60c59e681d7",
+                "reference": "76792dbd99690a5ebef8050d9206c60c59e681d7",
                 "shasum": ""
             },
             "require": {
@@ -4115,7 +4097,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.8"
+                "source": "https://github.com/symfony/string/tree/v6.4.9"
             },
             "funding": [
                 {
@@ -4131,7 +4113,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-06-28T09:25:38+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4409,9 +4391,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "laminas/laminas-i18n": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,6 +50,22 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -103,6 +119,7 @@
       <code><![CDATA[$this->cardLength[$type]]]></code>
       <code><![CDATA[$this->options['type']]]></code>
       <code><![CDATA[$this->options['type']]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArrayAssignment>
       <code><![CDATA[$this->options['type'][]]]></code>
@@ -177,6 +194,9 @@
       <code><![CDATA['']]></code>
       <code><![CDATA[is_string($value)]]></code>
     </DocblockTypeContradiction>
+    <InvalidArgument>
+      <code><![CDATA[$this->getAllow()]]></code>
+    </InvalidArgument>
     <LessSpecificImplementedReturnType>
       <code><![CDATA[AbstractValidator]]></code>
     </LessSpecificImplementedReturnType>
@@ -196,7 +216,7 @@
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
-      <code><![CDATA[int-mask-of<Hostname::ALLOW_*>]]></code>
+      <code><![CDATA[int]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code><![CDATA[setAllow]]></code>
@@ -254,13 +274,11 @@
     </UnusedClass>
   </file>
   <file src="src/Explode.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$this->getPluginManager()->build($name, $options)]]></code>
-    </LessSpecificReturnStatement>
     <MixedInferredReturnType>
       <code><![CDATA[ValidatorInterface]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
+      <code><![CDATA[$this->getPluginManager()->build($name, $options)]]></code>
       <code><![CDATA[$this->getPluginManager()->build($name, $options)]]></code>
       <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
       <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
@@ -355,6 +373,9 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$messageTemplates]]></code>
+    </NonInvariantDocblockPropertyType>
     <PossiblyFalseOperand>
       <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
@@ -985,18 +1006,74 @@
     </MixedArgument>
   </file>
   <file src="src/Hostname.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($options)]]></code>
+      <code><![CDATA[is_string($value)]]></code>
+    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$regexChar]]></code>
+      <code><![CDATA[$regexKey]]></code>
     </MixedArgument>
     <MixedAssignment>
+      <code><![CDATA[$partRegexChars]]></code>
       <code><![CDATA[$regexChar]]></code>
+      <code><![CDATA[$regexChars]]></code>
+      <code><![CDATA[$regexKey]]></code>
+      <code><![CDATA[$temp['allow']]]></code>
+      <code><![CDATA[$temp['ipValidator']]]></code>
+      <code><![CDATA[$temp['useIdnCheck']]]></code>
+      <code><![CDATA[$temp['useTldCheck']]]></code>
     </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[Ip]]></code>
+      <code><![CDATA[bool]]></code>
+      <code><![CDATA[bool]]></code>
+      <code><![CDATA[int]]></code>
+    </MixedInferredReturnType>
+    <MixedOperand>
+      <code><![CDATA[$regexChars]]></code>
+    </MixedOperand>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['allow']]]></code>
+      <code><![CDATA[$this->options['ipValidator']]]></code>
+      <code><![CDATA[$this->options['useIdnCheck']]]></code>
+      <code><![CDATA[$this->options['useTldCheck']]]></code>
+    </MixedReturnStatement>
+    <MoreSpecificImplementedParamType>
+      <code><![CDATA[$value]]></code>
+    </MoreSpecificImplementedParamType>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$options]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$temp]]></code>
+    </PossiblyUndefinedVariable>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[setAllow]]></code>
+      <code><![CDATA[setIpValidator]]></code>
+    </PossiblyUnusedMethod>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(bool) $useIdnCheck]]></code>
+      <code><![CDATA[(bool) $useTldCheck]]></code>
+    </RedundantCastGivenDocblockType>
+    <UnresolvableInclude>
+      <code><![CDATA[include __DIR__ . '/' . $this->validIdns[$this->tld]]]></code>
+    </UnresolvableInclude>
   </file>
   <file src="src/Iban.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_string($value)]]></code>
+    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['allow_non_sepa']]]></code>
       <code><![CDATA[$options['country_code']]]></code>
     </MixedArgument>
+    <MixedOperand>
+      <code><![CDATA[static::$ibanRegex[$countryCode]]]></code>
+    </MixedOperand>
+    <MoreSpecificImplementedParamType>
+      <code><![CDATA[$value]]></code>
+    </MoreSpecificImplementedParamType>
     <PossiblyInvalidArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyInvalidArgument>
@@ -1053,6 +1130,20 @@
       <code><![CDATA[(bool) $recursive]]></code>
     </RedundantCastGivenDocblockType>
   </file>
+  <file src="src/IsInstanceOf.php">
+    <MixedAssignment>
+      <code><![CDATA[$tmpOptions['className']]]></code>
+    </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$options]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[setClassName]]></code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
+      <code><![CDATA[$className]]></code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="src/IsJsonString.php">
     <InvalidArgument>
       <code><![CDATA[$this->maxDepth]]></code>
@@ -1082,6 +1173,27 @@
     <UnusedClass>
       <code><![CDATA[Module]]></code>
     </UnusedClass>
+  </file>
+  <file src="src/NotEmpty.php">
+    <MixedAssignment>
+      <code><![CDATA[$temp['type']]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[int]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->options['type']]]></code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$options]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$type]]></code>
+    </PossiblyNullArgument>
+    <RedundantCondition>
+      <code><![CDATA[is_object($value) && method_exists($value, '__toString') && (string) $value === '']]></code>
+    </RedundantCondition>
   </file>
   <file src="src/NumberComparison.php">
     <MixedAssignment>
@@ -1113,6 +1225,41 @@
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="src/StaticValidator.php">
+    <UndefinedMethod>
+      <code><![CDATA[setShareByDefault]]></code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/Step.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($options)]]></code>
+    </DocblockTypeContradiction>
+    <MixedArgument>
+      <code><![CDATA[$options['baseValue']]]></code>
+      <code><![CDATA[$options['step']]]></code>
+    </MixedArgument>
+    <MixedAssignment>
+      <code><![CDATA[$temp['baseValue']]]></code>
+      <code><![CDATA[$temp['step']]]></code>
+    </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$options]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedVariable>
+      <code><![CDATA[$temp]]></code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="src/Translator/DummyTranslator.php">
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $number]]></code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/Translator/TranslatorAwareInterface.php">
+    <PossiblyUnusedReturnValue>
+      <code><![CDATA[TranslatorAwareInterface]]></code>
+      <code><![CDATA[self]]></code>
+    </PossiblyUnusedReturnValue>
+  </file>
   <file src="src/ValidatorChain.php">
     <MixedPropertyTypeCoercion>
       <code><![CDATA[new PriorityQueue()]]></code>
@@ -1128,28 +1275,18 @@
   </file>
   <file src="src/ValidatorPluginManager.php">
     <DeprecatedMethod>
-      <code><![CDATA[getServiceLocator]]></code>
-      <code><![CDATA[getServiceLocator]]></code>
+      <code><![CDATA[addInitializer]]></code>
+      <code><![CDATA[addInitializer]]></code>
     </DeprecatedMethod>
     <MethodSignatureMismatch>
       <code><![CDATA[ValidatorPluginManager]]></code>
     </MethodSignatureMismatch>
-    <MissingParamType>
-      <code><![CDATA[$configOrContainerInstance]]></code>
-    </MissingParamType>
-    <MixedArgument>
-      <code><![CDATA[$configOrContainerInstance]]></code>
-      <code><![CDATA[$container->get('MvcTranslator')]]></code>
-    </MixedArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[validatePlugin]]></code>
-    </PossiblyUnusedMethod>
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$shareByDefault]]></code>
-    </PossiblyUnusedProperty>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$container->getServiceLocator()]]></code>
-    </RedundantConditionGivenDocblockType>
+    <NonInvariantDocblockPropertyType>
+      <code><![CDATA[$instanceOf]]></code>
+    </NonInvariantDocblockPropertyType>
+    <UnusedParam>
+      <code><![CDATA[$container]]></code>
+    </UnusedParam>
   </file>
   <file src="src/ValidatorPluginManagerAwareInterface.php">
     <MissingReturnType>
@@ -1157,18 +1294,9 @@
     </MissingReturnType>
   </file>
   <file src="src/ValidatorPluginManagerFactory.php">
-    <DeprecatedClass>
-      <code><![CDATA[new Config($config['validators'])]]></code>
-    </DeprecatedClass>
-    <DeprecatedInterface>
-      <code><![CDATA[ValidatorPluginManagerFactory]]></code>
-    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[$config['validators']]]></code>
     </MixedArgument>
-    <ParamNameMismatch>
-      <code><![CDATA[$container]]></code>
-    </ParamNameMismatch>
   </file>
   <file src="src/ValidatorProviderInterface.php">
     <UnusedClass>
@@ -1176,6 +1304,10 @@
     </UnusedClass>
   </file>
   <file src="test/AbstractValidatorTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setService]]></code>
+      <code><![CDATA[setService]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$options]]></code>
     </InvalidArgument>
@@ -1185,6 +1317,10 @@
     <MixedAssignment>
       <code><![CDATA[$message]]></code>
     </MixedAssignment>
+    <NullArgument>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </NullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[invalidOptionsArguments]]></code>
     </PossiblyUnusedMethod>
@@ -1255,7 +1391,12 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EmailAddressTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setService]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
@@ -1266,6 +1407,9 @@
     <InvalidCast>
       <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
+    <NullArgument>
+      <code><![CDATA[null]]></code>
+    </NullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[emailAddressesForMxChecks]]></code>
       <code><![CDATA[errorHandler]]></code>
@@ -1566,9 +1710,34 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/HostnameTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setService]]></code>
+    </DeprecatedMethod>
+    <InvalidArgument>
+      <code><![CDATA[$option]]></code>
+      <code><![CDATA[$option]]></code>
+      <code><![CDATA[$option]]></code>
+      <code><![CDATA[$option]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
+      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
+      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
+      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
+      <code><![CDATA[Hostname::ALLOW_URI]]></code>
+      <code><![CDATA[[1 => 1]]]></code>
+    </InvalidArgument>
+    <InvalidCast>
+      <code><![CDATA[[1 => 1]]]></code>
+    </InvalidCast>
     <MixedArrayOffset>
       <code><![CDATA[$translations[$code]]]></code>
     </MixedArrayOffset>
+    <NullArgument>
+      <code><![CDATA[null]]></code>
+    </NullArgument>
     <PossiblyUndefinedVariable>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$message]]></code>
@@ -1627,9 +1796,24 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/IsCountableTest.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$options]]></code>
+    </PossiblyInvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[conflictingOptionsProvider]]></code>
+      <code><![CDATA[conflictingSecondaryOptionsProvider]]></code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="test/IsInstanceOfTest.php">
+    <InvalidArgument>
+      <code><![CDATA[DateTime::class]]></code>
+      <code><![CDATA[DateTime::class]]></code>
+      <code><![CDATA[DateTime::class]]></code>
+      <code><![CDATA[DateTime::class]]></code>
+      <code><![CDATA[DateTime::class]]></code>
+      <code><![CDATA[Exception::class]]></code>
+      <code><![CDATA[TestCase::class]]></code>
+    </InvalidArgument>
   </file>
   <file src="test/IsJsonStringTest.php">
     <PossiblyUnusedMethod>
@@ -1661,17 +1845,20 @@
     </UndefinedThisPropertyFetch>
   </file>
   <file src="test/NotEmptyTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[[
-            'type' => [$string, $string],
-        ]]]></code>
-    </ArgumentTypeCoercion>
+    <InvalidArgument>
+      <code><![CDATA[$type]]></code>
+      <code><![CDATA['boolean']]></code>
+      <code><![CDATA['boolean']]></code>
+      <code><![CDATA[true]]></code>
+    </InvalidArgument>
     <PossiblyUnusedMethod>
+      <code><![CDATA[arrayConfigNotationProvider]]></code>
       <code><![CDATA[arrayConfigNotationWithoutKeyProvider]]></code>
       <code><![CDATA[arrayConstantNotationProvider]]></code>
       <code><![CDATA[arrayOnlyProvider]]></code>
       <code><![CDATA[basicProvider]]></code>
       <code><![CDATA[booleanProvider]]></code>
+      <code><![CDATA[configObjectProvider]]></code>
       <code><![CDATA[constructorWithTypeArrayProvider]]></code>
       <code><![CDATA[duplicateStringSettingProvider]]></code>
       <code><![CDATA[floatOnlyProvider]]></code>
@@ -1731,10 +1918,25 @@
       <code><![CDATA[$value]]></code>
     </PossiblyInvalidCast>
   </file>
+  <file src="test/StaticValidatorTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setService]]></code>
+    </DeprecatedMethod>
+    <NullArgument>
+      <code><![CDATA[null]]></code>
+    </NullArgument>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[invalidParameterizedData]]></code>
+      <code><![CDATA[parameterizedData]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/StepTest.php">
+    <InvalidArgument>
+      <code><![CDATA[$baseValue]]></code>
+    </InvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[decimalHundredthStepValues]]></code>
-      <code><![CDATA[decimalStepSubtractionBugValues]]></code>
+      <code><![CDATA[decimalStepSubstractionBugValues]]></code>
       <code><![CDATA[decimalStepValues]]></code>
       <code><![CDATA[decimalValues]]></code>
       <code><![CDATA[valuesToValidate]]></code>
@@ -1786,5 +1988,10 @@
     <UnusedParam>
       <code><![CDATA[$errnum]]></code>
     </UnusedParam>
+  </file>
+  <file src="test/ValidatorPluginManagerTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setService]]></code>
+    </DeprecatedMethod>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,22 +50,6 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -119,7 +103,6 @@
       <code><![CDATA[$this->cardLength[$type]]]></code>
       <code><![CDATA[$this->options['type']]]></code>
       <code><![CDATA[$this->options['type']]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArrayAssignment>
       <code><![CDATA[$this->options['type'][]]]></code>
@@ -194,9 +177,6 @@
       <code><![CDATA['']]></code>
       <code><![CDATA[is_string($value)]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code><![CDATA[$this->getAllow()]]></code>
-    </InvalidArgument>
     <LessSpecificImplementedReturnType>
       <code><![CDATA[AbstractValidator]]></code>
     </LessSpecificImplementedReturnType>
@@ -216,7 +196,7 @@
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
-      <code><![CDATA[int]]></code>
+      <code><![CDATA[int-mask-of<Hostname::ALLOW_*>]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code><![CDATA[setAllow]]></code>
@@ -373,9 +353,6 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
-    <NonInvariantDocblockPropertyType>
-      <code><![CDATA[$messageTemplates]]></code>
-    </NonInvariantDocblockPropertyType>
     <PossiblyFalseOperand>
       <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
@@ -1006,74 +983,18 @@
     </MixedArgument>
   </file>
   <file src="src/Hostname.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($options)]]></code>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$regexChar]]></code>
-      <code><![CDATA[$regexKey]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$partRegexChars]]></code>
       <code><![CDATA[$regexChar]]></code>
-      <code><![CDATA[$regexChars]]></code>
-      <code><![CDATA[$regexKey]]></code>
-      <code><![CDATA[$temp['allow']]]></code>
-      <code><![CDATA[$temp['ipValidator']]]></code>
-      <code><![CDATA[$temp['useIdnCheck']]]></code>
-      <code><![CDATA[$temp['useTldCheck']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[Ip]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$regexChars]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['allow']]]></code>
-      <code><![CDATA[$this->options['ipValidator']]]></code>
-      <code><![CDATA[$this->options['useIdnCheck']]]></code>
-      <code><![CDATA[$this->options['useTldCheck']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setAllow]]></code>
-      <code><![CDATA[setIpValidator]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $useIdnCheck]]></code>
-      <code><![CDATA[(bool) $useTldCheck]]></code>
-    </RedundantCastGivenDocblockType>
-    <UnresolvableInclude>
-      <code><![CDATA[include __DIR__ . '/' . $this->validIdns[$this->tld]]]></code>
-    </UnresolvableInclude>
   </file>
   <file src="src/Iban.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['allow_non_sepa']]]></code>
       <code><![CDATA[$options['country_code']]]></code>
     </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[static::$ibanRegex[$countryCode]]]></code>
-    </MixedOperand>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
     <PossiblyInvalidArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyInvalidArgument>
@@ -1130,20 +1051,6 @@
       <code><![CDATA[(bool) $recursive]]></code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/IsInstanceOf.php">
-    <MixedAssignment>
-      <code><![CDATA[$tmpOptions['className']]]></code>
-    </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setClassName]]></code>
-    </PossiblyUnusedMethod>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$className]]></code>
-    </PropertyNotSetInConstructor>
-  </file>
   <file src="src/IsJsonString.php">
     <InvalidArgument>
       <code><![CDATA[$this->maxDepth]]></code>
@@ -1174,27 +1081,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/NotEmpty.php">
-    <MixedAssignment>
-      <code><![CDATA[$temp['type']]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['type']]]></code>
-    </MixedReturnStatement>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$type]]></code>
-    </PossiblyNullArgument>
-    <RedundantCondition>
-      <code><![CDATA[is_object($value) && method_exists($value, '__toString') && (string) $value === '']]></code>
-    </RedundantCondition>
-  </file>
   <file src="src/NumberComparison.php">
     <MixedAssignment>
       <code><![CDATA[$inclusiveMax]]></code>
@@ -1224,41 +1110,6 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
-  </file>
-  <file src="src/StaticValidator.php">
-    <UndefinedMethod>
-      <code><![CDATA[setShareByDefault]]></code>
-    </UndefinedMethod>
-  </file>
-  <file src="src/Step.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($options)]]></code>
-    </DocblockTypeContradiction>
-    <MixedArgument>
-      <code><![CDATA[$options['baseValue']]]></code>
-      <code><![CDATA[$options['step']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$temp['baseValue']]]></code>
-      <code><![CDATA[$temp['step']]]></code>
-    </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-  </file>
-  <file src="src/Translator/DummyTranslator.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int) $number]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Translator/TranslatorAwareInterface.php">
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[TranslatorAwareInterface]]></code>
-      <code><![CDATA[self]]></code>
-    </PossiblyUnusedReturnValue>
   </file>
   <file src="src/ValidatorChain.php">
     <MixedPropertyTypeCoercion>
@@ -1304,10 +1155,6 @@
     </UnusedClass>
   </file>
   <file src="test/AbstractValidatorTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$options]]></code>
     </InvalidArgument>
@@ -1317,10 +1164,6 @@
     <MixedAssignment>
       <code><![CDATA[$message]]></code>
     </MixedAssignment>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[invalidOptionsArguments]]></code>
     </PossiblyUnusedMethod>
@@ -1391,12 +1234,7 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EmailAddressTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
     <InvalidArgument>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
@@ -1407,9 +1245,6 @@
     <InvalidCast>
       <code><![CDATA[[1 => 1]]]></code>
     </InvalidCast>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[emailAddressesForMxChecks]]></code>
       <code><![CDATA[errorHandler]]></code>
@@ -1710,34 +1545,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/HostnameTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_URI]]></code>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidArgument>
-    <InvalidCast>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidCast>
     <MixedArrayOffset>
       <code><![CDATA[$translations[$code]]]></code>
     </MixedArrayOffset>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
     <PossiblyUndefinedVariable>
       <code><![CDATA[$code]]></code>
       <code><![CDATA[$message]]></code>
@@ -1796,24 +1606,9 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/IsCountableTest.php">
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[conflictingOptionsProvider]]></code>
-      <code><![CDATA[conflictingSecondaryOptionsProvider]]></code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="test/IsInstanceOfTest.php">
-    <InvalidArgument>
-      <code><![CDATA[DateTime::class]]></code>
-      <code><![CDATA[DateTime::class]]></code>
-      <code><![CDATA[DateTime::class]]></code>
-      <code><![CDATA[DateTime::class]]></code>
-      <code><![CDATA[DateTime::class]]></code>
-      <code><![CDATA[Exception::class]]></code>
-      <code><![CDATA[TestCase::class]]></code>
-    </InvalidArgument>
   </file>
   <file src="test/IsJsonStringTest.php">
     <PossiblyUnusedMethod>
@@ -1845,20 +1640,17 @@
     </UndefinedThisPropertyFetch>
   </file>
   <file src="test/NotEmptyTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA['boolean']]></code>
-      <code><![CDATA['boolean']]></code>
-      <code><![CDATA[true]]></code>
-    </InvalidArgument>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+            'type' => [$string, $string],
+        ]]]></code>
+    </ArgumentTypeCoercion>
     <PossiblyUnusedMethod>
-      <code><![CDATA[arrayConfigNotationProvider]]></code>
       <code><![CDATA[arrayConfigNotationWithoutKeyProvider]]></code>
       <code><![CDATA[arrayConstantNotationProvider]]></code>
       <code><![CDATA[arrayOnlyProvider]]></code>
       <code><![CDATA[basicProvider]]></code>
       <code><![CDATA[booleanProvider]]></code>
-      <code><![CDATA[configObjectProvider]]></code>
       <code><![CDATA[constructorWithTypeArrayProvider]]></code>
       <code><![CDATA[duplicateStringSettingProvider]]></code>
       <code><![CDATA[floatOnlyProvider]]></code>
@@ -1918,25 +1710,10 @@
       <code><![CDATA[$value]]></code>
     </PossiblyInvalidCast>
   </file>
-  <file src="test/StaticValidatorTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[setService]]></code>
-    </DeprecatedMethod>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[invalidParameterizedData]]></code>
-      <code><![CDATA[parameterizedData]]></code>
-    </PossiblyUnusedMethod>
-  </file>
   <file src="test/StepTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$baseValue]]></code>
-    </InvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[decimalHundredthStepValues]]></code>
-      <code><![CDATA[decimalStepSubstractionBugValues]]></code>
+      <code><![CDATA[decimalStepSubtractionBugValues]]></code>
       <code><![CDATA[decimalStepValues]]></code>
       <code><![CDATA[decimalValues]]></code>
       <code><![CDATA[valuesToValidate]]></code>

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -105,7 +105,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
     public function plugin($name, ?array $options = null)
     {
         $plugins = $this->getPluginManager();
-        return $plugins->get($name, $options);
+        return $plugins->build($name, $options);
     }
 
     /**

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -246,7 +246,7 @@ final class ValidatorPluginManager extends AbstractSingleInstancePluginManager
 
         if ($container->has('MvcTranslator')) {
             $translator = $container->get('MvcTranslator');
-            assert($translator instanceof Translator\TranslatorInterface);
+            assert($translator instanceof TranslatorInterface);
             $validator->setTranslator($translator);
 
             return;

--- a/src/ValidatorPluginManager.php
+++ b/src/ValidatorPluginManager.php
@@ -4,337 +4,250 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\Exception\InvalidServiceException;
+use Closure;
+use Laminas\ServiceManager\AbstractSingleInstancePluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Translator\TranslatorInterface;
 use Psr\Container\ContainerInterface;
 
-use function get_debug_type;
-use function method_exists;
-use function sprintf;
+use function array_replace_recursive;
+use function assert;
 
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
- * @extends AbstractPluginManager<ValidatorInterface>
+ * @extends AbstractSingleInstancePluginManager<ValidatorInterface>
  */
-final class ValidatorPluginManager extends AbstractPluginManager
+final class ValidatorPluginManager extends AbstractSingleInstancePluginManager
 {
-    /**
-     * Default set of aliases
-     *
-     * @inheritDoc
-     */
-    protected $aliases = [
-        'barcode'                => Barcode::class,
-        'Barcode'                => Barcode::class,
-        'BIC'                    => BusinessIdentifierCode::class,
-        'bic'                    => BusinessIdentifierCode::class,
-        'bitwise'                => Bitwise::class,
-        'Bitwise'                => Bitwise::class,
-        'BusinessIdentifierCode' => BusinessIdentifierCode::class,
-        'businessidentifiercode' => BusinessIdentifierCode::class,
-        'callback'               => Callback::class,
-        'Callback'               => Callback::class,
-        'creditcard'             => CreditCard::class,
-        'creditCard'             => CreditCard::class,
-        'CreditCard'             => CreditCard::class,
-        'date'                   => Date::class,
-        'Date'                   => Date::class,
-        'datestep'               => DateStep::class,
-        'dateStep'               => DateStep::class,
-        'DateStep'               => DateStep::class,
-        'digits'                 => Digits::class,
-        'Digits'                 => Digits::class,
-        'emailaddress'           => EmailAddress::class,
-        'emailAddress'           => EmailAddress::class,
-        'EmailAddress'           => EmailAddress::class,
-        'explode'                => Explode::class,
-        'Explode'                => Explode::class,
-        'filecount'              => File\Count::class,
-        'fileCount'              => File\Count::class,
-        'FileCount'              => File\Count::class,
-        'filecrc32'              => File\Crc32::class,
-        'fileCrc32'              => File\Crc32::class,
-        'FileCrc32'              => File\Crc32::class,
-        'fileexcludeextension'   => File\ExcludeExtension::class,
-        'fileExcludeExtension'   => File\ExcludeExtension::class,
-        'FileExcludeExtension'   => File\ExcludeExtension::class,
-        'fileexcludemimetype'    => File\ExcludeMimeType::class,
-        'fileExcludeMimeType'    => File\ExcludeMimeType::class,
-        'FileExcludeMimeType'    => File\ExcludeMimeType::class,
-        'fileexists'             => File\Exists::class,
-        'fileExists'             => File\Exists::class,
-        'FileExists'             => File\Exists::class,
-        'fileextension'          => File\Extension::class,
-        'fileExtension'          => File\Extension::class,
-        'FileExtension'          => File\Extension::class,
-        'filefilessize'          => File\FilesSize::class,
-        'fileFilesSize'          => File\FilesSize::class,
-        'FileFilesSize'          => File\FilesSize::class,
-        'filehash'               => File\Hash::class,
-        'fileHash'               => File\Hash::class,
-        'FileHash'               => File\Hash::class,
-        'fileimagesize'          => File\ImageSize::class,
-        'fileImageSize'          => File\ImageSize::class,
-        'FileImageSize'          => File\ImageSize::class,
-        'fileiscompressed'       => File\IsCompressed::class,
-        'fileIsCompressed'       => File\IsCompressed::class,
-        'FileIsCompressed'       => File\IsCompressed::class,
-        'fileisimage'            => File\IsImage::class,
-        'fileIsImage'            => File\IsImage::class,
-        'FileIsImage'            => File\IsImage::class,
-        'filemd5'                => File\Md5::class,
-        'fileMd5'                => File\Md5::class,
-        'FileMd5'                => File\Md5::class,
-        'filemimetype'           => File\MimeType::class,
-        'fileMimeType'           => File\MimeType::class,
-        'FileMimeType'           => File\MimeType::class,
-        'filenotexists'          => File\NotExists::class,
-        'fileNotExists'          => File\NotExists::class,
-        'FileNotExists'          => File\NotExists::class,
-        'filesha1'               => File\Sha1::class,
-        'fileSha1'               => File\Sha1::class,
-        'FileSha1'               => File\Sha1::class,
-        'filesize'               => File\Size::class,
-        'fileSize'               => File\Size::class,
-        'FileSize'               => File\Size::class,
-        'fileupload'             => File\Upload::class,
-        'fileUpload'             => File\Upload::class,
-        'FileUpload'             => File\Upload::class,
-        'fileuploadfile'         => File\UploadFile::class,
-        'fileUploadFile'         => File\UploadFile::class,
-        'FileUploadFile'         => File\UploadFile::class,
-        'filewordcount'          => File\WordCount::class,
-        'fileWordCount'          => File\WordCount::class,
-        'FileWordCount'          => File\WordCount::class,
-        'gpspoint'               => GpsPoint::class,
-        'gpsPoint'               => GpsPoint::class,
-        'GpsPoint'               => GpsPoint::class,
-        'hex'                    => Hex::class,
-        'Hex'                    => Hex::class,
-        'hostname'               => Hostname::class,
-        'Hostname'               => Hostname::class,
-        'iban'                   => Iban::class,
-        'Iban'                   => Iban::class,
-        'identical'              => Identical::class,
-        'Identical'              => Identical::class,
-        'inarray'                => InArray::class,
-        'inArray'                => InArray::class,
-        'InArray'                => InArray::class,
-        'ip'                     => Ip::class,
-        'Ip'                     => Ip::class,
-        'IsArray'                => IsArray::class,
-        'isbn'                   => Isbn::class,
-        'Isbn'                   => Isbn::class,
-        'isCountable'            => IsCountable::class,
-        'IsCountable'            => IsCountable::class,
-        'iscountable'            => IsCountable::class,
-        'isinstanceof'           => IsInstanceOf::class,
-        'isInstanceOf'           => IsInstanceOf::class,
-        'IsInstanceOf'           => IsInstanceOf::class,
-        'notempty'               => NotEmpty::class,
-        'notEmpty'               => NotEmpty::class,
-        'NotEmpty'               => NotEmpty::class,
-        'regex'                  => Regex::class,
-        'Regex'                  => Regex::class,
-        'sitemapchangefreq'      => Sitemap\Changefreq::class,
-        'sitemapChangefreq'      => Sitemap\Changefreq::class,
-        'SitemapChangefreq'      => Sitemap\Changefreq::class,
-        'sitemaplastmod'         => Sitemap\Lastmod::class,
-        'sitemapLastmod'         => Sitemap\Lastmod::class,
-        'SitemapLastmod'         => Sitemap\Lastmod::class,
-        'sitemaploc'             => Sitemap\Loc::class,
-        'sitemapLoc'             => Sitemap\Loc::class,
-        'SitemapLoc'             => Sitemap\Loc::class,
-        'sitemappriority'        => Sitemap\Priority::class,
-        'sitemapPriority'        => Sitemap\Priority::class,
-        'SitemapPriority'        => Sitemap\Priority::class,
-        'stringlength'           => StringLength::class,
-        'stringLength'           => StringLength::class,
-        'StringLength'           => StringLength::class,
-        'step'                   => Step::class,
-        'Step'                   => Step::class,
-        'timezone'               => Timezone::class,
-        'Timezone'               => Timezone::class,
-        'uri'                    => Uri::class,
-        'Uri'                    => Uri::class,
-        'uuid'                   => Uuid::class,
-        'Uuid'                   => Uuid::class,
+    private const DEFAULT_CONFIGURATION = [
+        'factories' => [
+            Barcode::class                   => InvokableFactory::class,
+            Bitwise::class                   => InvokableFactory::class,
+            BusinessIdentifierCode::class    => InvokableFactory::class,
+            Callback::class                  => InvokableFactory::class,
+            CreditCard::class                => InvokableFactory::class,
+            DateStep::class                  => InvokableFactory::class,
+            Date::class                      => InvokableFactory::class,
+            DateComparison::class            => InvokableFactory::class,
+            Digits::class                    => InvokableFactory::class,
+            EmailAddress::class              => InvokableFactory::class,
+            Explode::class                   => InvokableFactory::class,
+            File\Count::class                => InvokableFactory::class,
+            File\Crc32::class                => InvokableFactory::class,
+            File\ExcludeExtension::class     => InvokableFactory::class,
+            File\ExcludeMimeType::class      => InvokableFactory::class,
+            File\Exists::class               => InvokableFactory::class,
+            File\Extension::class            => InvokableFactory::class,
+            File\FilesSize::class            => InvokableFactory::class,
+            File\Hash::class                 => InvokableFactory::class,
+            File\ImageSize::class            => InvokableFactory::class,
+            File\IsCompressed::class         => InvokableFactory::class,
+            File\IsImage::class              => InvokableFactory::class,
+            File\Md5::class                  => InvokableFactory::class,
+            File\MimeType::class             => InvokableFactory::class,
+            File\NotExists::class            => InvokableFactory::class,
+            File\Sha1::class                 => InvokableFactory::class,
+            File\Size::class                 => InvokableFactory::class,
+            File\Upload::class               => InvokableFactory::class,
+            File\UploadFile::class           => InvokableFactory::class,
+            File\WordCount::class            => InvokableFactory::class,
+            GpsPoint::class                  => InvokableFactory::class,
+            Hex::class                       => InvokableFactory::class,
+            Hostname::class                  => InvokableFactory::class,
+            HostWithPublicIPv4Address::class => InvokableFactory::class,
+            Iban::class                      => InvokableFactory::class,
+            Identical::class                 => InvokableFactory::class,
+            InArray::class                   => InvokableFactory::class,
+            Ip::class                        => InvokableFactory::class,
+            IsArray::class                   => InvokableFactory::class,
+            Isbn::class                      => InvokableFactory::class,
+            IsCountable::class               => InvokableFactory::class,
+            IsInstanceOf::class              => InvokableFactory::class,
+            IsJsonString::class              => InvokableFactory::class,
+            NotEmpty::class                  => InvokableFactory::class,
+            NumberComparison::class          => InvokableFactory::class,
+            Regex::class                     => InvokableFactory::class,
+            Sitemap\Changefreq::class        => InvokableFactory::class,
+            Sitemap\Lastmod::class           => InvokableFactory::class,
+            Sitemap\Loc::class               => InvokableFactory::class,
+            Sitemap\Priority::class          => InvokableFactory::class,
+            StringLength::class              => InvokableFactory::class,
+            Step::class                      => InvokableFactory::class,
+            Timezone::class                  => InvokableFactory::class,
+            Uri::class                       => InvokableFactory::class,
+            Uuid::class                      => InvokableFactory::class,
+        ],
+        'aliases'   => [
+            'barcode'                => Barcode::class,
+            'Barcode'                => Barcode::class,
+            'BIC'                    => BusinessIdentifierCode::class,
+            'bic'                    => BusinessIdentifierCode::class,
+            'bitwise'                => Bitwise::class,
+            'Bitwise'                => Bitwise::class,
+            'BusinessIdentifierCode' => BusinessIdentifierCode::class,
+            'businessidentifiercode' => BusinessIdentifierCode::class,
+            'callback'               => Callback::class,
+            'Callback'               => Callback::class,
+            'creditcard'             => CreditCard::class,
+            'creditCard'             => CreditCard::class,
+            'CreditCard'             => CreditCard::class,
+            'date'                   => Date::class,
+            'Date'                   => Date::class,
+            'datestep'               => DateStep::class,
+            'dateStep'               => DateStep::class,
+            'DateStep'               => DateStep::class,
+            'digits'                 => Digits::class,
+            'Digits'                 => Digits::class,
+            'emailaddress'           => EmailAddress::class,
+            'emailAddress'           => EmailAddress::class,
+            'EmailAddress'           => EmailAddress::class,
+            'explode'                => Explode::class,
+            'Explode'                => Explode::class,
+            'filecount'              => File\Count::class,
+            'fileCount'              => File\Count::class,
+            'FileCount'              => File\Count::class,
+            'filecrc32'              => File\Crc32::class,
+            'fileCrc32'              => File\Crc32::class,
+            'FileCrc32'              => File\Crc32::class,
+            'fileexcludeextension'   => File\ExcludeExtension::class,
+            'fileExcludeExtension'   => File\ExcludeExtension::class,
+            'FileExcludeExtension'   => File\ExcludeExtension::class,
+            'fileexcludemimetype'    => File\ExcludeMimeType::class,
+            'fileExcludeMimeType'    => File\ExcludeMimeType::class,
+            'FileExcludeMimeType'    => File\ExcludeMimeType::class,
+            'fileexists'             => File\Exists::class,
+            'fileExists'             => File\Exists::class,
+            'FileExists'             => File\Exists::class,
+            'fileextension'          => File\Extension::class,
+            'fileExtension'          => File\Extension::class,
+            'FileExtension'          => File\Extension::class,
+            'filefilessize'          => File\FilesSize::class,
+            'fileFilesSize'          => File\FilesSize::class,
+            'FileFilesSize'          => File\FilesSize::class,
+            'filehash'               => File\Hash::class,
+            'fileHash'               => File\Hash::class,
+            'FileHash'               => File\Hash::class,
+            'fileimagesize'          => File\ImageSize::class,
+            'fileImageSize'          => File\ImageSize::class,
+            'FileImageSize'          => File\ImageSize::class,
+            'fileiscompressed'       => File\IsCompressed::class,
+            'fileIsCompressed'       => File\IsCompressed::class,
+            'FileIsCompressed'       => File\IsCompressed::class,
+            'fileisimage'            => File\IsImage::class,
+            'fileIsImage'            => File\IsImage::class,
+            'FileIsImage'            => File\IsImage::class,
+            'filemd5'                => File\Md5::class,
+            'fileMd5'                => File\Md5::class,
+            'FileMd5'                => File\Md5::class,
+            'filemimetype'           => File\MimeType::class,
+            'fileMimeType'           => File\MimeType::class,
+            'FileMimeType'           => File\MimeType::class,
+            'filenotexists'          => File\NotExists::class,
+            'fileNotExists'          => File\NotExists::class,
+            'FileNotExists'          => File\NotExists::class,
+            'filesha1'               => File\Sha1::class,
+            'fileSha1'               => File\Sha1::class,
+            'FileSha1'               => File\Sha1::class,
+            'filesize'               => File\Size::class,
+            'fileSize'               => File\Size::class,
+            'FileSize'               => File\Size::class,
+            'fileupload'             => File\Upload::class,
+            'fileUpload'             => File\Upload::class,
+            'FileUpload'             => File\Upload::class,
+            'fileuploadfile'         => File\UploadFile::class,
+            'fileUploadFile'         => File\UploadFile::class,
+            'FileUploadFile'         => File\UploadFile::class,
+            'filewordcount'          => File\WordCount::class,
+            'fileWordCount'          => File\WordCount::class,
+            'FileWordCount'          => File\WordCount::class,
+            'gpspoint'               => GpsPoint::class,
+            'gpsPoint'               => GpsPoint::class,
+            'GpsPoint'               => GpsPoint::class,
+            'hex'                    => Hex::class,
+            'Hex'                    => Hex::class,
+            'hostname'               => Hostname::class,
+            'Hostname'               => Hostname::class,
+            'iban'                   => Iban::class,
+            'Iban'                   => Iban::class,
+            'identical'              => Identical::class,
+            'Identical'              => Identical::class,
+            'inarray'                => InArray::class,
+            'inArray'                => InArray::class,
+            'InArray'                => InArray::class,
+            'ip'                     => Ip::class,
+            'Ip'                     => Ip::class,
+            'IsArray'                => IsArray::class,
+            'isbn'                   => Isbn::class,
+            'Isbn'                   => Isbn::class,
+            'isCountable'            => IsCountable::class,
+            'IsCountable'            => IsCountable::class,
+            'iscountable'            => IsCountable::class,
+            'isinstanceof'           => IsInstanceOf::class,
+            'isInstanceOf'           => IsInstanceOf::class,
+            'IsInstanceOf'           => IsInstanceOf::class,
+            'notempty'               => NotEmpty::class,
+            'notEmpty'               => NotEmpty::class,
+            'NotEmpty'               => NotEmpty::class,
+            'regex'                  => Regex::class,
+            'Regex'                  => Regex::class,
+            'sitemapchangefreq'      => Sitemap\Changefreq::class,
+            'sitemapChangefreq'      => Sitemap\Changefreq::class,
+            'SitemapChangefreq'      => Sitemap\Changefreq::class,
+            'sitemaplastmod'         => Sitemap\Lastmod::class,
+            'sitemapLastmod'         => Sitemap\Lastmod::class,
+            'SitemapLastmod'         => Sitemap\Lastmod::class,
+            'sitemaploc'             => Sitemap\Loc::class,
+            'sitemapLoc'             => Sitemap\Loc::class,
+            'SitemapLoc'             => Sitemap\Loc::class,
+            'sitemappriority'        => Sitemap\Priority::class,
+            'sitemapPriority'        => Sitemap\Priority::class,
+            'SitemapPriority'        => Sitemap\Priority::class,
+            'stringlength'           => StringLength::class,
+            'stringLength'           => StringLength::class,
+            'StringLength'           => StringLength::class,
+            'step'                   => Step::class,
+            'Step'                   => Step::class,
+            'timezone'               => Timezone::class,
+            'Timezone'               => Timezone::class,
+            'uri'                    => Uri::class,
+            'Uri'                    => Uri::class,
+            'uuid'                   => Uuid::class,
+            'Uuid'                   => Uuid::class,
+        ],
     ];
 
     /**
-     * Default set of factories
-     *
-     * @inheritDoc
+     * Whether to share by default; default to false
      */
-    protected $factories = [
-        Barcode::class                   => InvokableFactory::class,
-        Bitwise::class                   => InvokableFactory::class,
-        BusinessIdentifierCode::class    => InvokableFactory::class,
-        Callback::class                  => InvokableFactory::class,
-        CreditCard::class                => InvokableFactory::class,
-        DateStep::class                  => InvokableFactory::class,
-        Date::class                      => InvokableFactory::class,
-        DateComparison::class            => InvokableFactory::class,
-        Digits::class                    => InvokableFactory::class,
-        EmailAddress::class              => InvokableFactory::class,
-        Explode::class                   => InvokableFactory::class,
-        File\Count::class                => InvokableFactory::class,
-        File\Crc32::class                => InvokableFactory::class,
-        File\ExcludeExtension::class     => InvokableFactory::class,
-        File\ExcludeMimeType::class      => InvokableFactory::class,
-        File\Exists::class               => InvokableFactory::class,
-        File\Extension::class            => InvokableFactory::class,
-        File\FilesSize::class            => InvokableFactory::class,
-        File\Hash::class                 => InvokableFactory::class,
-        File\ImageSize::class            => InvokableFactory::class,
-        File\IsCompressed::class         => InvokableFactory::class,
-        File\IsImage::class              => InvokableFactory::class,
-        File\Md5::class                  => InvokableFactory::class,
-        File\MimeType::class             => InvokableFactory::class,
-        File\NotExists::class            => InvokableFactory::class,
-        File\Sha1::class                 => InvokableFactory::class,
-        File\Size::class                 => InvokableFactory::class,
-        File\Upload::class               => InvokableFactory::class,
-        File\UploadFile::class           => InvokableFactory::class,
-        File\WordCount::class            => InvokableFactory::class,
-        GpsPoint::class                  => InvokableFactory::class,
-        Hex::class                       => InvokableFactory::class,
-        Hostname::class                  => InvokableFactory::class,
-        HostWithPublicIPv4Address::class => InvokableFactory::class,
-        Iban::class                      => InvokableFactory::class,
-        Identical::class                 => InvokableFactory::class,
-        InArray::class                   => InvokableFactory::class,
-        Ip::class                        => InvokableFactory::class,
-        IsArray::class                   => InvokableFactory::class,
-        Isbn::class                      => InvokableFactory::class,
-        IsCountable::class               => InvokableFactory::class,
-        IsInstanceOf::class              => InvokableFactory::class,
-        IsJsonString::class              => InvokableFactory::class,
-        NotEmpty::class                  => InvokableFactory::class,
-        NumberComparison::class          => InvokableFactory::class,
-        Regex::class                     => InvokableFactory::class,
-        Sitemap\Changefreq::class        => InvokableFactory::class,
-        Sitemap\Lastmod::class           => InvokableFactory::class,
-        Sitemap\Loc::class               => InvokableFactory::class,
-        Sitemap\Priority::class          => InvokableFactory::class,
-        StringLength::class              => InvokableFactory::class,
-        Step::class                      => InvokableFactory::class,
-        Timezone::class                  => InvokableFactory::class,
-        Uri::class                       => InvokableFactory::class,
-        Uuid::class                      => InvokableFactory::class,
-    ];
+    protected bool $sharedByDefault = false;
+
+    protected string $instanceOf = ValidatorInterface::class;
 
     /**
-     * Whether or not to share by default; default to false (v2)
-     *
-     * @var bool
+     * @param ServiceManagerConfiguration $config
      */
-    protected $shareByDefault = false;
-
-    /**
-     * Whether or not to share by default; default to false (v3)
-     *
-     * @var bool
-     */
-    protected $sharedByDefault = false;
-
-    /**
-     * Default instance type
-     *
-     * @inheritDoc
-     */
-    protected $instanceOf = ValidatorInterface::class;
-
-    /**
-     * Constructor
-     *
-     * After invoking parent constructor, add an initializer to inject the
-     * attached translator, if any, to the currently requested helper.
-     *
-     * {@inheritDoc}
-     *
-     * @param ServiceManagerConfiguration $v3config
-     */
-    public function __construct($configOrContainerInstance = null, array $v3config = [])
+    public function __construct(ContainerInterface $creationContext, array $config = [])
     {
-        parent::__construct($configOrContainerInstance, $v3config);
+        /** @var ServiceManagerConfiguration $config */
+        $config = array_replace_recursive(self::DEFAULT_CONFIGURATION, $config);
+        parent::__construct($creationContext, $config);
 
-        $this->addInitializer([$this, 'injectTranslator']);
-        $this->addInitializer([$this, 'injectValidatorPluginManager']);
+        $this->addInitializer(Closure::fromCallable([$this, 'injectTranslator']));
+        $this->addInitializer(Closure::fromCallable([$this, 'injectValidatorPluginManager']));
     }
 
-    /**
-     * @param mixed $instance
-     * @psalm-assert ValidatorInterface $instance
-     */
-    public function validate($instance)
+    /** @internal */
+    protected function injectTranslator(ContainerInterface $container, object $validator): void
     {
-        if (! $instance instanceof $this->instanceOf) {
-            throw new InvalidServiceException(sprintf(
-                '%s expects only to create instances of %s; %s is invalid',
-                static::class,
-                (string) $this->instanceOf,
-                get_debug_type($instance)
-            ));
-        }
-    }
-
-    /**
-     * For v2 compatibility: validate plugin instance.
-     *
-     * Proxies to `validate()`.
-     *
-     * @return void
-     * @throws Exception\RuntimeException
-     */
-    public function validatePlugin(mixed $plugin)
-    {
-        try {
-            $this->validate($plugin);
-        } catch (InvalidServiceException $e) {
-            throw new Exception\RuntimeException(sprintf(
-                'Plugin of type %s is invalid; must implement %s',
-                get_debug_type($plugin),
-                ValidatorInterface::class
-            ), $e->getCode(), $e);
-        }
-    }
-
-    /**
-     * Inject a validator instance with the registered translator
-     *
-     * @param  ContainerInterface|object $first
-     * @param  ContainerInterface|object $second
-     * @return void
-     */
-    public function injectTranslator($first, $second)
-    {
-        if ($first instanceof ContainerInterface) {
-            $container = $first;
-            $validator = $second;
-        } else {
-            $container = $second;
-            $validator = $first;
-        }
-
         if (! $validator instanceof Translator\TranslatorAwareInterface) {
             return;
         }
 
-        // V2 means we pull it from the parent container
-        if ($container === $this && method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
-            $container = $container->getServiceLocator();
-        }
-
-        if (! $container instanceof ContainerInterface) {
-            return;
-        }
-
         if ($container->has('MvcTranslator')) {
-            $validator->setTranslator($container->get('MvcTranslator'));
+            $translator = $container->get('MvcTranslator');
+            assert($translator instanceof Translator\TranslatorInterface);
+            $validator->setTranslator($translator);
 
             return;
         }
@@ -344,22 +257,15 @@ final class ValidatorPluginManager extends AbstractPluginManager
         }
     }
 
-    /**
-     * Inject a validator plugin manager
-     *
-     * @param  ContainerInterface|object $first
-     * @param  ContainerInterface|object $second
-     * @return void
-     */
-    public function injectValidatorPluginManager($first, $second)
-    {
-        if ($first instanceof ContainerInterface) {
-            $validator = $second;
-        } else {
-            $validator = $first;
+    /** @internal */
+    protected function injectValidatorPluginManager(
+        ContainerInterface $container,
+        object $validator,
+    ): void {
+        if (! $validator instanceof ValidatorPluginManagerAwareInterface) {
+            return;
         }
-        if ($validator instanceof ValidatorPluginManagerAwareInterface) {
-            $validator->setValidatorPluginManager($this);
-        }
+
+        $validator->setValidatorPluginManager($this);
     }
 }

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -16,14 +16,6 @@ use function is_array;
  */
 final class ValidatorPluginManagerFactory
 {
-    /**
-     * {@inheritDoc}
-     *
-     * @param string $name
-     * @param ServiceManagerConfiguration|null $options
-     * @return ValidatorPluginManager
-     * @psalm-suppress MoreSpecificImplementedParamType
-     */
     public function __invoke(ContainerInterface $container): ValidatorPluginManager
     {
         // If this is in a laminas-mvc application, the ServiceListener will inject

--- a/src/ValidatorPluginManagerFactory.php
+++ b/src/ValidatorPluginManagerFactory.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\ServiceManager\Config;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
 
@@ -17,15 +14,8 @@ use function is_array;
  *
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
-final class ValidatorPluginManagerFactory implements FactoryInterface
+final class ValidatorPluginManagerFactory
 {
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @var null|ServiceManagerConfiguration
-     */
-    protected $creationOptions;
-
     /**
      * {@inheritDoc}
      *
@@ -34,54 +24,26 @@ final class ValidatorPluginManagerFactory implements FactoryInterface
      * @return ValidatorPluginManager
      * @psalm-suppress MoreSpecificImplementedParamType
      */
-    public function __invoke(ContainerInterface $container, $name, ?array $options = null)
+    public function __invoke(ContainerInterface $container): ValidatorPluginManager
     {
-        $pluginManager = new ValidatorPluginManager($container, $options ?? []);
-
         // If this is in a laminas-mvc application, the ServiceListener will inject
         // merged configuration during bootstrap.
         if ($container->has('ServiceListener')) {
-            return $pluginManager;
+            return new ValidatorPluginManager($container);
         }
 
         // If we do not have a config service, nothing more to do
         if (! $container->has('config')) {
-            return $pluginManager;
+            return new ValidatorPluginManager($container);
         }
 
         $config = $container->get('config');
 
         // If we do not have validators configuration, nothing more to do
         if (! isset($config['validators']) || ! is_array($config['validators'])) {
-            return $pluginManager;
+            return new ValidatorPluginManager($container);
         }
 
-        // Wire service configuration for validators
-        (new Config($config['validators']))->configureServiceManager($pluginManager);
-
-        return $pluginManager;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @param string|null $name
-     * @param string|null $requestedName
-     * @return ValidatorPluginManager
-     */
-    public function createService(ServiceLocatorInterface $container, $name = null, $requestedName = null)
-    {
-        return $this($container, $requestedName ?? ValidatorPluginManager::class, $this->creationOptions);
-    }
-
-    /**
-     * laminas-servicemanager v2 support for invocation options.
-     *
-     * @param ServiceManagerConfiguration $options
-     * @return void
-     */
-    public function setCreationOptions(array $options)
-    {
-        $this->creationOptions = $options;
+        return new ValidatorPluginManager($container, $config['validators']);
     }
 }

--- a/test/StaticAnalysis/PluginManager.php
+++ b/test/StaticAnalysis/PluginManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Validator\StaticAnalysis;
 
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\Uuid;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
@@ -13,13 +14,13 @@ final class PluginManager
 {
     public function validateAssertsPluginType(mixed $input): ValidatorInterface
     {
-        (new ValidatorPluginManager())->validate($input);
+        (new ValidatorPluginManager(new ServiceManager()))->validate($input);
 
         return $input;
     }
 
     public function getWithClassStringReturnsCorrectInstanceType(): ValidatorInterface
     {
-        return (new ValidatorPluginManager())->get(Uuid::class);
+        return (new ValidatorPluginManager(new ServiceManager()))->get(Uuid::class);
     }
 }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Validator;
 
+use Laminas\ServiceManager\AbstractSingleInstancePluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use Laminas\Validator\Barcode;
@@ -27,6 +28,7 @@ use function assert;
 use function in_array;
 use function is_string;
 
+/** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class ValidatorPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
@@ -45,9 +47,14 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         IsInstanceOf::class,
     ];
 
-    protected static function getPluginManager(): ValidatorPluginManager
+    /**
+     * Returns the plugin manager to test
+     *
+     * @param ServiceManagerConfiguration $config
+     */
+    protected static function getPluginManager(array $config = []): AbstractSingleInstancePluginManager
     {
-        return new ValidatorPluginManager(new ServiceManager());
+        return new ValidatorPluginManager(new ServiceManager(), $config);
     }
 
     protected function getV2InvalidPluginException(): string

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -11,7 +11,6 @@ use Laminas\Validator\Barcode;
 use Laminas\Validator\Bitwise;
 use Laminas\Validator\Callback;
 use Laminas\Validator\DateComparison;
-use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\Explode;
 use Laminas\Validator\File\ExcludeExtension;
 use Laminas\Validator\File\Extension;
@@ -22,7 +21,7 @@ use Laminas\Validator\Regex;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
+use ReflectionClass;
 
 use function assert;
 use function in_array;
@@ -57,11 +56,6 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         return new ValidatorPluginManager(new ServiceManager(), $config);
     }
 
-    protected function getV2InvalidPluginException(): string
-    {
-        return RuntimeException::class;
-    }
-
     protected function getInstanceOf(): string
     {
         return ValidatorInterface::class;
@@ -70,14 +64,14 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
     /** @return array<string, array{0: string, 1: string}> */
     public static function aliasProvider(): array
     {
-        $out           = [];
-        $pluginManager = self::getPluginManager();
+        $class  = new ReflectionClass(ValidatorPluginManager::class);
+        $config = $class->getConstant('DEFAULT_CONFIGURATION');
+        self::assertIsArray($config);
+        self::assertIsArray($config['aliases'] ?? null);
 
-        $r       = new ReflectionProperty($pluginManager, 'aliases');
-        $aliases = $r->getValue($pluginManager);
-        self::assertIsArray($aliases);
+        $out = [];
 
-        foreach ($aliases as $alias => $target) {
+        foreach ($config['aliases'] as $alias => $target) {
             assert(is_string($target));
             assert(is_string($alias));
 

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -23,39 +23,6 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
     }
 
-    #[Depends('testFactoryReturnsPluginManager')]
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
-    {
-        $validator = $this->createMock(ValidatorInterface::class);
-
-        $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory(new InMemoryContainer(), ValidatorPluginManagerFactory::class, [
-            'services' => [
-                'test' => $validator,
-            ],
-        ]);
-
-        self::assertSame($validator, $validators->get('test'));
-    }
-
-    #[Depends('testFactoryReturnsPluginManager')]
-    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
-    {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $validator = $this->createMock(ValidatorInterface::class);
-
-        $factory = new ValidatorPluginManagerFactory();
-        $factory->setCreationOptions([
-            'services' => [
-                'test' => $validator,
-            ],
-        ]);
-
-        $validators = $factory->createService($container);
-
-        self::assertSame($validator, $validators->get('test'));
-    }
-
     public function testConfiguresValidatorServicesWhenFound(): void
     {
         $validator = $this->createMock(ValidatorInterface::class);

--- a/test/ValidatorPluginManagerFactoryTest.php
+++ b/test/ValidatorPluginManagerFactoryTest.php
@@ -10,7 +10,6 @@ use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use Laminas\Validator\ValidatorPluginManagerFactory;
 use LaminasTest\Validator\TestAsset\InMemoryContainer;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 final class ValidatorPluginManagerFactoryTest extends TestCase
@@ -18,7 +17,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
     public function testFactoryReturnsPluginManager(): void
     {
         $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory(new InMemoryContainer(), ValidatorPluginManagerFactory::class);
+        $validators = $factory(new InMemoryContainer());
 
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
     }
@@ -41,7 +40,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
         $container->set('config', $config);
 
         $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory($container, 'ValidatorManager');
+        $validators = $factory($container);
 
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
         self::assertTrue($validators->has('test'));
@@ -66,7 +65,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
             ->with('config');
 
         $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory($container, 'ValidatorManager');
+        $validators = $factory($container);
 
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
         self::assertFalse($validators->has('test'));
@@ -77,7 +76,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
     {
         $container  = new InMemoryContainer();
         $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory($container, 'ValidatorManager');
+        $validators = $factory($container);
 
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
     }
@@ -87,7 +86,7 @@ final class ValidatorPluginManagerFactoryTest extends TestCase
         $container = new InMemoryContainer();
         $container->set('config', ['foo' => 'bar']);
         $factory    = new ValidatorPluginManagerFactory();
-        $validators = $factory($container, 'ValidatorManager');
+        $validators = $factory($container);
 
         self::assertInstanceOf(ValidatorPluginManager::class, $validators);
         self::assertFalse($validators->has('foo'));


### PR DESCRIPTION
|    Q          |   A
|-------------- | -----
| BC Break      | yes
| New Feature   | yes

### Description

Initial support for Service Manager v4

- [x] Remove the shipped CSRF validator
- [x] Remove dependency on `laminas-session`
- [x] Support Service Manager v4 in `laminas-i18n`, or swap the dependency with the proposed [laminas-translator component](https://github.com/gsteel/laminas-translator)
- [x] Remove temporary dev branch for `i18n` in `composer.json`

Related https://github.com/laminas/laminas-session/pull/86

- Closes #233 