### PR TITLE
Refactor `Explode` validator

### DIFF
--- a/docs/book/v3/validators/explode.md
+++ b/docs/book/v3/validators/explode.md
@@ -39,7 +39,7 @@ $explodeValidator = new Laminas\Validator\Explode([
     'validator' => [
         'name' => Laminas\Validator\InArray::class,
         'options' => [
-            'haystack' => 'a;b;c'
+            'haystack' => ['a', 'b', 'c']
         ],
     ],
     'valueDelimiter' => ';',

--- a/docs/book/v3/validators/explode.md
+++ b/docs/book/v3/validators/explode.md
@@ -8,9 +8,10 @@ array.
 The following options are supported for `Laminas\Validator\Explode`:
 
 - `valueDelimiter`: Defines the delimiter used to explode values from an array.
-  It defaults to `,`. If the given value is an array, this option isn't used.
+  It defaults to `,`.
 - `validator`: Sets the validator that will be executed on each exploded item.
-  This may be a validator instance, or a validator service name.
+  This may be a validator instance, a validator service name, or a "specification" array.
+- `validatorPluginManager`: The validator plugin manager in use in your application. If this plugin manager is not provided, a plugin manager will be created with the default configuration.
 
 ## Basic usage
 
@@ -25,24 +26,25 @@ $explodeValidator = new Laminas\Validator\Explode([
     'validator' => $inArrayValidator
 ]);
 
-$explodeValidator->isValid([1, 4, 6]);    // returns true
-$explodeValidator->isValid([1, 4, 6, 8]); // returns false
+$explodeValidator->isValid('1,4,6');    // returns true
+$explodeValidator->isValid('1,4,6,8'); // returns false
 ```
 
-## Exploding strings
+## Configuration using a validator specification
 
-To validate if every e-mail in a string is contained in a list of names:
+Instead of creating a validator instance, you can provide an array to describe the validator you wish to use for each element:
 
 ```php
-$inEmailListValidator = new Laminas\Validator\InArray([
-    'haystack' => ['joseph@test.com', 'mark@test.com', 'lucia@test.com'],
-]);
-
 $explodeValidator = new Laminas\Validator\Explode([
-    'validator' => $inEmailListValidator,
-    'valueDelimiter' => ','
+    'validator' => [
+        'name' => Laminas\Validator\InArray::class,
+        'options' => [
+            'haystack' => 'a;b;c'
+        ],
+    ],
+    'valueDelimiter' => ';',
 ]);
 
-$explodeValidator->isValid('joseph@test.com,mark@test.com'); // returns true
-$explodeValidator->isValid('lucia@test.com,maria@test.com');  // returns false
+$explodeValidator->isValid('a;b'); // returns true
+$explodeValidator->isValid('x;y;z');  // returns false
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="bin/update_hostname_validator.php">
     <MissingClosureParamType>
       <code><![CDATA[$domain]]></code>
@@ -44,7 +44,6 @@
       <code><![CDATA[$messageKey]]></code>
     </PossiblyUnusedParam>
     <UndefinedThisPropertyAssignment>
-      <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
@@ -540,28 +539,17 @@
     </UnusedClass>
   </file>
   <file src="src/Explode.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[[$value]]]></code>
-    </DocblockTypeContradiction>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->abstractOptions['messages'][]]]></code>
-    </MixedArrayAssignment>
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setBreakOnFirstFailure]]></code>
-      <code><![CDATA[setValueDelimiter]]></code>
-    </PossiblyUnusedMethod>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->abstractOptions]]></code>
-    </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $break]]></code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[null !== $delimiter]]></code>
-    </RedundantConditionGivenDocblockType>
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->getPluginManager()->build($name, $options)]]></code>
+    </LessSpecificReturnStatement>
+    <MixedInferredReturnType>
+      <code><![CDATA[ValidatorInterface]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->getPluginManager()->build($name, $options)]]></code>
+      <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
+      <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
+    </MixedReturnStatement>
     <TooManyArguments>
       <code><![CDATA[isValid]]></code>
     </TooManyArguments>
@@ -1807,18 +1795,6 @@
     <UnusedPsalmSuppress>
       <code><![CDATA[TooManyArguments]]></code>
     </UnusedPsalmSuppress>
-  </file>
-  <file src="test/ExplodeTest.php">
-    <InvalidArgument>
-      <code><![CDATA['inarray']]></code>
-    </InvalidArgument>
-    <MissingClosureParamType>
-      <code><![CDATA[$c]]></code>
-      <code><![CDATA[$v]]></code>
-    </MissingClosureParamType>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getExpectedData]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="test/File/CountTest.php">
     <MixedArgument>

--- a/src/Explode.php
+++ b/src/Explode.php
@@ -5,82 +5,64 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Stdlib\ArrayUtils;
-use Traversable;
+use Laminas\Validator\Exception\RuntimeException;
 
 use function explode;
+use function implode;
 use function is_array;
 use function is_string;
 use function sprintf;
 
 /**
+ * @psalm-type OptionsArgument = array{
+ *     valueDelimiter?: non-empty-string,
+ *     validatorPluginManager?: ValidatorPluginManager|null,
+ *     validator?: ValidatorInterface|class-string<ValidatorInterface>|ValidatorSpecification,
+ *     breakOnFirstFailure?: bool,
+ * }
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
- * @final
  */
-final class Explode extends AbstractValidator implements ValidatorPluginManagerAwareInterface
+final class Explode extends AbstractValidator
 {
-    public const INVALID = 'explodeInvalid';
+    public const INVALID      = 'explodeInvalid';
+    public const INVALID_ITEM = 'invalidItem';
 
-    /** @var null|ValidatorPluginManager */
-    protected $pluginManager;
-
-    /** @var array */
-    protected $messageTemplates = [
-        self::INVALID => 'Invalid type given',
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
+        self::INVALID      => 'Invalid type given, string expected',
+        self::INVALID_ITEM => '%count% items were invalid: %error%',
     ];
 
-    /** @var array */
-    protected $messageVariables = [];
-
     /** @var non-empty-string */
-    protected $valueDelimiter = ',';
+    private readonly string $valueDelimiter;
+    private ValidatorPluginManager|null $pluginManager;
+    private ValidatorInterface $validator;
+    private readonly bool $breakOnFirstFailure;
 
-    /** @var ValidatorInterface|null */
-    protected $validator;
+    protected int $count     = 0;
+    protected ?string $error = null;
 
-    /** @var bool */
-    protected $breakOnFirstFailure = false;
+    /** @var array<string, string> */
+    protected array $messageVariables = [
+        'count' => 'count',
+        'error' => 'error',
+    ];
 
-    /**
-     * Sets the delimiter string that the values will be split upon
-     *
-     * @param non-empty-string $delimiter
-     * @return $this
-     */
-    public function setValueDelimiter($delimiter)
+    /** @param OptionsArgument $options */
+    public function __construct(array $options = [])
     {
-        $this->valueDelimiter = $delimiter;
-        return $this;
+        $this->valueDelimiter      = $options['valueDelimiter'] ?? ',';
+        $plugins                   = $options['validatorPluginManager'] ?? null;
+        $this->pluginManager       = $plugins instanceof ValidatorPluginManager ? $plugins : null;
+        $this->validator           = $this->resolveValidator($options['validator'] ?? null);
+        $this->breakOnFirstFailure = $options['breakOnFirstFailure'] ?? false;
+
+        parent::__construct($options);
     }
 
-    /**
-     * Returns the delimiter string that the values will be split upon
-     *
-     * @return non-empty-string
-     */
-    public function getValueDelimiter()
+    private function getPluginManager(): ValidatorPluginManager
     {
-        return $this->valueDelimiter;
-    }
-
-    /**
-     * Set validator plugin manager
-     *
-     * @return void
-     */
-    public function setValidatorPluginManager(ValidatorPluginManager $pluginManager)
-    {
-        $this->pluginManager = $pluginManager;
-    }
-
-    /**
-     * Get validator plugin manager
-     *
-     * @return ValidatorPluginManager
-     */
-    public function getValidatorPluginManager()
-    {
-        if (! $this->pluginManager) {
+        if (! $this->pluginManager instanceof ValidatorPluginManager) {
             $this->pluginManager = new ValidatorPluginManager(new ServiceManager());
         }
 
@@ -90,64 +72,35 @@ final class Explode extends AbstractValidator implements ValidatorPluginManagerA
     /**
      * Sets the Validator for validating each value
      *
-     * @param ValidatorInterface|ValidatorSpecification $validator
-     * @throws Exception\RuntimeException
-     * @return $this
+     * @param ValidatorInterface|string|ValidatorSpecification $validator
+     * @throws RuntimeException
      */
-    public function setValidator($validator)
+    private function resolveValidator(ValidatorInterface|string|array|null $validator): ValidatorInterface
     {
+        if ($validator instanceof ValidatorInterface) {
+            return $validator;
+        }
+
         if (is_array($validator)) {
             if (! isset($validator['name'])) {
-                throw new Exception\RuntimeException(
-                    'Invalid validator specification provided; does not include "name" key'
+                throw new RuntimeException(
+                    'Invalid validator specification provided; does not include "name" key',
                 );
             }
             $name    = $validator['name'];
             $options = $validator['options'] ?? [];
-            /** @psalm-suppress MixedAssignment $validator */
-            $validator = $this->getValidatorPluginManager()->get($name, $options);
+
+            return $this->getPluginManager()->build($name, $options);
         }
 
-        if (! $validator instanceof ValidatorInterface) {
-            throw new Exception\RuntimeException(
-                'Invalid validator given'
-            );
+        if (is_string($validator)) {
+            return $this->getPluginManager()->get($validator);
         }
 
-        $this->validator = $validator;
-        return $this;
-    }
-
-    /**
-     * Gets the Validator for validating each value
-     *
-     * @return ValidatorInterface|null
-     */
-    public function getValidator()
-    {
-        return $this->validator;
-    }
-
-    /**
-     * Set break on first failure setting
-     *
-     * @param  bool $break
-     * @return $this
-     */
-    public function setBreakOnFirstFailure($break)
-    {
-        $this->breakOnFirstFailure = (bool) $break;
-        return $this;
-    }
-
-    /**
-     * Get break on first failure setting
-     *
-     * @return bool
-     */
-    public function isBreakOnFirstFailure()
-    {
-        return $this->breakOnFirstFailure;
+        throw new RuntimeException(sprintf(
+            '%s expects a validator to be set; none given',
+            self::class,
+        ));
     }
 
     /**
@@ -155,53 +108,42 @@ final class Explode extends AbstractValidator implements ValidatorPluginManagerA
      *
      * Returns true if all values validate true
      *
-     * @param  mixed $value
-     * @param  mixed $context Extra "context" to provide the composed validator
-     * @return bool
-     * @throws Exception\RuntimeException
+     * @param array<string, mixed> $context
+     * @throws RuntimeException
      */
-    public function isValid($value, $context = null)
+    public function isValid(mixed $value, ?array $context = null): bool
     {
+        if (! is_string($value)) {
+            $this->error(self::INVALID);
+
+            return false;
+        }
+
         $this->setValue($value);
 
-        if ($value instanceof Traversable) {
-            $value = ArrayUtils::iteratorToArray($value);
-        }
-
-        if (is_array($value)) {
-            $values = $value;
-        } elseif (is_string($value)) {
-            $delimiter = $this->getValueDelimiter();
-            // Skip explode if delimiter is null,
-            // used when value is expected to be either an
-            // array when multiple values and a string for
-            // single values (ie. MultiCheckbox form behavior)
-            $values = null !== $delimiter
-                      ? explode($this->valueDelimiter, $value)
-                      : [$value];
-        } else {
-            $values = [$value];
-        }
-
-        $validator = $this->getValidator();
-
-        if (! $validator) {
-            throw new Exception\RuntimeException(sprintf(
-                '%s expects a validator to be set; none given',
-                __METHOD__
-            ));
-        }
+        $values      = explode($this->valueDelimiter, $value);
+        $this->count = 0;
 
         foreach ($values as $value) {
-            if (! $validator->isValid($value, $context)) {
-                $this->abstractOptions['messages'][] = $validator->getMessages();
+            if ($this->validator->isValid($value, $context)) {
+                continue;
+            }
 
-                if ($this->isBreakOnFirstFailure()) {
-                    return false;
-                }
+            $this->count++;
+
+            if ($this->breakOnFirstFailure) {
+                break;
             }
         }
 
-        return $this->abstractOptions['messages'] === [];
+        if ($this->count > 0) {
+            $this->error = implode(', ', $this->validator->getMessages());
+
+            $this->error(self::INVALID_ITEM);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -8,6 +8,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use Laminas\Validator\Bitwise;
 use Laminas\Validator\Exception\RuntimeException;
+use Laminas\Validator\Explode;
 use Laminas\Validator\ValidatorInterface;
 use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
@@ -94,6 +95,11 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
 
             // Skipping due to required options
             if ($target === Bitwise::class) {
+                continue;
+            }
+
+            // Skipping due to required options
+            if ($target === Explode::class) {
                 continue;
             }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Remove option getters and setters
- Only accept an array for configuration
- Add types everywhere
- Changes handling of error messages
- fail validation for non-string arguments
- Allow the composed validator option to be a class-string or alias

Validator error messages should be `array<string, string>`. This validator would yield `list<array<string, string>>` on validation failure. The validation error was also largely pointless because repeated errors would be squashed internally by AbstractValidator leaving only one element in the list anyhow.

This validator now yields a new error message, something like `"5 items were invalid: composed validator error messages"`
