### PR TITLE
Clean up IP validator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1454,15 +1454,6 @@
       <code><![CDATA[(bool) $recursive]]></code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/Ip.php">
-    <MixedArgument>
-      <code><![CDATA[$regex]]></code>
-      <code><![CDATA[$regex]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-  </file>
   <file src="src/IsInstanceOf.php">
     <MixedAssignment>
       <code><![CDATA[$tmpOptions['className']]]></code>

--- a/src/Ip.php
+++ b/src/Ip.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Traversable;
-
 use function bindec;
 use function hexdec;
 use function ip2long;
@@ -19,57 +17,65 @@ use function strrpos;
 use function substr;
 use function substr_count;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ *     allowipv4?: bool,
+ *     allowipv6?: bool,
+ *     allowipvfuture?: bool,
+ *     allowliteral?: bool,
+ *     ...<string, mixed>,
+ * }
+ * @psalm-type Options = array{
+ *      allowipv4: bool,
+ *      allowipv6: bool,
+ *      allowipvfuture: bool,
+ *      allowliteral: bool,
+ *  }
+ */
 final class Ip extends AbstractValidator
 {
     public const INVALID        = 'ipInvalid';
     public const NOT_IP_ADDRESS = 'notIpAddress';
 
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::INVALID        => 'Invalid type given. String expected',
         self::NOT_IP_ADDRESS => 'The input does not appear to be a valid IP address',
     ];
 
-    /**
-     * Internal options
-     *
-     * @var array
-     */
-    protected $options = [
+    /** @var Options */
+    protected array $options = [
         'allowipv4'      => true, // Enable IPv4 Validation
         'allowipv6'      => true, // Enable IPv6 Validation
         'allowipvfuture' => false, // Enable IPvFuture Validation
         'allowliteral'   => true, // Enable IPs in literal format (only IPv6 and IPvFuture)
     ];
 
-    /**
-     * Sets the options for this validator
-     *
-     * @param array|Traversable $options
-     * @throws Exception\InvalidArgumentException If there is any kind of IP allowed or $options is not an array
-     *                                            or Traversable.
-     * @return AbstractValidator
-     */
-    public function setOptions($options = [])
+    /** @param OptionsArgument $options */
+    public function __construct(array $options = [])
     {
-        parent::setOptions($options);
+        $this->options['allowipv4']      = $options['allowipv4'] ?? true;
+        $this->options['allowipv6']      = $options['allowipv6'] ?? true;
+        $this->options['allowipvfuture'] = $options['allowipvfuture'] ?? false;
+        $this->options['allowliteral']   = $options['allowliteral'] ?? true;
 
-        if (! $this->options['allowipv4'] && ! $this->options['allowipv6'] && ! $this->options['allowipvfuture']) {
+        if (
+            $this->options['allowipv4'] === false
+            && $this->options['allowipv6'] === false
+            && $this->options['allowipvfuture'] === false
+        ) {
             throw new Exception\InvalidArgumentException('Nothing to validate. Check your options');
         }
 
-        return $this;
+        parent::__construct($options);
     }
 
     /**
      * Returns true if and only if $value is a valid IP address
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
-        if (! is_string($value)) {
+        if (! is_string($value) || $value === '') {
             $this->error(self::INVALID);
             return false;
         }
@@ -79,34 +85,28 @@ final class Ip extends AbstractValidator
         if ($this->options['allowipv4'] && $this->validateIPv4($value)) {
             return true;
         } else {
-            if ((bool) $this->options['allowliteral']) {
-                static $regex = '/^\[(.*)\]$/';
-                if ((bool) preg_match($regex, $value, $matches)) {
+            if ($this->options['allowliteral']) {
+                if (preg_match('/^\[(.*)\]$/', $value, $matches)) {
                     $value = $matches[1];
                 }
             }
 
-            $isValidV6Address = $this->validateIPv6($value);
-            $isValidV6Address = $isValidV6Address !== false && $isValidV6Address !== 0;
-
             if (
-                ($this->options['allowipv6'] && $isValidV6Address) ||
+                ($this->options['allowipv6'] && $this->validateIPv6($value)) ||
                 ($this->options['allowipvfuture'] && $this->validateIPvFuture($value))
             ) {
                 return true;
             }
         }
+
         $this->error(self::NOT_IP_ADDRESS);
         return false;
     }
 
     /**
      * Validates an IPv4 address
-     *
-     * @param string $value
-     * @return bool
      */
-    protected function validateIPv4($value)
+    private function validateIPv4(string $value): bool
     {
         if (preg_match('/^([01]{8}\.){3}[01]{8}\z/i', $value)) {
             // binary format  00000000.00000000.00000000.00000000
@@ -132,11 +132,8 @@ final class Ip extends AbstractValidator
 
     /**
      * Validates an IPv6 address
-     *
-     * @param string $value Value to check against
-     * @return bool|int True when $value is a valid ipv6 address False otherwise
      */
-    protected function validateIPv6($value)
+    private function validateIPv6(string $value): bool
     {
         if (strlen($value) < 3) {
             return $value === '::';
@@ -152,17 +149,17 @@ final class Ip extends AbstractValidator
         }
 
         if (! str_contains($value, '::')) {
-            return preg_match('/\A(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}\z/i', $value);
+            return (bool) preg_match('/\A(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}\z/i', $value);
         }
 
         $colonCount = substr_count($value, ':');
         if ($colonCount < 8) {
-            return preg_match('/\A(?::|(?:[a-f0-9]{1,4}:)+):(?:(?:[a-f0-9]{1,4}:)*[a-f0-9]{1,4})?\z/i', $value);
+            return (bool) preg_match('/\A(?::|(?:[a-f0-9]{1,4}:)+):(?:(?:[a-f0-9]{1,4}:)*[a-f0-9]{1,4})?\z/i', $value);
         }
 
         // special case with ending or starting double colon
         if ($colonCount === 8) {
-            return preg_match('/\A(?:::)?(?:[a-f0-9]{1,4}:){6}[a-f0-9]{1,4}(?:::)?\z/i', $value);
+            return (bool) preg_match('/\A(?:::)?(?:[a-f0-9]{1,4}:){6}[a-f0-9]{1,4}(?:::)?\z/i', $value);
         }
 
         return false;
@@ -172,12 +169,8 @@ final class Ip extends AbstractValidator
      * Validates an IPvFuture address.
      *
      * IPvFuture is loosely defined in the Section 3.2.2 of RFC 3986
-     *
-     * @param  string $value Value to check against
-     * @return bool True when $value is a valid IPvFuture address
-     *                 False otherwise
      */
-    protected function validateIPvFuture($value)
+    private function validateIPvFuture(string $value): bool
     {
         /*
          * ABNF:
@@ -186,7 +179,7 @@ final class Ip extends AbstractValidator
          * sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / ","
          *               / ";" / "="
          */
-        static $regex = '/^v([[:xdigit:]]+)\.[[:alnum:]\-\._~!\$&\'\(\)\*\+,;=:]+$/';
+        $regex = '/^v([[:xdigit:]]+)\.[[:alnum:]\-\._~!\$&\'\(\)\*\+,;=:]+$/';
 
         $result = (bool) preg_match($regex, $value, $matches);
 

--- a/test/IpTest.php
+++ b/test/IpTest.php
@@ -15,96 +15,85 @@ use function array_keys;
 
 final class IpTest extends TestCase
 {
-    private Ip $validator;
-
-    /**
-     * The list with the options supported.
-     * By default all options are disabled.
-     */
-    private array $options;
-
-    /**
-     * Creates a new IP Validator for each test
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->validator = new Ip();
-        $this->options   = [
-            'allowipv4'      => false,
-            'allowipv6'      => false,
-            'allowipvfuture' => false,
-            'allowliteral'   => false,
-        ];
-    }
-
     /**
      * Ensures that the validator follows expected behavior
      */
     public function testBasic(): void
     {
-        self::assertTrue($this->validator->isValid('1.2.3.4'));
-        self::assertTrue($this->validator->isValid('10.0.0.1'));
-        self::assertTrue($this->validator->isValid('255.255.255.255'));
+        $validator = new Ip();
+        self::assertTrue($validator->isValid('1.2.3.4'));
+        self::assertTrue($validator->isValid('10.0.0.1'));
+        self::assertTrue($validator->isValid('255.255.255.255'));
 
-        self::assertFalse($this->validator->isValid('0.0.0.256'));
-        self::assertFalse($this->validator->isValid('1.2.3.4.5'));
+        self::assertFalse($validator->isValid('0.0.0.256'));
+        self::assertFalse($validator->isValid('1.2.3.4.5'));
     }
 
     public function testZeroIpForLaminas420(): void
     {
-        self::assertTrue($this->validator->isValid('0.0.0.0'));
+        $validator = new Ip();
+        self::assertTrue($validator->isValid('0.0.0.0'));
     }
 
     public function testOnlyIpv4(): void
     {
-        $this->options['allowipv4'] = true;
-        $this->validator->setOptions($this->options);
+        $validator = new Ip([
+            'allowipv4'      => true,
+            'allowipv6'      => false,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ]);
 
-        self::assertTrue($this->validator->isValid('1.2.3.4'));
-        self::assertFalse($this->validator->isValid('a:b:c:d:e::1.2.3.4'));
-        self::assertFalse($this->validator->isValid('v1.09azAZ-._~!$&\'()*+,;='));
+        self::assertTrue($validator->isValid('1.2.3.4'));
+        self::assertFalse($validator->isValid('a:b:c:d:e::1.2.3.4'));
+        self::assertFalse($validator->isValid('v1.09azAZ-._~!$&\'()*+,;='));
     }
 
     public function testOnlyIpv6(): void
     {
-        $this->options['allowipv6'] = true;
-        $this->validator->setOptions($this->options);
+        $validator = new Ip([
+            'allowipv4'      => false,
+            'allowipv6'      => true,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ]);
 
-        self::assertFalse($this->validator->isValid('1.2.3.4'));
-        self::assertTrue($this->validator->isValid('a:b:c:d:e::1.2.3.4'));
-        self::assertFalse($this->validator->isValid('v1.09azAZ-._~!$&\'()*+,;='));
+        self::assertFalse($validator->isValid('1.2.3.4'));
+        self::assertTrue($validator->isValid('a:b:c:d:e::1.2.3.4'));
+        self::assertFalse($validator->isValid('v1.09azAZ-._~!$&\'()*+,;='));
     }
 
     public function testOnlyIpvfuture(): void
     {
-        $this->options['allowipvfuture'] = true;
-        $this->validator->setOptions($this->options);
+        $validator = new Ip([
+            'allowipv4'      => false,
+            'allowipv6'      => false,
+            'allowipvfuture' => true,
+            'allowliteral'   => false,
+        ]);
 
-        self::assertFalse($this->validator->isValid('1.2.3.4'));
-        self::assertFalse($this->validator->isValid('a:b:c:d:e::1.2.3.4'));
-        self::assertTrue($this->validator->isValid("v1.09azAZ-._~!$&'()*+,;=:"));
+        self::assertFalse($validator->isValid('1.2.3.4'));
+        self::assertFalse($validator->isValid('a:b:c:d:e::1.2.3.4'));
+        self::assertTrue($validator->isValid("v1.09azAZ-._~!$&'()*+,;=:"));
     }
 
     public function testLiteral(): void
     {
-        $this->options = [
+        $validator = new Ip([
             'allowipv4'      => true,
             'allowipv6'      => true,
             'allowipvfuture' => true,
             'allowliteral'   => true,
-        ];
-        $this->validator->setOptions($this->options);
+        ]);
 
-        self::assertFalse($this->validator->isValid('[1.2.3.4]'));
-        self::assertTrue($this->validator->isValid('[a:b:c:d:e::1.2.3.4]'));
-        self::assertFalse($this->validator->isValid('[[a:b:c:d:e::1.2.3.4]]'));
-        self::assertFalse($this->validator->isValid('[[a:b:c:d:e::1.2.3.4]'));
-        self::assertFalse($this->validator->isValid('[[a:b:c:d:e::1.2.3.4'));
-        self::assertFalse($this->validator->isValid('[a:b:c:d:e::1.2.3.4]]'));
-        self::assertFalse($this->validator->isValid('a:b:c:d:e::1.2.3.4]]'));
-        self::assertTrue($this->validator->isValid('[v1.ZZ:ZZ]'));
+        self::assertFalse($validator->isValid('[1.2.3.4]'));
+        self::assertTrue($validator->isValid('[a:b:c:d:e::1.2.3.4]'));
+        self::assertFalse($validator->isValid('[[a:b:c:d:e::1.2.3.4]]'));
+        self::assertFalse($validator->isValid('[[a:b:c:d:e::1.2.3.4]'));
+        self::assertFalse($validator->isValid('[[a:b:c:d:e::1.2.3.4'));
+        self::assertFalse($validator->isValid('[a:b:c:d:e::1.2.3.4]]'));
+        self::assertFalse($validator->isValid('a:b:c:d:e::1.2.3.4]]'));
+        self::assertTrue($validator->isValid('[v1.ZZ:ZZ]'));
     }
 
     /**
@@ -131,10 +120,14 @@ final class IpTest extends TestCase
     #[Depends('testOnlyIpvfuture')]
     public function testVersionsAllowedIpvfuture(string $ip, bool $expected): void
     {
-        $this->options['allowipvfuture'] = true;
-        $this->validator->setOptions($this->options);
+        $validator = new Ip([
+            'allowipv4'      => false,
+            'allowipv6'      => false,
+            'allowipvfuture' => true,
+            'allowliteral'   => false,
+        ]);
 
-        self::assertSame($expected, $this->validator->isValid($ip));
+        self::assertSame($expected, $validator->isValid($ip));
     }
 
     public function testNoValidation(): void
@@ -142,17 +135,24 @@ final class IpTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Nothing to validate');
 
-        $this->validator->setOptions($this->options);
+        new Ip([
+            'allowipv4'      => false,
+            'allowipv6'      => false,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ]);
     }
 
     public function testInvalidIpForLaminas4809(): void
     {
-        self::assertFalse($this->validator->isValid('1.2.333'));
+        $validator = new Ip();
+        self::assertFalse($validator->isValid('1.2.333'));
     }
 
     public function testInvalidIpForLaminas435(): void
     {
-        self::assertFalse($this->validator->isValid('192.168.0.2 adfs'));
+        $validator = new Ip();
+        self::assertFalse($validator->isValid('192.168.0.2 adfs'));
     }
 
     #[Group('Laminas-2694')]
@@ -232,11 +232,13 @@ final class IpTest extends TestCase
             'total gibberish'              => false,
         ];
 
+        $validator = new Ip();
+
         foreach ($ips as $ip => $expectedOutcome) {
             if ($expectedOutcome) {
-                self::assertTrue($this->validator->isValid($ip), $ip . ' failed validation (expects true)');
+                self::assertTrue($validator->isValid($ip), $ip . ' failed validation (expects true)');
             } else {
-                self::assertFalse($this->validator->isValid($ip), $ip . ' failed validation (expects false)');
+                self::assertFalse($validator->isValid($ip), $ip . ' failed validation (expects false)');
             }
         }
     }
@@ -246,7 +248,8 @@ final class IpTest extends TestCase
      */
     public function testNonStringValidation(): void
     {
-        self::assertFalse($this->validator->isValid([1 => 1]));
+        $validator = new Ip();
+        self::assertFalse($validator->isValid([1 => 1]));
     }
 
     /**
@@ -254,7 +257,8 @@ final class IpTest extends TestCase
      */
     public function testNonNewlineValidation(): void
     {
-        self::assertFalse($this->validator->isValid("::C0A8:2\n"));
+        $validator = new Ip();
+        self::assertFalse($validator->isValid("::C0A8:2\n"));
     }
 
     #[Group('Laminas-10621')]
@@ -284,11 +288,18 @@ final class IpTest extends TestCase
             "a0.b0.c0.d0\n"                         => false,
         ];
 
+        $validator = new Ip([
+            'allowipv4'      => true,
+            'allowipv6'      => false,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ]);
+
         foreach ($ips as $ip => $expectedOutcome) {
             if ($expectedOutcome) {
-                self::assertTrue($this->validator->isValid($ip), $ip . ' failed validation (expects true)');
+                self::assertTrue($validator->isValid($ip), $ip . ' failed validation (expects true)');
             } else {
-                self::assertFalse($this->validator->isValid($ip), $ip . ' failed validation (expects false)');
+                self::assertFalse($validator->isValid($ip), $ip . ' failed validation (expects false)');
             }
         }
     }
@@ -296,11 +307,14 @@ final class IpTest extends TestCase
     #[DataProvider('iPvFutureAddressesProvider')]
     public function testIPvFutureAddresses(string $ip, bool $expected): void
     {
-        $this->options['allowipvfuture'] = true;
-        $this->options['allowliteral']   = true;
-        $this->validator->setOptions($this->options);
+        $validator = new Ip([
+            'allowipv4'      => false,
+            'allowipv6'      => false,
+            'allowipvfuture' => true,
+            'allowliteral'   => true,
+        ]);
 
-        self::assertSame($expected, $this->validator->isValid($ip));
+        self::assertSame($expected, $validator->isValid($ip));
     }
 
     /**
@@ -355,19 +369,21 @@ final class IpTest extends TestCase
      */
     public function testGetMessages(): void
     {
-        self::assertSame([], $this->validator->getMessages());
+        $validator = new Ip();
+        self::assertSame([], $validator->getMessages());
     }
 
     public function testEqualsMessageTemplates(): void
     {
+        $validator = new Ip();
         self::assertSame(
             [
                 Ip::INVALID,
                 Ip::NOT_IP_ADDRESS,
             ],
-            array_keys($this->validator->getMessageTemplates())
+            array_keys($validator->getMessageTemplates())
         );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
+        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     /**
@@ -389,6 +405,12 @@ final class IpTest extends TestCase
     #[DataProvider('invalidIpV4Addresses')]
     public function testIpV4ValidationShouldFailForIpV4AddressesMissingQuartets(string $address): void
     {
-        self::assertFalse($this->validator->isValid($address));
+        $validator = new Ip([
+            'allowipv4'      => true,
+            'allowipv6'      => false,
+            'allowipvfuture' => false,
+            'allowliteral'   => false,
+        ]);
+        self::assertFalse($validator->isValid($address));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

- Makes protected methods private
- Moves option handling to the constructor, allowing only `array` (Moving away from `setOptions`)
- General cleanup
- Update tests so that options used per test are easier to understand/read