### PR TITLE
Refactor `Timezone` validator

### DIFF
--- a/docs/book/v3/validators/timezone.md
+++ b/docs/book/v3/validators/timezone.md
@@ -28,10 +28,25 @@ To validate against only the location string you can set the type:
 ```php
 use Laminas\Validator\Timezone;
 
-$validator = new Timezone();
-$validator->setType(Timezone::LOCATION);
+$validator = new Timezone([
+    'type' => Timezone::LOCATION,
+]);
 
 $validator->isValid('America/Los_Angeles'); // returns true
 $validator->isValid('ewt'); // returns false
+$validator->isValid('Foobar');  // returns false
+```
+
+Similarly, to validate only abbreviations:
+
+```php
+use Laminas\Validator\Timezone;
+
+$validator = new Timezone([
+    'type' => Timezone::ABBREVIATION,
+]);
+
+$validator->isValid('America/Los_Angeles'); // returns false
+$validator->isValid('ewt'); // returns true
 $validator->isValid('Foobar');  // returns false
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1521,42 +1521,6 @@
       <code><![CDATA[$temp]]></code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="src/Timezone.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($type)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidOperand>
-      <code><![CDATA[array_search($value, $this->constants)]]></code>
-    </InvalidOperand>
-    <MixedAssignment>
-      <code><![CDATA[$opts['type']]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$type]]></code>
-    </MixedOperand>
-    <PossiblyFalseOperand>
-      <code><![CDATA[array_search($value, $this->constants)]]></code>
-    </PossiblyFalseOperand>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$opts]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$opts]]></code>
-    </PossiblyUndefinedVariable>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[gettype($type)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/Translator/DummyTranslator.php">
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(int) $number]]></code>
@@ -2315,21 +2279,11 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/TimezoneTest.php">
-    <InvalidArgument>
-      <code><![CDATA['abbreviation']]></code>
-      <code><![CDATA['abbreviation']]></code>
-      <code><![CDATA['location']]></code>
-      <code><![CDATA['location']]></code>
-    </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[abbreviationProvider]]></code>
       <code><![CDATA[getInvalidTypes]]></code>
       <code><![CDATA[locationAndAbbreviationProvider]]></code>
       <code><![CDATA[locationProvider]]></code>
-      <code><![CDATA[wrongTypesProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/UndisclosedPasswordTest.php">

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use DateTimeZone;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_key_exists;
-use function array_search;
-use function gettype;
 use function in_array;
-use function is_array;
 use function is_int;
 use function is_string;
-use function sprintf;
+use function strtolower;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ *     type?: int-mask<Timezone::LOCATION,Timezone::ABBREVIATION,Timezone::ALL>,
+ * }
+ */
 final class Timezone extends AbstractValidator
 {
     public const INVALID                       = 'invalidTimezone';
@@ -25,148 +28,73 @@ final class Timezone extends AbstractValidator
     public const ABBREVIATION = 0b10;
     public const ALL          = 0b11;
 
-    /** @var array */
-    protected $constants = [
-        self::LOCATION     => 'location',
-        self::ABBREVIATION => 'abbreviation',
-    ];
-
-    /**
-     * Default value for types; value = 3
-     *
-     * @var array
-     */
-    protected $defaultType = [
-        self::LOCATION,
-        self::ABBREVIATION,
-    ];
-
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::INVALID                       => 'Invalid timezone given.',
         self::INVALID_TIMEZONE_LOCATION     => 'Invalid timezone location given.',
         self::INVALID_TIMEZONE_ABBREVIATION => 'Invalid timezone abbreviation given.',
     ];
 
-    /**
-     * Options for this validator
-     *
-     * @var array
-     */
-    protected $options = [];
+    /** @var int-mask<self::LOCATION,self::ABBREVIATION> */
+    private readonly int $type;
 
     /**
-     * Constructor
-     *
-     * @param array|int $options OPTIONAL
+     * @param OptionsArgument $options
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        $opts['type'] = $this->defaultType;
+        $type = $options['type'] ?? self::ALL;
 
-        if (is_array($options)) {
-            if (array_key_exists('type', $options)) {
-                $opts['type'] = $options['type'];
-            }
-        } elseif (! empty($options)) {
-            $opts['type'] = $options;
+        /** @psalm-suppress DocblockTypeContradiction - This is a defensive check */
+        if (! is_int($type) || ($type & self::ALL) === 0) {
+            throw new InvalidArgumentException(
+                'The type option must be an int-mask of the type constants',
+            );
         }
 
-        // setType called by parent constructor then setOptions method
-        parent::__construct($opts);
-    }
+        $this->type = $type;
 
-    /**
-     * Set the types
-     *
-     * @param int|array $type
-     * @return void
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setType($type = null)
-    {
-        $type = $this->calculateTypeValue($type);
-
-        if (! is_int($type) || ($type < 1) || ($type > self::ALL)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Unknown type "%s" provided',
-                is_string($type) || is_int($type)
-                    ? $type : gettype($type)
-            ));
-        }
-
-        $this->options['type'] = $type;
+        parent::__construct($options);
     }
 
     /**
      * Returns true if timezone location or timezone abbreviations is correct.
-     *
-     * @param mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
-        if ($value !== null && ! is_string($value)) {
+        if (! is_string($value) || $value === '') {
             $this->error(self::INVALID);
             return false;
         }
 
-        $type = $this->options['type'];
         $this->setValue($value);
 
-        switch (true) {
-            // Check in locations and abbreviations
-            case ($type & self::LOCATION) && ($type & self::ABBREVIATION):
-                $abbrs     = DateTimeZone::listAbbreviations();
-                $locations = DateTimeZone::listIdentifiers();
+        if ($this->type === self::ALL) {
+            if (
+                ! array_key_exists(strtolower($value), DateTimeZone::listAbbreviations())
+                && ! in_array($value, DateTimeZone::listIdentifiers(), true)
+            ) {
+                $this->error(self::INVALID);
 
-                if (! array_key_exists($value, $abbrs) && ! in_array($value, $locations)) {
-                    $this->error(self::INVALID);
-                    return false;
-                }
-                break;
-
-            // Check only in locations
-            case $type & self::LOCATION:
-                $locations = DateTimeZone::listIdentifiers();
-
-                if (! in_array($value, $locations)) {
-                    $this->error(self::INVALID_TIMEZONE_LOCATION);
-                    return false;
-                }
-                break;
-
-            // Check only in abbreviations
-            case $type & self::ABBREVIATION:
-                $abbrs = DateTimeZone::listAbbreviations();
-
-                if (! array_key_exists($value, $abbrs)) {
-                    $this->error(self::INVALID_TIMEZONE_ABBREVIATION);
-                    return false;
-                }
-                break;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array|int|string $type
-     * @return float|int
-     */
-    protected function calculateTypeValue($type)
-    {
-        $types    = (array) $type;
-        $detected = 0;
-
-        foreach ($types as $value) {
-            if (is_int($value)) {
-                $detected |= $value;
-            } elseif (false !== array_search($value, $this->constants)) {
-                $detected |= array_search($value, $this->constants);
+                return false;
             }
         }
 
-        return $detected;
+        if ($this->type === self::LOCATION && ! in_array($value, DateTimeZone::listIdentifiers(), true)) {
+            $this->error(self::INVALID_TIMEZONE_LOCATION);
+
+            return false;
+        }
+
+        if (
+            $this->type === self::ABBREVIATION
+            && ! array_key_exists(strtolower($value), DateTimeZone::listAbbreviations())
+        ) {
+            $this->error(self::INVALID_TIMEZONE_ABBREVIATION);
+
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes all option setters and getters
- Allow only an array for the options passed to the constructor
- Only accept an `int-mask` for the `type` option
- Add types
- Make TZ abbreviation comparison case-insensitive
