### PR TITLE
Refactor `Regex` validator

### DIFF
--- a/docs/book/v3/validators/regex.md
+++ b/docs/book/v3/validators/regex.md
@@ -1,7 +1,8 @@
 # Regex Validator
 
-This validator allows you to validate if a given string conforms a defined
-regular expression.
+This validator allows you to validate if a given string conforms a defined regular expression.
+
+It will *not* automatically cast integers or floats to string prior to evaluation - when provided a non string value, validation will fail.
 
 ## Supported options
 
@@ -11,8 +12,7 @@ The following options are supported for `Laminas\Validator\Regex`:
 
 ## Usage
 
-Validation with regular expressions allows complex validations
-without writing a custom validator.
+Validation with regular expressions allows complex validations without writing a custom validator.
 
 ```php
 $validator = new Laminas\Validator\Regex(['pattern' => '/^Test/']);
@@ -25,17 +25,3 @@ $validator->isValid("Pest"); // returns false
 The pattern uses the same syntax as `preg_match()`. For details about regular
 expressions take a look into [PHP's manual about PCRE pattern
 syntax](http://php.net/reference.pcre.pattern.syntax).
-
-## Pattern handling
-
-It is also possible to set a different pattern afterwards by using
-`setPattern()` and to get the actual set pattern with `getPattern()`.
-
-```php
-$validator = new Laminas\Validator\Regex(['pattern' => '/^Test/']);
-$validator->setPattern('ing$/');
-
-$validator->isValid("Test"); // returns false
-$validator->isValid("Testing"); // returns true
-$validator->isValid("Pest"); // returns false
-```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
   <file src="bin/update_hostname_validator.php">
     <MissingClosureParamType>
       <code><![CDATA[$domain]]></code>
@@ -1537,17 +1537,6 @@
       <code><![CDATA[is_object($value) && method_exists($value, '__toString') && (string) $value === '']]></code>
     </RedundantCondition>
   </file>
-  <file src="src/Regex.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($pattern)]]></code>
-    </DocblockTypeContradiction>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$pattern]]></code>
-    </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $pattern]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Sitemap/Changefreq.php">
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($value)]]></code>
@@ -2390,10 +2379,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/RegexTest.php">
-    <MixedArgument>
-      <code><![CDATA[$options]]></code>
-      <code><![CDATA[$options]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
       <code><![CDATA[invalidConstructorArgumentsProvider]]></code>

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -4,32 +4,29 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\ErrorHandler;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
-use function array_key_exists;
-use function is_array;
-use function is_float;
-use function is_int;
 use function is_string;
 use function preg_match;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ *     pattern: non-empty-string,
+ * }
+ */
 final class Regex extends AbstractValidator
 {
     public const INVALID   = 'regexInvalid';
     public const NOT_MATCH = 'regexNotMatch';
-    public const ERROROUS  = 'regexErrorous';
 
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::INVALID   => 'Invalid type given. String, integer or float expected',
         self::NOT_MATCH => "The input does not match against pattern '%pattern%'",
-        self::ERROROUS  => "There was an internal error while using the pattern '%pattern%'",
     ];
 
-    /** @var array */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'pattern' => 'pattern',
     ];
 
@@ -38,98 +35,48 @@ final class Regex extends AbstractValidator
      *
      * @var non-empty-string
      */
-    protected $pattern;
+    protected string $pattern;
 
     /**
      * Sets validator options
      *
-     * @param  non-empty-string|array|Traversable $pattern
-     * @throws Exception\InvalidArgumentException On missing 'pattern' parameter.
+     * @param non-empty-string|OptionsArgument $options
      */
-    public function __construct($pattern)
+    public function __construct(string|array $options)
     {
-        if (is_string($pattern)) {
-            $this->setPattern($pattern);
-            parent::__construct([]);
-            return;
+        $pattern = is_string($options) ? $options : $options['pattern'] ?? null;
+        /** @psalm-suppress DocblockTypeContradiction The user may still supply an empty string */
+        if (! is_string($pattern) || $pattern === '') {
+            throw new InvalidArgumentException('A regex pattern is required');
         }
 
-        if ($pattern instanceof Traversable) {
-            $pattern = ArrayUtils::iteratorToArray($pattern);
-        }
-
-        if (! is_array($pattern)) {
-            throw new Exception\InvalidArgumentException('Invalid options provided to constructor');
-        }
-
-        if (! array_key_exists('pattern', $pattern) || ! is_string($pattern['pattern']) || $pattern['pattern'] === '') {
-            throw new Exception\InvalidArgumentException("Missing option 'pattern'");
-        }
-
-        $this->setPattern($pattern['pattern']);
-        unset($pattern['pattern']);
-        parent::__construct($pattern);
-    }
-
-    /**
-     * Returns the pattern option
-     *
-     * @return non-empty-string|null
-     */
-    public function getPattern()
-    {
-        return $this->pattern;
-    }
-
-    /**
-     * Sets the pattern option
-     *
-     * @param non-empty-string $pattern
-     * @throws Exception\InvalidArgumentException If there is a fatal error in pattern matching.
-     * @return $this Provides a fluent interface
-     */
-    public function setPattern($pattern)
-    {
-        ErrorHandler::start();
-        $this->pattern = (string) $pattern;
-        $status        = preg_match($this->pattern, 'Test');
-        $error         = ErrorHandler::stop();
-
-        if (false === $status) {
-            throw new Exception\InvalidArgumentException(
-                "Internal error parsing the pattern '{$this->pattern}'",
-                0,
-                $error
+        $status = preg_match($pattern, 'Test');
+        if ($status === false) {
+            throw new InvalidArgumentException(
+                "Internal error parsing the pattern '{$pattern}'",
             );
         }
 
-        return $this;
+        $this->pattern = $pattern;
+
+        parent::__construct();
     }
 
     /**
      * Returns true if and only if $value matches against the pattern option
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
-        if (! is_string($value) && ! is_int($value) && ! is_float($value)) {
+        if (! is_string($value)) {
             $this->error(self::INVALID);
             return false;
         }
 
         $this->setValue($value);
 
-        ErrorHandler::start();
-        $status = preg_match($this->pattern, (string) $value);
-        ErrorHandler::stop();
-        if (false === $status) {
-            $this->error(self::ERROROUS);
-            return false;
-        }
+        $status = preg_match($this->pattern, $value);
 
-        if (! $status) {
+        if ((bool) $status === false) {
             $this->error(self::NOT_MATCH);
             return false;
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | arguably
| BC Break      | yes
| QA            | yes

### Description

- Fails validation for non strings
- Removes getters and setters
- Adds types
- Validates the pattern in the constructor instead of during validation meaning we can drop one of the validation error constants

Closes #179
