### PR TITLE
Refactor `StringLength` validator

### DIFF
--- a/docs/book/v3/validators/string-length.md
+++ b/docs/book/v3/validators/string-length.md
@@ -13,9 +13,9 @@ length.
 
 The following options are supported for `Laminas\Validator\StringLength`:
 
-- `encoding`: Sets the `ICONV` encoding to use with the string.
-- `min`: Sets the minimum allowed length for a string.
-- `max`: Sets the maximum allowed length for a string.
+- `encoding`: Sets the expected encoding of the input string. _(Default `'utf-8'`)_
+- `min`: Sets the minimum allowed length for a string. _(Default `0`)_
+- `max`: Sets the maximum allowed length for a string. _(Default `null`)_
 
 ## Default behaviour
 
@@ -37,17 +37,6 @@ $validator->isValid("Test"); // returns true
 $validator->isValid("Testing"); // returns false
 ```
 
-You can set the maximum allowed length after instantiation by using the
-`setMax()` method; `getMax()` retrieves the value.
-
-```php
-$validator = new Laminas\Validator\StringLength();
-$validator->setMax(6);
-
-$validator->isValid("Test"); // returns true
-$validator->isValid("Testing"); // returns false
-```
-
 ## Limiting the minimum string length
 
 To limit the minimal required string length, set the `min`
@@ -60,22 +49,11 @@ $validator->isValid("Test"); // returns false
 $validator->isValid("Testing"); // returns true
 ```
 
-You can set the value after instantiation using the `setMin()`
-method; `getMin()` retrieves the value.
-
-```php
-$validator = new Laminas\Validator\StringLength();
-$validator->setMin(5);
-
-$validator->isValid("Test"); // returns false
-$validator->isValid("Testing"); // returns true
-```
-
 ## Limiting both minimum and maximum string length
 
 Sometimes you will need to set both a minimum and a maximum string length;
 as an example, in a username input, you may want to limit the name to a maximum
-of 30 characters, but require at least three charcters:
+of 30 characters, but require at least three characters:
 
 ```php
 $validator = new Laminas\Validator\StringLength(['min' => 3, 'max' => 30]);
@@ -106,30 +84,25 @@ $validator->isValid('Testi'); // returns false
 
 ## Encoding of values
 
-Strings are always using a encoding. Even when you don't set the encoding
+Strings are always using an encoding. Even when you don't set the encoding
 explicitly, PHP uses one. When your application is using a different encoding
 than PHP itself, you should set an encoding manually.
 
-You can set an encoding at instantiation with the `encoding` option, or by using
-the `setEncoding()` method. We assume that your installation uses ISO and your
-application it set to ISO. In this case you will see the below behaviour.
+You can set an encoding at instantiation with the `encoding` option. Assuming that your installation and application uses UTF-8 encoding, you will see the below behaviour.
 
 ```php
 $validator = new Laminas\Validator\StringLength(['min' => 6]);
-$validator->isValid("Ärger"); // returns false
-
-$validator->setEncoding("UTF-8");
 $validator->isValid("Ärger"); // returns true
 
-$validator2 = new Laminas\Validator\StringLength([
-    'min' => 6,
-    'encoding' => 'UTF-8',
-]);
-$validator2->isValid("Ärger"); // returns true
+$validator = new Laminas\Validator\StringLength(['min' => 6, 'encoding' => 'ascii']);
+$validator->isValid("Ärger"); // returns false
 ```
 
 When your installation and your application are using different encodings, then
 you should always set an encoding manually.
+
+NOTE: **Default Encoding**
+By default, the expected input encoding is `UTF-8`
 
 ## Validation Messages
 
@@ -137,5 +110,5 @@ Using the setMessage() method you can set another message to be returned in case
 
 ```php
 $validator = new Laminas\Validator\StringLength(['min' => 3, 'max' => 30]);
-$validator->setMessage('Youre string is too long. You typed '%length%' chars.', Laminas\Validator\StringLength::TOO_LONG);
+$validator->setMessage('Your string is too long. You typed '%length%' chars.', Laminas\Validator\StringLength::TOO_LONG);
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1593,48 +1593,6 @@
       <code><![CDATA[$temp]]></code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="src/StringLength.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
-    <MixedAssignment>
-      <code><![CDATA[$temp['encoding']]]></code>
-      <code><![CDATA[$temp['max']]]></code>
-      <code><![CDATA[$temp['min']]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int|null]]></code>
-      <code><![CDATA[string]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['encoding']]]></code>
-      <code><![CDATA[$this->options['length']]]></code>
-      <code><![CDATA[$this->options['max']]]></code>
-      <code><![CDATA[$this->options['min']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyFalseArgument>
-      <code><![CDATA[$this->getStringWrapper()->strlen($value)]]></code>
-    </PossiblyFalseArgument>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setStringWrapper]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int) $length]]></code>
-      <code><![CDATA[(int) $max]]></code>
-      <code><![CDATA[(int) $min]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Timezone.php">
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($type)]]></code>
@@ -2347,17 +2305,17 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/MessageTest.php">
-    <InaccessibleProperty>
-      <code><![CDATA[$this->validator->value]]></code>
-    </InaccessibleProperty>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[assertIsArray]]></code>
     </RedundantConditionGivenDocblockType>
     <UndefinedMagicPropertyFetch>
-      <code><![CDATA[$this->validator->max]]></code>
-      <code><![CDATA[$this->validator->min]]></code>
       <code><![CDATA[$this->validator->unknownProperty]]></code>
     </UndefinedMagicPropertyFetch>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->validator->__get('max')]]></code>
+      <code><![CDATA[$this->validator->__get('min')]]></code>
+      <code><![CDATA[$this->validator->__get('value')]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="test/NotEmptyTest.php">
     <InvalidArgument>
@@ -2457,15 +2415,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringLengthTest.php">
-    <InvalidArgument>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidArgument>
-    <InvalidCast>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidCast>
-    <MixedArgument>
-      <code><![CDATA[$options]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>

--- a/src/StringLength.php
+++ b/src/StringLength.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Laminas\Stdlib\StringUtils;
-use Laminas\Stdlib\StringWrapper\StringWrapperInterface as StringWrapper;
-use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
+use Laminas\Validator\Exception\RuntimeException;
+use Throwable;
 
-use function array_shift;
-use function func_get_args;
-use function is_array;
 use function is_string;
-use function max;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ *     min?: int,
+ *     max?: int|null,
+ *     encoding?: string,
+ * }
+ */
 final class StringLength extends AbstractValidator
 {
     public const INVALID   = 'stringLengthInvalid';
@@ -22,193 +25,57 @@ final class StringLength extends AbstractValidator
     public const TOO_LONG  = 'stringLengthTooLong';
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INVALID   => 'Invalid type given. String expected',
         self::TOO_SHORT => 'The input is less than %min% characters long',
         self::TOO_LONG  => 'The input is more than %max% characters long',
     ];
 
-    /** @var array<string, array<string, string>> */
-    protected $messageVariables = [
-        'min'    => ['options' => 'min'],
-        'max'    => ['options' => 'max'],
-        'length' => ['options' => 'length'],
+    /** @var array<string, string> */
+    protected array $messageVariables = [
+        'min'    => 'min',
+        'max'    => 'max',
+        'length' => 'length',
     ];
 
+    protected readonly int $min;
+    protected readonly int|null $max;
+    private readonly string $encoding;
+    protected ?int $length = null;
+
     /** @var array<string, mixed> */
-    protected $options = [
+    protected array $options = [
         'min'      => 0, // Minimum length
         'max'      => null, // Maximum length, null if there is no length limitation
         'encoding' => 'UTF-8', // Encoding to use
         'length'   => 0, // Actual length
     ];
 
-    /** @var null|StringWrapperInterface */
-    protected $stringWrapper;
-
     /**
      * Sets validator options
      *
-     * @param int|array|Traversable $options
+     * @param OptionsArgument $options
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        if (! is_array($options)) {
-            $options     = func_get_args();
-            $temp['min'] = array_shift($options);
-            if (! empty($options)) {
-                $temp['max'] = array_shift($options);
-            }
-
-            if (! empty($options)) {
-                $temp['encoding'] = array_shift($options);
-            }
-
-            $options = $temp;
-        }
-
         parent::__construct($options);
-    }
 
-    /**
-     * Returns the min option
-     *
-     * @return int
-     */
-    public function getMin()
-    {
-        return $this->options['min'];
-    }
+        $this->min      = $options['min'] ?? 0;
+        $this->max      = $options['max'] ?? null;
+        $this->encoding = $options['encoding'] ?? 'utf-8';
 
-    /**
-     * Sets the min option
-     *
-     * @param  int $min
-     * @throws Exception\InvalidArgumentException
-     * @return $this Provides a fluent interface
-     */
-    public function setMin($min)
-    {
-        if (null !== $this->getMax() && $min > $this->getMax()) {
-            throw new Exception\InvalidArgumentException(
-                "The minimum must be less than or equal to the maximum length, but {$min} > {$this->getMax()}"
+        if ($this->max !== null && $this->max < $this->min) {
+            throw new InvalidArgumentException(
+                "The maximum must be greater than or equal to the minimum length, but {$this->max} < {$this->min}"
             );
         }
-
-        $this->options['min'] = max(0, (int) $min);
-        return $this;
-    }
-
-    /**
-     * Returns the max option
-     *
-     * @return int|null
-     */
-    public function getMax()
-    {
-        return $this->options['max'];
-    }
-
-    /**
-     * Sets the max option
-     *
-     * @param  int|null $max
-     * @throws Exception\InvalidArgumentException
-     * @return $this Provides a fluent interface
-     */
-    public function setMax($max)
-    {
-        if (null === $max) {
-            $this->options['max'] = null;
-        } elseif ($max < $this->getMin()) {
-            throw new Exception\InvalidArgumentException(
-                "The maximum must be greater than or equal to the minimum length, but {$max} < {$this->getMin()}"
-            );
-        } else {
-            $this->options['max'] = (int) $max;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Get the string wrapper to detect the string length
-     *
-     * @return StringWrapper
-     */
-    public function getStringWrapper()
-    {
-        if (! $this->stringWrapper) {
-            $this->stringWrapper = StringUtils::getWrapper($this->getEncoding());
-        }
-        return $this->stringWrapper;
-    }
-
-    /**
-     * Set the string wrapper to detect the string length
-     *
-     * @return void
-     */
-    public function setStringWrapper(StringWrapper $stringWrapper)
-    {
-        $stringWrapper->setEncoding($this->getEncoding());
-        $this->stringWrapper = $stringWrapper;
-    }
-
-    /**
-     * Returns the actual encoding
-     *
-     * @return string
-     */
-    public function getEncoding()
-    {
-        return $this->options['encoding'];
-    }
-
-    /**
-     * Sets a new encoding to use
-     *
-     * @param string $encoding
-     * @return $this
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setEncoding($encoding)
-    {
-        $this->stringWrapper       = StringUtils::getWrapper($encoding);
-        $this->options['encoding'] = $encoding;
-        return $this;
-    }
-
-    /**
-     * Returns the length option
-     *
-     * @return int
-     */
-    private function getLength()
-    {
-        return $this->options['length'];
-    }
-
-    /**
-     * Sets the length option
-     *
-     * @param  int $length
-     * @return $this Provides a fluent interface
-     */
-    private function setLength($length)
-    {
-        $this->options['length'] = (int) $length;
-        return $this;
     }
 
     /**
      * Returns true if and only if the string length of $value is at least the min option and
      * no greater than the max option (when the max option is not null).
-     *
-     * @param  string $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::INVALID);
@@ -217,16 +84,29 @@ final class StringLength extends AbstractValidator
 
         $this->setValue($value);
 
-        $this->setLength($this->getStringWrapper()->strlen($value));
-        if ($this->getLength() < $this->getMin()) {
+        $wrapper   = StringUtils::getWrapper($this->encoding);
+        $exception = null;
+        try {
+            $length = $wrapper->strlen($value);
+        } catch (Throwable $exception) {
+            $length = false;
+        }
+
+        if ($length === false) {
+            throw new RuntimeException('Failed to detect string length', 0, $exception);
+        }
+
+        $this->length = $length;
+
+        if ($this->length < $this->min) {
             $this->error(self::TOO_SHORT);
+
+            return false;
         }
 
-        if (null !== $this->getMax() && $this->getMax() < $this->getLength()) {
+        if ($this->max !== null && $this->length > $this->max) {
             $this->error(self::TOO_LONG);
-        }
 
-        if ($this->getMessages()) {
             return false;
         }
 

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -21,7 +21,7 @@ final class MessageTest extends TestCase
     {
         parent::setUp();
 
-        $this->validator = new StringLength(4, 8);
+        $this->validator = new StringLength(['min' => 4, 'max' => 8]);
     }
 
     /**
@@ -221,9 +221,9 @@ final class MessageTest extends TestCase
 
         self::assertSame('Your value is too long', current($messages));
 
-        self::assertSame($inputInvalid, $this->validator->value);
-        self::assertSame(8, $this->validator->max);
-        self::assertSame(4, $this->validator->min);
+        self::assertSame($inputInvalid, $this->validator->__get('value'));
+        self::assertSame(8, $this->validator->__get('max'));
+        self::assertSame(4, $this->validator->__get('min'));
     }
 
     /**
@@ -291,9 +291,9 @@ final class MessageTest extends TestCase
     public function testEqualsMessageVariables(): void
     {
         $messageVariables = [
-            'min'    => ['options' => 'min'],
-            'max'    => ['options' => 'max'],
-            'length' => ['options' => 'length'],
+            'min'    => 'min',
+            'max'    => 'max',
+            'length' => 'length',
         ];
 
         self::assertSame($messageVariables, $this->validator->getOption('messageVariables'));

--- a/test/StaticValidatorTest.php
+++ b/test/StaticValidatorTest.php
@@ -93,7 +93,6 @@ final class StaticValidatorTest extends TestCase
 
         $this->validator->setTranslator($translator);
 
-        /** @psalm-suppress InvalidArgument */
         self::assertFalse($this->validator->isValid(123));
 
         $messages = $this->validator->getMessages();

--- a/test/StringLengthTest.php
+++ b/test/StringLengthTest.php
@@ -18,27 +18,37 @@ use const E_WARNING;
 
 final class StringLengthTest extends TestCase
 {
+    /**
+     * @return array<string, array{
+     *     0: int,
+     *     1: int|null,
+     *     2: string,
+     *     3: mixed,
+     *     4: bool,
+     *     5: string|null,
+     * }>
+     */
     public static function basicDataProvider(): array
     {
         return [
-            [0, null, 'utf-8', '', true, null],
-            [0, null, 'ISO-8859-16', '', true, null],
-            [1, null, 'utf-8', '', false, StringLength::TOO_SHORT],
-            [0, null, 'utf-8', 'a', true, null],
-            [0, null, 'utf-8', 'aa', true, null],
-            [1, null, 'utf-8', 'a', true, null],
-            [1, 2, 'utf-8', 'aaa', false, StringLength::TOO_LONG],
-            [2, 2, 'utf-8', '  ', true, null],
-            [2, 2, 'utf-8', 'aa', true, null],
-            [3, 3, 'utf-8', 'äöü', true, null],
-            [0, 6, 'utf-8', 'Müller', true, null],
-            [0, 6, 'utf-8', 'Müllered', false, null],
-            [0, 1, 'utf-8', 1, false, StringLength::INVALID],
-            [0, 1, 'utf-8', 0.123, false, StringLength::INVALID],
-            [0, 1, 'utf-8', ['foo'], false, StringLength::INVALID],
-            [0, 1, 'utf-8', false, false, StringLength::INVALID],
-            [0, 1, 'utf-8', null, false, StringLength::INVALID],
-            [0, 1, 'utf-8', (object) [], false, StringLength::INVALID],
+            'empty, utf-8, no-constraint'    => [0, null, 'utf-8', '', true, null],
+            'empty, iso, no-constraint'      => [0, null, 'ISO-8859-16', '', true, null],
+            'empty, min constraint'          => [1, null, 'utf-8', '', false, StringLength::TOO_SHORT],
+            'non empty, no constraint'       => [0, null, 'utf-8', 'a', true, null],
+            'non empty, no constraint - 2'   => [0, null, 'utf-8', 'aa', true, null],
+            'non empty, min constraint'      => [1, null, 'utf-8', 'a', true, null],
+            'too long'                       => [1, 2, 'utf-8', 'aaa', false, StringLength::TOO_LONG],
+            'exact whitespace'               => [2, 2, 'utf-8', '  ', true, null],
+            'exact non-empty'                => [2, 2, 'utf-8', 'aa', true, null],
+            'exact utf8'                     => [3, 3, 'utf-8', 'äöü', true, null],
+            'non empty utf8, max constraint' => [0, 6, 'utf-8', 'Müller', true, null],
+            'utf8 - too long'                => [0, 6, 'utf-8', 'Müllered', false, null],
+            'invalid arg: int'               => [0, 1, 'utf-8', 1, false, StringLength::INVALID],
+            'invalid arg: float'             => [0, 1, 'utf-8', 0.123, false, StringLength::INVALID],
+            'invalid arg: array'             => [0, 1, 'utf-8', ['foo'], false, StringLength::INVALID],
+            'invalid arg: bool'              => [0, 1, 'utf-8', false, false, StringLength::INVALID],
+            'invalid arg: null'              => [0, 1, 'utf-8', null, false, StringLength::INVALID],
+            'invalid arg: object'            => [0, 1, 'utf-8', (object) [], false, StringLength::INVALID],
         ];
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- remove all option setters and getters
- constructor options now only accepts a documented array shape
- Provides better handling of malformed utf-8 and other string handling issues in underlying string wrappers
- adds types to parameters, properties and methods
