### PR TITLE
Refactor Bitwise Validator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -69,7 +69,6 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode.php">
@@ -353,32 +352,6 @@
       <code><![CDATA[setMax]]></code>
       <code><![CDATA[setMin]]></code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="src/Bitwise.php">
-    <MixedAssignment>
-      <code><![CDATA[$temp['control']]]></code>
-      <code><![CDATA[$temp['operator']]]></code>
-      <code><![CDATA[$temp['strict']]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedOperand>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$control]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $strict]]></code>
-      <code><![CDATA[(int) $control]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Callback.php">
     <MixedAssignment>
@@ -1794,18 +1767,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/BitwiseTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$control]]></code>
-      <code><![CDATA[$control]]></code>
-      <code><![CDATA[0x1]]></code>
-      <code><![CDATA[0x1]]></code>
-      <code><![CDATA[0x1]]></code>
-      <code><![CDATA[0x1]]></code>
-      <code><![CDATA[0x1]]></code>
-    </InvalidArgument>
     <PossiblyUnusedMethod>
-      <code><![CDATA[bitwiseXorProvider]]></code>
-      <code><![CDATA[constructDataProvider]]></code>
+      <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/BusinessIdentifierCodeTest.php">

--- a/src/Bitwise.php
+++ b/src/Bitwise.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Traversable;
+use function is_float;
+use function is_numeric;
 
-use function array_shift;
-use function func_get_args;
-use function is_array;
-use function iterator_to_array;
-
+/**
+ * @psalm-type OptionsArgument = array{
+ *     operator?: Bitwise::OP_AND|Bitwise::OP_XOR|null,
+ *     control: int,
+ *     strict?: bool,
+ * }
+ */
 final class Bitwise extends AbstractValidator
 {
     public const OP_AND = 'and';
@@ -20,20 +23,19 @@ final class Bitwise extends AbstractValidator
     public const NOT_AND_STRICT = 'notAndStrict';
     public const NOT_XOR        = 'notXor';
     public const NO_OP          = 'noOp';
-
-    /** @var int */
-    protected $control;
+    public const NOT_INTEGER    = 'notInteger';
 
     /**
      * Validation failure message template definitions
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_AND        => "The input has no common bit set with '%control%'",
         self::NOT_AND_STRICT => "The input doesn't have the same bits set as '%control%'",
         self::NOT_XOR        => "The input has common bit set with '%control%'",
         self::NO_OP          => "No operator was present to compare '%control%' against",
+        self::NOT_INTEGER    => "Expected an integer to compare '%control%' against",
     ];
 
     /**
@@ -41,90 +43,36 @@ final class Bitwise extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'control' => 'control',
     ];
 
-    /** @var null|string */
-    protected $operator;
+    /** @var self::OP_AND|self::OP_XOR|null */
+    private readonly ?string $operator;
+    private readonly bool $strict;
+    protected readonly int $control;
 
-    /** @var bool */
-    protected $strict = false;
-
-    /**
-     * Sets validator options
-     * Accepts the following option keys:
-     *   'control'  => int
-     *   'operator' =>
-     *   'strict'   => bool
-     *
-     * @param array|Traversable $options
-     */
-    public function __construct($options = null)
+    /** @param OptionsArgument $options */
+    public function __construct(array $options)
     {
-        if ($options instanceof Traversable) {
-            $options = iterator_to_array($options);
-        }
-
-        if (! is_array($options)) {
-            $options = func_get_args();
-
-            $temp['control'] = array_shift($options);
-
-            if (! empty($options)) {
-                $temp['operator'] = array_shift($options);
-            }
-
-            if (! empty($options)) {
-                $temp['strict'] = array_shift($options);
-            }
-
-            $options = $temp;
-        }
+        $this->control  = $options['control'];
+        $this->operator = $options['operator'] ?? null;
+        $this->strict   = $options['strict'] ?? false;
 
         parent::__construct($options);
     }
 
-    /**
-     * Returns the control parameter.
-     *
-     * @return integer
-     */
-    public function getControl()
-    {
-        return $this->control;
-    }
-
-    /**
-     * Returns the operator parameter.
-     *
-     * @return null|string
-     */
-    public function getOperator()
-    {
-        return $this->operator;
-    }
-
-    /**
-     * Returns the strict parameter.
-     *
-     * @return boolean
-     */
-    public function getStrict()
-    {
-        return $this->strict;
-    }
-
-    /**
-     * Returns true if and only if $value is between min and max options, inclusively
-     * if inclusive option is true.
-     *
-     * @param  mixed $value
-     * @return bool
-     */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
+
+        if (! is_numeric($value) || is_float($value)) {
+            $this->error(self::NOT_INTEGER);
+
+            return false;
+        }
+
+        $value = (int) $value;
 
         if (self::OP_AND === $this->operator) {
             if ($this->strict) {
@@ -162,44 +110,5 @@ final class Bitwise extends AbstractValidator
 
         $this->error(self::NO_OP);
         return false;
-    }
-
-    /**
-     * Sets the control parameter.
-     *
-     * @param  integer $control
-     * @return $this
-     */
-    public function setControl($control)
-    {
-        $this->control = (int) $control;
-
-        return $this;
-    }
-
-    /**
-     * Sets the operator parameter.
-     *
-     * @param  string  $operator
-     * @return $this
-     */
-    public function setOperator($operator)
-    {
-        $this->operator = $operator;
-
-        return $this;
-    }
-
-    /**
-     * Sets the strict parameter.
-     *
-     * @param  boolean $strict
-     * @return $this
-     */
-    public function setStrict($strict)
-    {
-        $this->strict = (bool) $strict;
-
-        return $this;
     }
 }

--- a/test/BitwiseTest.php
+++ b/test/BitwiseTest.php
@@ -4,250 +4,65 @@ declare(strict_types=1);
 
 namespace LaminasTest\Validator;
 
-use ArrayObject;
 use Laminas\Validator\Bitwise;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BitwiseTest extends TestCase
 {
-    #[DataProvider('constructDataProvider')]
-    public function testConstruct(array $args, array $options): void
-    {
-        $validator = new Bitwise($args);
-
-        self::assertSame($options['control'], $validator->getControl());
-        self::assertSame($options['operator'], $validator->getOperator());
-        self::assertSame($options['strict'], $validator->getStrict());
-    }
-
-    #[DataProvider('constructDataProvider')]
-    public function testConstructWithTraversableOptions(array $args, array $options): void
-    {
-        $validator = new Bitwise(
-            new ArrayObject($args)
-        );
-
-        self::assertSame($options['control'], $validator->getControl());
-        self::assertSame($options['operator'], $validator->getOperator());
-        self::assertSame($options['strict'], $validator->getStrict());
-    }
-
     /**
-     * @psalm-return array<array-key, array{
-     *     0: array,
-     *     1: array<string, mixed>
-     * }>
-     */
-    public static function constructDataProvider(): array
-    {
-        return [
-            [
-                [],
-                ['control' => null, 'operator' => null, 'strict' => false],
-            ],
-            [
-                ['control' => 0x1],
-                ['control' => 0x1, 'operator' => null, 'strict' => false],
-            ],
-            [
-                ['control' => 0x1, 'operator' => Bitwise::OP_AND],
-                ['control' => 0x1, 'operator' => Bitwise::OP_AND, 'strict' => false],
-            ],
-            [
-                ['control' => 0x1, 'operator' => Bitwise::OP_AND, 'strict' => true],
-                ['control' => 0x1, 'operator' => Bitwise::OP_AND, 'strict' => true],
-            ],
-        ];
-    }
-
-    public function testBitwiseAndNotStrict(): void
-    {
-        $controlSum = 0x7; // (0x1 | 0x2 | 0x4) === 0x7
-
-        $validator = new Bitwise();
-        $validator->setControl($controlSum);
-        $validator->setOperator(Bitwise::OP_AND);
-
-        self::assertTrue($validator->isValid(0x1));
-        self::assertTrue($validator->isValid(0x2));
-        self::assertTrue($validator->isValid(0x4));
-        self::assertFalse($validator->isValid(0x8));
-
-        $validator->isValid(0x8);
-        $messages = $validator->getMessages();
-
-        self::assertArrayHasKey($validator::NOT_AND, $messages);
-        self::assertSame("The input has no common bit set with '$controlSum'", $messages[$validator::NOT_AND]);
-
-        self::assertTrue($validator->isValid(0x1 | 0x2));
-        self::assertTrue($validator->isValid(0x1 | 0x2 | 0x4));
-        self::assertTrue($validator->isValid(0x1 | 0x8));
-    }
-
-    public function testBitwiseAndStrict(): void
-    {
-        $controlSum = 0x7; // (0x1 | 0x2 | 0x4) === 0x7
-
-        $validator = new Bitwise();
-        $validator->setControl($controlSum);
-        $validator->setOperator(Bitwise::OP_AND);
-        $validator->setStrict(true);
-
-        self::assertTrue($validator->isValid(0x1));
-        self::assertTrue($validator->isValid(0x2));
-        self::assertTrue($validator->isValid(0x4));
-        self::assertFalse($validator->isValid(0x8));
-
-        $validator->isValid(0x8);
-        $messages = $validator->getMessages();
-
-        self::assertArrayHasKey($validator::NOT_AND_STRICT, $messages);
-        self::assertSame(
-            "The input doesn't have the same bits set as '$controlSum'",
-            $messages[$validator::NOT_AND_STRICT]
-        );
-
-        self::assertTrue($validator->isValid(0x1 | 0x2));
-        self::assertTrue($validator->isValid(0x1 | 0x2 | 0x4));
-        self::assertFalse($validator->isValid(0x1 | 0x8));
-    }
-
-    /**
-     * @psalm-return array<array-key, array{
-     *     0: int,
+     * @return list<array{
+     *     0: Bitwise::OP_AND|Bitwise::OP_XOR|null,
      *     1: bool,
-     *     2: array<string, string>
+     *     2: int,
+     *     3: mixed,
+     *     4: bool,
+     *     5: string|null,
      * }>
      */
-    public static function bitwiseXorProvider(): array
+    public static function basicDataProvider(): array
     {
         return [
-            [0x2, true, []],
-            [0x8, true, []],
-            [0x10, true, []],
-            [0x1, false, [Bitwise::NOT_XOR => "The input has common bit set with '5'"]],
-            [0x4, false, [Bitwise::NOT_XOR => "The input has common bit set with '5'"]],
-            [0x8 | 0x10, true, []],
-            [0x1 | 0x4, false, [Bitwise::NOT_XOR => "The input has common bit set with '5'"]],
-            [0x1 | 0x8, false, [Bitwise::NOT_XOR => "The input has common bit set with '5'"]],
-            [0x4 | 0x8, false, [Bitwise::NOT_XOR => "The input has common bit set with '5'"]],
+            [null, false, 0b0001, 0b0001, false, Bitwise::NO_OP],
+            [Bitwise::OP_AND, false, 0b0001, 0b0001, true, null],
+            [Bitwise::OP_AND, false, 0b0001, 1, true, null],
+            [Bitwise::OP_AND, false, 0b0001, '1', true, null],
+            [Bitwise::OP_AND, true,  0b0001, 1, true, null],
+            [Bitwise::OP_AND, true,  0b0001, '1', true, null],
+            [Bitwise::OP_AND, false, 0b0111, 0b0001, true, null],
+            [Bitwise::OP_AND, true,  0b0001, 0b0011, false, Bitwise::NOT_AND_STRICT],
+            [Bitwise::OP_AND, false, 0b0001, 0b0010, false, Bitwise::NOT_AND],
+            [Bitwise::OP_AND, false, 0b0001, 'foo', false, Bitwise::NOT_INTEGER],
+            [Bitwise::OP_AND, false, 0b0001, null, false, Bitwise::NOT_INTEGER],
+            [Bitwise::OP_AND, false, 0b0001, 0.5, false, Bitwise::NOT_INTEGER],
+            [Bitwise::OP_XOR, true,  0b0001, 0b0010, true, null],
+            [Bitwise::OP_XOR, true,  0b0001, 0b0100, true, null],
+            [Bitwise::OP_XOR, true,  0b0111, 0b0100, false, Bitwise::NOT_XOR],
         ];
     }
 
-    #[DataProvider('bitwiseXorProvider')]
-    public function testBitwiseXor(int $value, bool $expected, array $expectedMessages): void
-    {
-        $controlSum = 0x5; // (0x1 | 0x4) === 0x5
-        $validator  = new Bitwise();
-        $validator->setControl($controlSum);
-        $validator->setOperator(Bitwise::OP_XOR);
+    /**
+     * @param Bitwise::OP_AND|Bitwise::OP_XOR|null $operator
+     */
+    #[DataProvider('basicDataProvider')]
+    public function testBasic(
+        ?string $operator,
+        bool $strict,
+        int $control,
+        mixed $input,
+        bool $valid,
+        string|null $errorKey,
+    ): void {
+        $validator = new Bitwise([
+            'operator' => $operator,
+            'strict'   => $strict,
+            'control'  => $control,
+        ]);
 
-        self::assertSame($expected, $validator->isValid($value));
-        self::assertSame($expectedMessages, $validator->getMessages());
+        self::assertSame($valid, $validator->isValid($input));
 
-        /*
-        self::assertTrue($validator->isValid(0x2));
-        self::assertTrue($validator->isValid(0x8));
-        self::assertTrue($validator->isValid(0x10));
-        self::assertFalse($validator->isValid(0x1));
-        self::assertFalse($validator->isValid(0x4));
-
-        $validator->isValid(0x4);
-        $messages = $validator->getMessages();
-        self::assertArrayHasKey($validator::NOT_XOR, $messages);
-        self::assertSame("The input has common bit set with '$controlSum'", $messages[$validator::NOT_XOR]);
-
-        self::assertTrue($validator->isValid(0x8 | 0x10));
-        self::assertFalse($validator->isValid(0x1 | 0x4));
-        self::assertFalse($validator->isValid(0x1 | 0x8));
-        self::assertFalse($validator->isValid(0x4 | 0x8));
-         */
-    }
-
-    public function testSetOperator(): void
-    {
-        $validator = new Bitwise();
-
-        $validator->setOperator(Bitwise::OP_AND);
-
-        self::assertSame(Bitwise::OP_AND, $validator->getOperator());
-
-        $validator->setOperator(Bitwise::OP_XOR);
-
-        self::assertSame(Bitwise::OP_XOR, $validator->getOperator());
-    }
-
-    public function testSetStrict(): void
-    {
-        $validator = new Bitwise();
-
-        self::assertFalse($validator->getStrict(), 'Strict false by default');
-
-        $validator->setStrict(false);
-        self::assertFalse($validator->getStrict());
-
-        $validator->setStrict(true);
-        self::assertTrue($validator->getStrict());
-
-        $validator = new Bitwise(0x1, Bitwise::OP_AND, false);
-        self::assertFalse($validator->getStrict());
-
-        $validator = new Bitwise(0x1, Bitwise::OP_AND, true);
-        self::assertTrue($validator->getStrict());
-    }
-
-    public function testConstructorCanAcceptAllOptionsAsDiscreteArguments(): void
-    {
-        $control  = 0x1;
-        $operator = Bitwise::OP_AND;
-        $strict   = true;
-
-        $validator = new Bitwise($control, $operator, $strict);
-
-        self::assertSame($control, $validator->getControl());
-        self::assertSame($operator, $validator->getOperator());
-        self::assertSame($strict, $validator->getStrict());
-    }
-
-    public function testCanRetrieveControlValue(): void
-    {
-        $control   = 0x1;
-        $validator = new Bitwise($control, Bitwise::OP_AND, false);
-
-        self::assertSame($control, $validator->getControl());
-    }
-
-    public function testCanRetrieveOperatorValue(): void
-    {
-        $operator  = Bitwise::OP_AND;
-        $validator = new Bitwise(0x1, $operator, false);
-
-        self::assertSame($operator, $validator->getOperator());
-    }
-
-    public function testCanRetrieveStrictValue(): void
-    {
-        $strict    = true;
-        $validator = new Bitwise(0x1, Bitwise::OP_AND, $strict);
-
-        self::assertSame($strict, $validator->getStrict());
-    }
-
-    public function testIsValidReturnsFalseWithInvalidOperator(): void
-    {
-        $validator      = new Bitwise(0x1, 'or', false);
-        $expectedResult = false;
-
-        self::assertSame($expectedResult, $validator->isValid(0x2));
-    }
-
-    public function testCanSetControlValue(): void
-    {
-        $validator = new Bitwise();
-        $control   = 0x2;
-        $validator->setControl($control);
-
-        self::assertSame($control, $validator->getControl());
+        if ($errorKey !== null) {
+            self::assertArrayHasKey($errorKey, $validator->getMessages());
+        }
     }
 }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Validator;
 
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
+use Laminas\Validator\Bitwise;
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
@@ -88,6 +89,11 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
 
             // Skipping due to required options
             if (strpos($target, '\\Regex') !== false) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if ($target === Bitwise::class) {
                 continue;
             }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

- Removes option setters and getters
- Accept only a documented array shape for options to the constructor
- Validate the input is an integer-like value
- Add types to parameters, return and properties
