### PR TITLE
Refactor `Callback` validator

### DIFF
--- a/docs/book/v3/validators/callback.md
+++ b/docs/book/v3/validators/callback.md
@@ -8,9 +8,9 @@ validate a given value.
 The following options are supported for `Laminas\Validator\Callback`:
 
 - `callback`: Sets the callback which will be called for the validation.
-- `callbackOptions`: Sets the additional options which will be given to the validator
-  and/or callback.
+- `callbackOptions`: Sets the additional arguments that will be given to the validator callback.
 - `throwExceptions`: When true, [allows exceptions thrown inside of callbacks to propagate](#exceptions-within-callbacks).
+- `bind`: When true, the callback will bound to the validator's scope allowing the closure to call internal methods of the validator.
 
 ## Basic usage
 
@@ -18,7 +18,7 @@ The simplest use case is to pass a function as a callback. Consider the
 following function:
 
 ```php
-function myMethod($value)
+function myMethod(mixed $value): bool
 {
     // some validation
     return true;
@@ -42,7 +42,7 @@ The `Callback` validator supports any PHP callable, including PHP
 [closures](http://php.net/functions.anonymous).
 
 ```php
-$valid = new Laminas\Validator\Callback(function($value) {
+$valid = new Laminas\Validator\Callback(function(mixed $value): bool {
     // some validation
     return true;
 });
@@ -56,13 +56,13 @@ if ($valid->isValid($input)) {
 
 ## Usage with class-based callbacks
 
-Of course it's also possible to use a class method as callback. Consider the
+Of course, it's also possible to use a class method as callback. Consider the
 following class definition:
 
 ```php
 class MyClass
 {
-    public function myMethod($value)
+    public function myMethod(mixed $value): bool
     {
         // some validation
         return true;
@@ -88,7 +88,7 @@ definition and validator usage:
 ```php
 class MyClass
 {
-    public static function test($value)
+    public static function test(mixed $value): bool
     {
         // some validation
         return true;
@@ -109,7 +109,7 @@ so, you can provide a class instance itself as the callback:
 ```php
 class MyClass
 {
-    public function __invoke($value)
+    public function __invoke(mixed $value): bool
     {
         // some validation
         return true;
@@ -126,15 +126,14 @@ if ($valid->isValid($input)) {
 
 ## Adding options
 
-`Laminas\Validator\Callback` also allows the usage of options which are provided as
-additional arguments to the callback.
+`Laminas\Validator\Callback` also allows the usage of options which are provided as additional arguments to the callback.
 
-Consider the following class and method definition:
+Consider the following class and method definitions:
 
 ```php
 class MyClass
 {
-    public static function myMethod($value, $option)
+    public static function myMethod(mixed $value, bool $option): bool
     {
         // some validation
         return true;
@@ -143,7 +142,7 @@ class MyClass
     /**
      * Or, to use with contextual validation
      */
-    public static function myMethod($value, $context, $option)
+    public static function myMethod(mixed $value, array $context, bool $option): bool
     {
         // some validation
         return true;
@@ -152,16 +151,12 @@ class MyClass
 }
 ```
 
-There are two ways to inform the validator of additional options: pass them in
-the constructor, or pass them to the `setOptions()` method.
-
-To pass them to the constructor, you would need to pass an array containing two
-keys, `callback` and `callbackOptions`:
+Pass additional callback arguments to the constructor as an array with the `callbackOptions` key:
 
 ```php
 $valid = new Laminas\Validator\Callback([
     'callback'        => [MyClass::class, 'myMethod'],
-    'callbackOptions' => $options,
+    'callbackOptions' => ['option' => true],
 ]);
 
 if ($valid->isValid($input)) {
@@ -171,25 +166,14 @@ if ($valid->isValid($input)) {
 }
 ```
 
-Otherwise, you may pass them to the validator after instantiation:
-
-```php
-$valid = new Laminas\Validator\Callback([MyClass::class, 'myMethod']);
-$valid->setOptions($options);
-
-if ($valid->isValid($input)) {
-    // input appears to be valid
-} else {
-    // input is invalid
-}
-```
-
-When there are additional values given to `isValid()`, then these values will be
+When there are additional values given to `isValid()`, the values will be
 passed as an additional argument:
 
 ```php
-$valid = new Laminas\Validator\Callback([MyClass::class, 'myMethod']);
-$valid->setOptions($options);
+$valid = new Laminas\Validator\Callback([
+    'callback' => [MyClass::class, 'myMethod'],
+    'callbackOptions' => ['option' => true],
+]);
 
 if ($valid->isValid($input, $context)) {
     // input appears to be valid
@@ -203,12 +187,47 @@ passed as the first argument to the callback followed by all other values given
 to `isValid()`; all other options will follow it. The amount and type of options
 which can be used is not limited.
 
+## Callbacks and scope
+
+By default, callbacks are executed in their own scope and do not have access to the validator instance they are executed in.
+
+It is possible to bind your callback to the validator scope by setting the `bind` option to true.
+
+This is useful when you wish to provide more detailed error messages in case there are multiple potential reasons for validation failure:
+
+```php
+$validator = new Laminas\Validator\Callback([
+    'callback' => function (mixed $value): bool {
+        if ($value === 42) {
+            $this->setMessage(
+                'Sorry, the meaning of life is not acceptable',
+                 Laminas\Validator\Callback::INVALID_VALUE,
+            );
+            
+            return false;
+        }
+        
+        if ($value === 'goats') {
+            $this->setMessage(
+                'Sorry, I don’t like goats…',
+                 Laminas\Validator\Callback::INVALID_VALUE,
+            );
+            
+            return false;
+        }
+        
+        return true;
+    },
+    'bind' => true,
+]);
+```
+
 ## Exceptions within Callbacks
 
 By default, the callback validator will catch any `Exception` thrown inside the callback and return false.
 The error message will indicate callback failure as opposed to invalid input.
 
-There is a third option `throwExceptions` that when `true` will re-throw exceptions that occur inside the callback.
+The option `throwExceptions`, when `true`, will re-throw exceptions that occur inside the callback.
 
 This is primarily useful in a development environment when you are testing callbacks and need to catch and verify exceptions thrown by your own application.
 

--- a/docs/book/v3/validators/callback.md
+++ b/docs/book/v3/validators/callback.md
@@ -187,7 +187,7 @@ passed as the first argument to the callback followed by all other values given
 to `isValid()`; all other options will follow it. The amount and type of options
 which can be used is not limited.
 
-## Callbacks and scope
+## Callbacks and Scope
 
 By default, callbacks are executed in their own scope and do not have access to the validator instance they are executed in.
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -352,28 +352,6 @@
       <code><![CDATA[setMin]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/Callback.php">
-    <MixedAssignment>
-      <code><![CDATA[$args[]]]></code>
-      <code><![CDATA[$args[]]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[array<array-key, mixed>]]></code>
-      <code><![CDATA[callable|null]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['callback']]]></code>
-      <code><![CDATA[$this->options['callbackOptions']]]></code>
-    </MixedReturnStatement>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(array) $options]]></code>
-    </RedundantCastGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty($context)]]></code>
-      <code><![CDATA[empty($context)]]></code>
-      <code><![CDATA[empty($context)]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
   <file src="src/CreditCard.php">
     <InvalidOperand>
       <code><![CDATA[$value[$i]]]></code>
@@ -395,7 +373,7 @@
       <code><![CDATA[$temp['type']]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code><![CDATA[callable]]></code>
+      <code><![CDATA[callable(mixed...):bool]]></code>
       <code><![CDATA[list<string>]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
@@ -1715,15 +1693,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/CallbackTest.php">
-    <MissingClosureParamType>
-      <code><![CDATA[$baz]]></code>
-      <code><![CDATA[$c]]></code>
-      <code><![CDATA[$c]]></code>
-      <code><![CDATA[$v]]></code>
-      <code><![CDATA[$v]]></code>
-    </MissingClosureParamType>
     <PossiblyUnusedMethod>
-      <code><![CDATA[optionsCallback]]></code>
+      <code><![CDATA[emptyContextProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/CreditCardTest.php">
@@ -2383,10 +2354,6 @@
     <InvalidArgument>
       <code><![CDATA[1]]></code>
     </InvalidArgument>
-    <MissingClosureParamType>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MissingClosureParamType>
     <PossiblyUnusedMethod>
       <code><![CDATA[breakChainFlags]]></code>
       <code><![CDATA[handleNotFoundError]]></code>

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -109,7 +109,7 @@ final class Callback extends AbstractValidator
              */
             $this->error(self::INVALID_CALLBACK);
 
-            if ($this->throwExceptions === true) {
+            if ($this->throwExceptions) {
                 throw $exception;
             }
 

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -237,7 +237,7 @@ class CreditCard extends AbstractValidator
      * Options for this validator
      *
      * @var array{
-     *     service: callable|null,
+     *     service: callable(mixed...):bool|null,
      *     type: list<string>,
      * }
      */
@@ -337,7 +337,7 @@ class CreditCard extends AbstractValidator
     /**
      * Returns the actual set service
      *
-     * @return callable
+     * @return callable(mixed...):bool
      */
     public function getService()
     {
@@ -430,8 +430,11 @@ class CreditCard extends AbstractValidator
         $service = $this->getService();
         if (! empty($service)) {
             try {
-                $callback = new Callback($service);
-                $callback->setCallbackOptions($this->getType());
+                $callback = new Callback([
+                    'callback'        => $service,
+                    'callbackOptions' => $this->getType(),
+                    'throwExceptions' => true,
+                ]);
                 if (! $callback->isValid($value)) {
                     $this->error(self::SERVICE, $value);
                     return false;

--- a/test/ValidatorChainTest.php
+++ b/test/ValidatorChainTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Between;
+use Laminas\Validator\Callback;
 use Laminas\Validator\GreaterThan;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\Timezone;
@@ -240,15 +241,15 @@ final class ValidatorChainTest extends TestCase
     public function testCanAttachMultipleValidatorsOfTheSameTypeAsDiscreteInstances(): void
     {
         $this->validator->attachByName('Callback', [
-            'callback' => static fn($value): bool => true,
+            'callback' => static fn(mixed $value): bool => true,
             'messages' => [
-                'callbackValue' => 'This should not be seen in the messages',
+                Callback::INVALID_VALUE => 'This should not be seen in the messages',
             ],
         ]);
         $this->validator->attachByName('Callback', [
-            'callback' => static fn($value): bool => false,
+            'callback' => static fn(mixed $value): bool => false,
             'messages' => [
-                'callbackValue' => 'Second callback trapped',
+                Callback::INVALID_VALUE => 'Second callback trapped',
             ],
         ]);
 

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Validator;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use Laminas\Validator\Bitwise;
+use Laminas\Validator\Callback;
 use Laminas\Validator\Exception\RuntimeException;
 use Laminas\Validator\Explode;
 use Laminas\Validator\ValidatorInterface;
@@ -100,6 +101,11 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
 
             // Skipping due to required options
             if ($target === Explode::class) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if ($target === Callback::class) {
                 continue;
             }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| New Feature   | yes
| QA            | yes

### Description

- Remove all options setters/getters
- Add types
- Add new option to bind the closure to the validator instance so that error messages can be set from within the closure.