### PR TITLE
Deprecate option setters and getters for the StringLength validator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="bin/update_hostname_validator.php">
     <MissingClosureParamType>
       <code><![CDATA[$domain]]></code>
@@ -1803,6 +1803,22 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="src/StringLength.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getEncoding]]></code>
+      <code><![CDATA[getEncoding]]></code>
+      <code><![CDATA[getLength]]></code>
+      <code><![CDATA[getLength]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMin]]></code>
+      <code><![CDATA[getMin]]></code>
+      <code><![CDATA[getMin]]></code>
+      <code><![CDATA[getStringWrapper]]></code>
+      <code><![CDATA[setLength]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($value)]]></code>
     </DocblockTypeContradiction>
@@ -2801,6 +2817,17 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringLengthTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getEncoding]]></code>
+      <code><![CDATA[getEncoding]]></code>
+      <code><![CDATA[getMax]]></code>
+      <code><![CDATA[getMin]]></code>
+      <code><![CDATA[setEncoding]]></code>
+      <code><![CDATA[setMax]]></code>
+      <code><![CDATA[setMax]]></code>
+      <code><![CDATA[setMin]]></code>
+      <code><![CDATA[setMin]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[[1 => 1]]]></code>
     </InvalidArgument>

--- a/src/StringLength.php
+++ b/src/StringLength.php
@@ -72,6 +72,8 @@ class StringLength extends AbstractValidator
     /**
      * Returns the min option
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return int
      */
     public function getMin()
@@ -82,9 +84,11 @@ class StringLength extends AbstractValidator
     /**
      * Sets the min option
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @param  int $min
-     * @throws Exception\InvalidArgumentException
      * @return $this Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function setMin($min)
     {
@@ -101,6 +105,8 @@ class StringLength extends AbstractValidator
     /**
      * Returns the max option
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return int|null
      */
     public function getMax()
@@ -111,9 +117,11 @@ class StringLength extends AbstractValidator
     /**
      * Sets the max option
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @param  int|null $max
-     * @throws Exception\InvalidArgumentException
      * @return $this Provides a fluent interface
+     * @throws Exception\InvalidArgumentException
      */
     public function setMax($max)
     {
@@ -133,6 +141,8 @@ class StringLength extends AbstractValidator
     /**
      * Get the string wrapper to detect the string length
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return StringWrapper
      */
     public function getStringWrapper()
@@ -146,6 +156,8 @@ class StringLength extends AbstractValidator
     /**
      * Set the string wrapper to detect the string length
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return void
      */
     public function setStringWrapper(StringWrapper $stringWrapper)
@@ -157,6 +169,8 @@ class StringLength extends AbstractValidator
     /**
      * Returns the actual encoding
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return string
      */
     public function getEncoding()
@@ -166,6 +180,8 @@ class StringLength extends AbstractValidator
 
     /**
      * Sets a new encoding to use
+     *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
      *
      * @param string $encoding
      * @return $this
@@ -181,6 +197,8 @@ class StringLength extends AbstractValidator
     /**
      * Returns the length option
      *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
+     *
      * @return int
      */
     private function getLength()
@@ -190,6 +208,8 @@ class StringLength extends AbstractValidator
 
     /**
      * Sets the length option
+     *
+     * @deprecated Since 2.60.0 all option setters and getters are deprecated for removal in 3.0
      *
      * @param  int $length
      * @return $this Provides a fluent interface


### PR DESCRIPTION
Relevant to #278 