### PR TITLE
Add parameter and return types to `ValidatorInterface::isValid()`

### DIFF
--- a/docs/book/v3/writing-validators.md
+++ b/docs/book/v3/writing-validators.md
@@ -45,11 +45,11 @@ class Float extends AbstractValidator
 {
     const FLOAT = 'float';
 
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::FLOAT => "'%value%' is not a floating point value",
     ];
 
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
 
@@ -101,7 +101,7 @@ class NumericBetween extends AbstractValidator
     public $minimum = 0;
     public $maximum = 100;
 
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'min' => 'minimum',
         'max' => 'maximum',
     ];
@@ -112,7 +112,7 @@ class NumericBetween extends AbstractValidator
         self::MSG_MAXIMUM => "'%value%' must be no more than '%max%'",
     ];
 
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
 
@@ -183,7 +183,7 @@ class PasswordStrength extends AbstractValidator
         self::DIGIT  => "'%value%' must contain at least one digit character",
     ];
 
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -119,7 +119,6 @@
       <code><![CDATA[$this->cardLength[$type]]]></code>
       <code><![CDATA[$this->options['type']]]></code>
       <code><![CDATA[$this->options['type']]]></code>
-      <code><![CDATA[$value]]></code>
     </MixedArgument>
     <MixedArrayAssignment>
       <code><![CDATA[$this->options['type'][]]]></code>
@@ -375,9 +374,6 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
-    <NonInvariantDocblockPropertyType>
-      <code><![CDATA[$messageTemplates]]></code>
-    </NonInvariantDocblockPropertyType>
     <PossiblyFalseOperand>
       <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
@@ -1063,19 +1059,10 @@
     </UnresolvableInclude>
   </file>
   <file src="src/Iban.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['allow_non_sepa']]]></code>
       <code><![CDATA[$options['country_code']]]></code>
     </MixedArgument>
-    <MixedOperand>
-      <code><![CDATA[static::$ibanRegex[$countryCode]]]></code>
-    </MixedOperand>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
     <PossiblyInvalidArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyInvalidArgument>

--- a/src/BusinessIdentifierCode.php
+++ b/src/BusinessIdentifierCode.php
@@ -15,8 +15,8 @@ final class BusinessIdentifierCode extends AbstractValidator
     public const NOT_STRING        = 'valueNotString';
     public const NOT_VALID_COUNTRY = 'valueNotCountry';
 
-    /** @var string[] */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::NOT_STRING        => 'Invalid type given; string expected',
         self::INVALID           => 'Invalid BIC format',
         self::NOT_VALID_COUNTRY => 'Invalid country code',
@@ -31,8 +31,6 @@ final class BusinessIdentifierCode extends AbstractValidator
      * List of all country codes defined by ISO 3166-1 alpha-2
      *
      * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Current_codes
-     *
-     * @var string[]
      */
     private const ISO_COUNTRIES = [
         'AD',
@@ -291,13 +289,11 @@ final class BusinessIdentifierCode extends AbstractValidator
      * This code is the only one used by SWIFT that is not defined by ISO 3166-1 alpha-2
      *
      * @see https://en.wikipedia.org/wiki/ISO_9362
-     *
-     * @var string
      */
     private const KOSOVO_EXCEPTION = 'XK';
 
     /** {@inheritDoc} */
-    public function isValid($value): bool
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::NOT_STRING);

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -58,9 +58,9 @@ class CreditCard extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::CHECKSUM       => 'The input seems to contain an invalid checksum',
         self::CONTENT        => 'The input must contain only digits',
         self::INVALID        => 'Invalid type given. String expected',
@@ -361,28 +361,22 @@ class CreditCard extends AbstractValidator
         return $this;
     }
 
-    // The following rule is buggy for parameters attributes
-    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
-
     /**
      * Returns true if and only if $value follows the Luhn algorithm (mod-10 checksum)
-     *
-     * @param  mixed $value
-     * @return bool
      */
     public function isValid(
         #[SensitiveParameter]
-        $value
-    ) {
+        mixed $value
+    ): bool {
         $this->setValue($value);
 
         if (! is_string($value)) {
-            $this->error(self::INVALID, $value);
+            $this->error(self::INVALID);
             return false;
         }
 
         if (! ctype_digit($value)) {
-            $this->error(self::CONTENT, $value);
+            $this->error(self::CONTENT);
             return false;
         }
 
@@ -403,12 +397,12 @@ class CreditCard extends AbstractValidator
         }
 
         if ($foundp === false) {
-            $this->error(self::PREFIX, $value);
+            $this->error(self::PREFIX);
             return false;
         }
 
         if ($foundl === false) {
-            $this->error(self::LENGTH, $value);
+            $this->error(self::LENGTH);
             return false;
         }
 
@@ -436,17 +430,15 @@ class CreditCard extends AbstractValidator
                     'throwExceptions' => true,
                 ]);
                 if (! $callback->isValid($value)) {
-                    $this->error(self::SERVICE, $value);
+                    $this->error(self::SERVICE);
                     return false;
                 }
             } catch (Exception) {
-                $this->error(self::SERVICEFAILURE, $value);
+                $this->error(self::SERVICEFAILURE);
                 return false;
             }
         }
 
         return true;
     }
-
-    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -37,16 +37,16 @@ class Date extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INVALID      => 'Invalid type given. String, integer, array or DateTime expected',
         self::INVALID_DATE => 'The input does not appear to be a valid date',
         self::FALSEFORMAT  => "The input does not fit the date format '%format%'",
     ];
 
-    /** @var string[] */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'format' => 'format',
     ];
 
@@ -115,9 +115,8 @@ class Date extends AbstractValidator
      * Returns true if $value is a DateTimeInterface instance or can be converted into one.
      *
      * @param  string|numeric|array|DateTimeInterface $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
 

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -46,9 +46,9 @@ final class DateStep extends Date
     /**
      * Validation failure message template definitions
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INVALID      => 'Invalid type given. String, integer, array or DateTime expected',
         self::INVALID_DATE => 'The input does not appear to be a valid date',
         self::FALSEFORMAT  => "The input does not fit the date format '%format%'",
@@ -217,10 +217,9 @@ final class DateStep extends Date
      * Returns true if a date is within a valid step
      *
      * @param string|int|DateTimeInterface $value
-     * @return bool
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! parent::isValid($value)) {
             return false;

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -20,7 +20,7 @@ final class Digits extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_DIGITS   => 'The input must contain only digits',
         self::STRING_EMPTY => 'The input is an empty string',
         self::INVALID      => 'Invalid type given. String, integer or float expected',

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -45,7 +45,7 @@ final class EmailAddress extends AbstractValidator
     // phpcs:disable Generic.Files.LineLength.TooLong
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INVALID            => "Invalid type given. String expected",
         self::INVALID_FORMAT     => "The input is not a valid email address. Use the basic format local-part@hostname",
         self::INVALID_HOSTNAME   => "'%hostname%' is not a valid hostname for the email address",
@@ -59,8 +59,8 @@ final class EmailAddress extends AbstractValidator
 
     // phpcs:enable
 
-    /** @var array */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'hostname'  => 'hostname',
         'localPart' => 'localPart',
     ];
@@ -486,9 +486,8 @@ final class EmailAddress extends AbstractValidator
      * @link   http://www.columbia.edu/kermit/ascii.html US-ASCII characters
      *
      * @param  string $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::INVALID);

--- a/src/File/Count.php
+++ b/src/File/Count.php
@@ -34,14 +34,14 @@ final class Count extends AbstractValidator
     public const TOO_FEW  = 'fileCountTooFew';
     /**#@-*/
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::TOO_MANY => "Too many files, maximum '%max%' are allowed but '%count%' are given",
         self::TOO_FEW  => "Too few files, minimum '%min%' are expected but '%count%' are given",
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'min'   => ['options' => 'min'],
         'max'   => ['options' => 'max'],
         'count' => 'count',
@@ -211,9 +211,8 @@ final class Count extends AbstractValidator
      *
      * @param  string|array|UploadedFileInterface $value Filenames to check for count
      * @param  array                              $file  File data from \Laminas\File\Transfer\Transfer
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         if ($this->isUploadedFilterInterface($value)) {
             $this->addFile($value);

--- a/src/File/Crc32.php
+++ b/src/File/Crc32.php
@@ -23,8 +23,8 @@ final class Crc32 extends Hash
     public const NOT_DETECTED   = 'fileCrc32NotDetected';
     public const NOT_FOUND      = 'fileCrc32NotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_NOT_MATCH => 'File does not match the given crc32 hashes',
         self::NOT_DETECTED   => 'A crc32 hash could not be evaluated for the given file',
         self::NOT_FOUND      => 'File is not readable or does not exist',
@@ -79,9 +79,8 @@ final class Crc32 extends Hash
      *
      * @param  string|array $value Filename to check for hash
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -23,8 +23,8 @@ final class ExcludeExtension extends Extension
     public const FALSE_EXTENSION = 'fileExcludeExtensionFalse';
     public const NOT_FOUND       = 'fileExcludeExtensionNotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::FALSE_EXTENSION => 'File has an incorrect extension',
         self::NOT_FOUND       => 'File is not readable or does not exist',
     ];
@@ -35,9 +35,8 @@ final class ExcludeExtension extends Extension
      *
      * @param  string|array $value Real file to check for extension
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/ExcludeMimeType.php
+++ b/src/File/ExcludeMimeType.php
@@ -28,8 +28,8 @@ final class ExcludeMimeType extends MimeType
     public const NOT_DETECTED = 'fileExcludeMimeTypeNotDetected';
     public const NOT_READABLE = 'fileExcludeMimeTypeNotReadable';
 
-    /** @inheritDoc */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::FALSE_TYPE   => "File has an incorrect mimetype of '%type%'",
         self::NOT_DETECTED => 'The mimetype could not be detected from the file',
         self::NOT_READABLE => 'File is not readable or does not exist',
@@ -42,9 +42,8 @@ final class ExcludeMimeType extends MimeType
      *
      * @param  string|array|UploadedFileInterface $value Real file to check for mimetype
      * @param  array                              $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file, true);
 

--- a/src/File/Exists.php
+++ b/src/File/Exists.php
@@ -31,8 +31,8 @@ class Exists extends AbstractValidator
      */
     public const DOES_NOT_EXIST = 'fileExistsDoesNotExist';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_NOT_EXIST => 'File does not exist',
     ];
 
@@ -45,8 +45,8 @@ class Exists extends AbstractValidator
         'directory' => null, // internal list of directories
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'directory' => ['options' => 'directory'],
     ];
 
@@ -145,9 +145,8 @@ class Exists extends AbstractValidator
      *
      * @param  string|array $value Real file to check for existence
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file, false, true);
 

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -36,8 +36,8 @@ class Extension extends AbstractValidator
     public const FALSE_EXTENSION = 'fileExtensionFalse';
     public const NOT_FOUND       = 'fileExtensionNotFound';
 
-    /** @var array<string, string> Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::FALSE_EXTENSION => 'File has an incorrect extension',
         self::NOT_FOUND       => 'File is not readable or does not exist',
     ];
@@ -53,8 +53,8 @@ class Extension extends AbstractValidator
         'allowNonExistentFile' => false, // Allow validation even if file does not exist
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'extension' => ['options' => 'extension'],
     ];
 
@@ -208,9 +208,8 @@ class Extension extends AbstractValidator
      *
      * @param  string|array $value Real file to check for extension
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/FilesSize.php
+++ b/src/File/FilesSize.php
@@ -22,8 +22,6 @@ use function is_string;
 
 /**
  * Validator for the size of all files which will be validated in sum
- *
- * @final
  */
 final class FilesSize extends Size
 {
@@ -34,8 +32,8 @@ final class FilesSize extends Size
     public const TOO_SMALL    = 'fileFilesSizeTooSmall';
     public const NOT_READABLE = 'fileFilesSizeNotReadable';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::TOO_BIG      => "All files in sum should have a maximum size of '%max%' but '%size%' were detected",
         self::TOO_SMALL    => "All files in sum should have a minimum size of '%min%' but '%size%' were detected",
         self::NOT_READABLE => 'One or more files can not be read',
@@ -88,9 +86,8 @@ final class FilesSize extends Size
      *
      * @param  string|array $value Real file to check for size
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         if (is_string($value)) {
             $value = [$value];

--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -36,8 +36,8 @@ class Hash extends AbstractValidator
     public const NOT_DETECTED   = 'fileHashHashNotDetected';
     public const NOT_FOUND      = 'fileHashNotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_NOT_MATCH => 'File does not match the given hashes',
         self::NOT_DETECTED   => 'A hash could not be evaluated for the given file',
         self::NOT_FOUND      => 'File is not readable or does not exist',
@@ -143,9 +143,8 @@ class Hash extends AbstractValidator
      *
      * @param  string|array $value File to check for hash
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -18,8 +18,6 @@ use function is_readable;
 
 /**
  * Validator for the image size of an image file
- *
- * @final
  */
 final class ImageSize extends AbstractValidator
 {
@@ -35,8 +33,8 @@ final class ImageSize extends AbstractValidator
     public const NOT_DETECTED     = 'fileImageSizeNotDetected';
     public const NOT_READABLE     = 'fileImageSizeNotReadable';
 
-    /** @var array Error message template */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::WIDTH_TOO_BIG    => "Maximum allowed width for image should be '%maxwidth%' but '%width%' detected",
         self::WIDTH_TOO_SMALL  => "Minimum expected width for image should be '%minwidth%' but '%width%' detected",
         self::HEIGHT_TOO_BIG   => "Maximum allowed height for image should be '%maxheight%' but '%height%' detected",
@@ -45,8 +43,8 @@ final class ImageSize extends AbstractValidator
         self::NOT_READABLE     => 'File is not readable or does not exist',
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'minwidth'  => ['options' => 'minWidth'],
         'maxwidth'  => ['options' => 'maxWidth'],
         'minheight' => ['options' => 'minHeight'],
@@ -331,9 +329,8 @@ final class ImageSize extends AbstractValidator
      *
      * @param  string|array $value Real file to check for image size
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/IsCompressed.php
+++ b/src/File/IsCompressed.php
@@ -9,8 +9,6 @@ use Traversable;
 
 /**
  * Validator which checks if the file already exists in the directory
- *
- * @final
  */
 final class IsCompressed extends MimeType
 {
@@ -21,8 +19,8 @@ final class IsCompressed extends MimeType
     public const NOT_DETECTED = 'fileIsCompressedNotDetected';
     public const NOT_READABLE = 'fileIsCompressedNotReadable';
 
-    /** @inheritDoc */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::FALSE_TYPE   => "File is not compressed, '%type%' detected",
         self::NOT_DETECTED => 'The mimetype could not be detected from the file',
         self::NOT_READABLE => 'File is not readable or does not exist',

--- a/src/File/IsImage.php
+++ b/src/File/IsImage.php
@@ -9,8 +9,6 @@ use Traversable;
 
 /**
  * Validator which checks if the file is an image
- *
- * @final
  */
 final class IsImage extends MimeType
 {
@@ -21,8 +19,8 @@ final class IsImage extends MimeType
     public const NOT_DETECTED = 'fileIsImageNotDetected';
     public const NOT_READABLE = 'fileIsImageNotReadable';
 
-    /** @inheritDoc */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::FALSE_TYPE   => "File is no image, '%type%' detected",
         self::NOT_DETECTED => 'The mimetype could not be detected from the file',
         self::NOT_READABLE => 'File is not readable or does not exist',

--- a/src/File/Md5.php
+++ b/src/File/Md5.php
@@ -11,8 +11,6 @@ use function is_readable;
 
 /**
  * Validator for the md5 hash of given files
- *
- * @final
  */
 final class Md5 extends Hash
 {
@@ -25,8 +23,8 @@ final class Md5 extends Hash
     public const NOT_DETECTED   = 'fileMd5NotDetected';
     public const NOT_FOUND      = 'fileMd5NotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_NOT_MATCH => 'File does not match the given md5 hashes',
         self::NOT_DETECTED   => 'An md5 hash could not be evaluated for the given file',
         self::NOT_FOUND      => 'File is not readable or does not exist',
@@ -81,9 +79,8 @@ final class Md5 extends Hash
      *
      * @param  string|array $value Filename to check for hash
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -53,14 +53,14 @@ class MimeType extends AbstractValidator
     /**#@-*/
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::FALSE_TYPE   => "File has an incorrect mimetype of '%type%'",
         self::NOT_DETECTED => 'The mimetype could not be detected from the file',
         self::NOT_READABLE => 'File is not readable or does not exist',
     ];
 
-    /** @var array */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'type' => 'type',
     ];
 
@@ -351,9 +351,8 @@ class MimeType extends AbstractValidator
      *
      * @param  string|array|UploadedFileInterface $value Real file to check for mimetype
      * @param  array               $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file, true);
 

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -10,8 +10,6 @@ use const DIRECTORY_SEPARATOR;
 
 /**
  * Validator which checks if the destination file does not exist
- *
- * @final
  */
 final class NotExists extends Exists
 {
@@ -22,8 +20,8 @@ final class NotExists extends Exists
      */
     public const DOES_EXIST = 'fileNotExistsDoesExist';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_EXIST => 'File exists',
     ];
 
@@ -32,9 +30,8 @@ final class NotExists extends Exists
      *
      * @param  string|array $value Real file to check for existence
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file, false, true);
 

--- a/src/File/Sha1.php
+++ b/src/File/Sha1.php
@@ -11,8 +11,6 @@ use function is_readable;
 
 /**
  * Validator for the sha1 hash of given files
- *
- * @final
  */
 final class Sha1 extends Hash
 {
@@ -25,8 +23,8 @@ final class Sha1 extends Hash
     public const NOT_DETECTED   = 'fileSha1NotDetected';
     public const NOT_FOUND      = 'fileSha1NotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::DOES_NOT_MATCH => 'File does not match the given sha1 hashes',
         self::NOT_DETECTED   => 'A sha1 hash could not be evaluated for the given file',
         self::NOT_FOUND      => 'File is not readable or does not exist',
@@ -81,9 +79,8 @@ final class Sha1 extends Hash
      *
      * @param (int|string)[]|string $value Filename to check for hash
      * @param array                 $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -35,15 +35,15 @@ class Size extends AbstractValidator
     public const TOO_SMALL = 'fileSizeTooSmall';
     public const NOT_FOUND = 'fileSizeNotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::TOO_BIG   => "Maximum allowed size for file is '%max%' but '%size%' detected",
         self::TOO_SMALL => "Minimum expected size for file is '%min%' but '%size%' detected",
         self::NOT_FOUND => 'File is not readable or does not exist',
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'min'  => ['options' => 'min'],
         'max'  => ['options' => 'max'],
         'size' => 'size',
@@ -236,9 +236,8 @@ class Size extends AbstractValidator
      *
      * @param  string|array $value File to check for size
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/File/Upload.php
+++ b/src/File/Upload.php
@@ -19,8 +19,6 @@ use function is_uploaded_file;
 
 /**
  * Validator for the maximum size of a file up to a max of 2GB
- *
- * @final
  */
 final class Upload extends AbstractValidator
 {
@@ -39,7 +37,7 @@ final class Upload extends AbstractValidator
     public const UNKNOWN        = 'fileUploadErrorUnknown';
 
     /** @var array<string, string> Error message templates */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INI_SIZE       => "File '%value%' exceeds upload_max_filesize directive in php.ini",
         self::FORM_SIZE      => "File '%value%' exceeds the MAX_FILE_SIZE directive that was "
             . 'specified in the HTML form',
@@ -151,9 +149,8 @@ final class Upload extends AbstractValidator
      * @param  string $value Single file to check for upload errors, when giving null the $_FILES array
      *                       from initialization will be used
      * @param  mixed  $file
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $files = [];
         $this->setValue($value);

--- a/src/File/UploadFile.php
+++ b/src/File/UploadFile.php
@@ -25,8 +25,6 @@ use const UPLOAD_ERR_PARTIAL;
 
 /**
  * Validator for the maximum size of a file up to a max of 2GB
- *
- * @final
  */
 final class UploadFile extends AbstractValidator
 {
@@ -44,8 +42,8 @@ final class UploadFile extends AbstractValidator
     public const FILE_NOT_FOUND = 'fileUploadFileErrorFileNotFound';
     public const UNKNOWN        = 'fileUploadFileErrorUnknown';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::INI_SIZE       => 'The uploaded file exceeds the upload_max_filesize directive in php.ini',
         self::FORM_SIZE      => 'The uploaded file exceeds the MAX_FILE_SIZE directive that was '
             . 'specified in the HTML form',
@@ -63,10 +61,9 @@ final class UploadFile extends AbstractValidator
      * Returns true if and only if the file was uploaded without errors
      *
      * @param  string|array|UploadedFileInterface $value File to check for upload errors
-     * @return bool
      * @throws Exception\InvalidArgumentException
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (is_array($value)) {
             if (! isset($value['tmp_name']) || ! isset($value['name']) || ! isset($value['error'])) {

--- a/src/File/WordCount.php
+++ b/src/File/WordCount.php
@@ -32,15 +32,15 @@ final class WordCount extends AbstractValidator
     public const TOO_LESS  = 'fileWordCountTooLess';
     public const NOT_FOUND = 'fileWordCountNotFound';
 
-    /** @var array Error message templates */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::TOO_MUCH  => "Too many words, maximum '%max%' are allowed but '%count%' were counted",
         self::TOO_LESS  => "Too few words, minimum '%min%' are expected but '%count%' were counted",
         self::NOT_FOUND => 'File is not readable or does not exist',
     ];
 
-    /** @var array Error message template variables */
-    protected $messageVariables = [
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
         'min'   => ['options' => 'min'],
         'max'   => ['options' => 'max'],
         'count' => 'count',
@@ -175,9 +175,8 @@ final class WordCount extends AbstractValidator
      *
      * @param  string|array $value Filename to check for word count
      * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
-     * @return bool
      */
-    public function isValid($value, $file = null)
+    public function isValid(mixed $value, $file = null): bool
     {
         $fileInfo = $this->getFileInfo($value, $file);
 

--- a/src/GpsPoint.php
+++ b/src/GpsPoint.php
@@ -18,6 +18,7 @@ final class GpsPoint extends AbstractValidator
     public const CONVERT_ERROR         = 'gpsPointConvertError';
     public const INCOMPLETE_COORDINATE = 'gpsPointIncompleteCoordinate';
 
+    /** @var array<string, string> */
     protected array $messageTemplates = [
         self::OUT_OF_BOUNDS         => '%value% is out of Bounds.',
         self::CONVERT_ERROR         => '%value% can not converted into a Decimal Degree Value.',

--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -37,22 +37,12 @@ use function strtoupper;
 use function substr;
 
 /**
- * Please note there are two standalone test scripts for testing IDN characters due to problems
- * with file encoding.
- *
- * The first is tests/Laminas/Validator/HostnameTestStandalone.php which is designed to be run on
- * the command line.
- *
- * The second is tests/Laminas/Validator/HostnameTestForm.php which is designed to be run via HTML
- * to allow users to test entering UTF-8 characters in a form.
- *
  * @psalm-type Options = array{
  *    allow?: int-mask-of<self::ALLOW_*>,
  *    useIdnCheck?: bool,
  *    useTldCheck?: bool,
  *    ipValidator?: null|ValidatorInterface,
  * }
- * @final
  */
 final class Hostname extends AbstractValidator
 {
@@ -68,8 +58,8 @@ final class Hostname extends AbstractValidator
     public const UNDECIPHERABLE_TLD      = 'hostnameUndecipherableTld';
     public const UNKNOWN_TLD             = 'hostnameUnknownTld';
 
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::CANNOT_DECODE_PUNYCODE  => "The input appears to be a DNS hostname but the given punycode notation cannot be decoded",
         self::INVALID                 => "Invalid type given. String expected",
         self::INVALID_DASH            => "The input appears to be a DNS hostname but contains a dash in an invalid position",
@@ -83,8 +73,8 @@ final class Hostname extends AbstractValidator
         self::UNKNOWN_TLD             => "The input appears to be a DNS hostname but cannot match TLD against known list",
     ];
 
-    /** @var array */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'tld' => 'tld',
     ];
 
@@ -102,7 +92,7 @@ final class Hostname extends AbstractValidator
      *
      * @var string[]
      */
-    protected $validTlds = [
+    private array $validTlds = [
         'aaa',
         'aarp',
         'abb',
@@ -1607,7 +1597,7 @@ final class Hostname extends AbstractValidator
      *
      * @var array<string, string|array<int, string>>
      */
-    protected $validIdns = [
+    private array $validIdns = [
         'AC'       => [1 => '/^[\x{002d}0-9a-zà-öø-ÿāăąćĉċčďđēėęěĝġģĥħīįĵķĺļľŀłńņňŋőœŕŗřśŝşšţťŧūŭůűųŵŷźżž]{1,63}$/iu'],
         'AR'       => [1 => '/^[\x{002d}0-9a-zà-ãç-êìíñ-õü]{1,63}$/iu'],
         'AS'       => [1 => '/^[\x{002d}0-9a-zà-öø-ÿāăąćĉċčďđēĕėęěĝğġģĥħĩīĭįıĵķĸĺļľłńņňŋōŏőœŕŗřśŝşšţťŧũūŭůűųŵŷźż]{1,63}$/iu'],
@@ -1751,7 +1741,7 @@ final class Hostname extends AbstractValidator
     ];
 
     /** @var array<string, array<int, int>> */
-    protected $idnLength = [
+    private array $idnLength = [
         'BIZ'      => [5 => 17, 11 => 15, 12 => 20],
         'CN'       => [1 => 20],
         'COM'      => [3 => 17, 5 => 20],
@@ -1936,9 +1926,8 @@ final class Hostname extends AbstractValidator
      * Returns true if and only if the $value is a valid hostname with respect to the current allow option
      *
      * @param  string $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::INVALID);

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -19,8 +19,6 @@ use function substr;
 
 /**
  * Validates IBAN Numbers (International Bank Account Numbers)
- *
- * @final
  */
 final class Iban extends AbstractValidator
 {
@@ -34,7 +32,7 @@ final class Iban extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOTSUPPORTED     => 'Unknown country within the IBAN',
         self::SEPANOTSUPPORTED => 'Countries outside the Single Euro Payments Area (SEPA) are not supported',
         self::FALSEFORMAT      => 'The input has a false IBAN format',
@@ -56,11 +54,9 @@ final class Iban extends AbstractValidator
     protected $allowNonSepa = true;
 
     /**
-     * The SEPA country codes
-     *
-     * @var string[] ISO 3166-1 codes
+     * SEPA ISO 3166-1country codes
      */
-    protected static $sepaCountries = [
+    private const SEPA_COUNTRIES = [
         'AT',
         'BE',
         'BG',
@@ -102,10 +98,8 @@ final class Iban extends AbstractValidator
 
     /**
      * IBAN regexes by country code
-     *
-     * @var array
      */
-    protected static $ibanRegex = [
+    private const IBAN_REGEX = [
         'AD' => 'AD[0-9]{2}[0-9]{4}[0-9]{4}[A-Z0-9]{12}',
         'AE' => 'AE[0-9]{2}[0-9]{3}[0-9]{16}',
         'AL' => 'AL[0-9]{2}[0-9]{8}[A-Z0-9]{16}',
@@ -218,7 +212,7 @@ final class Iban extends AbstractValidator
         if ($countryCode !== null) {
             $countryCode = (string) $countryCode;
 
-            if (! isset(static::$ibanRegex[$countryCode])) {
+            if (! isset(self::IBAN_REGEX[$countryCode])) {
                 throw new Exception\InvalidArgumentException(
                     "Country code '{$countryCode}' invalid by ISO 3166-1 or not supported"
                 );
@@ -253,11 +247,8 @@ final class Iban extends AbstractValidator
 
     /**
      * Returns true if $value is a valid IBAN
-     *
-     * @param  string $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::FALSEFORMAT);
@@ -272,19 +263,19 @@ final class Iban extends AbstractValidator
             $countryCode = substr($value, 0, 2);
         }
 
-        if (! array_key_exists($countryCode, static::$ibanRegex)) {
+        if (! array_key_exists($countryCode, self::IBAN_REGEX)) {
             $this->setValue($countryCode);
             $this->error(self::NOTSUPPORTED);
             return false;
         }
 
-        if (! $this->allowNonSepa && ! in_array($countryCode, static::$sepaCountries)) {
+        if (! $this->allowNonSepa && ! in_array($countryCode, self::SEPA_COUNTRIES)) {
             $this->setValue($countryCode);
             $this->error(self::SEPANOTSUPPORTED);
             return false;
         }
 
-        if (! preg_match('/^' . static::$ibanRegex[$countryCode] . '$/', $value)) {
+        if (! preg_match('/^' . self::IBAN_REGEX[$countryCode] . '$/', $value)) {
             $this->error(self::FALSEFORMAT);
             return false;
         }

--- a/src/Identical.php
+++ b/src/Identical.php
@@ -19,26 +19,17 @@ use function var_export;
 
 final class Identical extends AbstractValidator
 {
-    /**
-     * Error codes
-     *
-     * @const string
-     */
     public const NOT_SAME      = 'notSame';
     public const MISSING_TOKEN = 'missingToken';
 
-    /**
-     * Error messages
-     *
-     * @var array
-     */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::NOT_SAME      => 'The two given tokens do not match',
         self::MISSING_TOKEN => 'No token was provided to match against',
     ];
 
-    /** @var array */
-    protected $messageVariables = [
+    /** @var array<string, string> */
+    protected array $messageVariables = [
         'token' => 'tokenString',
     ];
 
@@ -156,12 +147,10 @@ final class Identical extends AbstractValidator
      * Returns true if and only if a token has been set and the provided value
      * matches that token.
      *
-     * @param  mixed $value
      * @param  null|array|ArrayAccess $context
      * @throws Exception\InvalidArgumentException If context is not array or ArrayObject.
-     * @return bool
      */
-    public function isValid($value, $context = null)
+    public function isValid(mixed $value, $context = null): bool
     {
         $this->setValue($value);
 

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -37,7 +37,7 @@ final class InArray extends AbstractValidator
     public const COMPARE_NOT_STRICT = -1;
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_IN_ARRAY => 'The input was not found in the haystack',
     ];
 
@@ -167,9 +167,8 @@ final class InArray extends AbstractValidator
      *
      * @param mixed $value
      * See {@link http://php.net/manual/function.in-array.php#104501}
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         // we create a copy of the haystack in case we need to modify it
         $haystack = $this->getHaystack();

--- a/src/IsArray.php
+++ b/src/IsArray.php
@@ -12,12 +12,12 @@ final class IsArray extends AbstractValidator
     public const NOT_ARRAY = 'NotArray';
 
     /** @var array<non-empty-string, non-empty-string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_ARRAY => 'Expected an array value but %type% provided',
     ];
 
     /** @var array<string, string> */
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'type' => 'type',
     ];
 

--- a/src/IsCountable.php
+++ b/src/IsCountable.php
@@ -38,7 +38,6 @@ use function is_numeric;
  * }&array<string, mixed>
  * @property Options&array<string, mixed> $options Required to stop Psalm getting confused about the declaration
  *                                                 on AbstractValidator
- * @final
  */
 final class IsCountable extends AbstractValidator
 {
@@ -52,7 +51,7 @@ final class IsCountable extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_COUNTABLE => 'The input must be an array or an instance of \\Countable',
         self::NOT_EQUALS    => "The input count must equal '%count%'",
         self::GREATER_THAN  => "The input count must be less than '%max%', inclusively",
@@ -64,7 +63,7 @@ final class IsCountable extends AbstractValidator
      *
      * @var array<string, array{options: string}>
      */
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'count' => ['options' => 'count'],
         'min'   => ['options' => 'min'],
         'max'   => ['options' => 'max'],
@@ -110,11 +109,8 @@ final class IsCountable extends AbstractValidator
 
     /**
      * Returns true if and only if $value is countable (and the count validates against optional values).
-     *
-     * @param mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_countable($value)) {
             $this->error(self::NOT_COUNTABLE);

--- a/src/IsInstanceOf.php
+++ b/src/IsInstanceOf.php
@@ -19,18 +19,18 @@ final class IsInstanceOf extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_INSTANCE_OF => "The input is not an instance of '%className%'",
     ];
 
     /**
      * Additional variables available for validation failure messages
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'className' => 'className',
     ];
 
@@ -90,11 +90,8 @@ final class IsInstanceOf extends AbstractValidator
 
     /**
      * Returns true if $value is instance of $this->className
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if ($value instanceof $this->className) {
             return true;

--- a/src/IsJsonString.php
+++ b/src/IsJsonString.php
@@ -40,7 +40,7 @@ final class IsJsonString extends AbstractValidator
     public const ALLOW_ALL    = 0b0011111;
 
     /** @var array<self::ERROR_*, non-empty-string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::ERROR_NOT_STRING         => 'Expected a string but %type% was received',
         self::ERROR_TYPE_NOT_ALLOWED   => 'Received a JSON %type% but this type is not acceptable',
         self::ERROR_MAX_DEPTH_EXCEEDED => 'The decoded JSON payload exceeds the allowed depth of %maxDepth%',
@@ -48,7 +48,7 @@ final class IsJsonString extends AbstractValidator
     ];
 
     /** @var array<string, string> */
-    protected $messageVariables = [
+    protected array $messageVariables = [
         'type'     => 'type',
         'maxDepth' => 'maxDepth',
     ];

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -24,15 +24,15 @@ final class Isbn extends AbstractValidator
     /**
      * Validation failure message template definitions.
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::INVALID => 'Invalid type given. String or integer expected',
         self::NO_ISBN => 'The input is not a valid ISBN number',
     ];
 
     /** @var array<string, mixed> */
-    protected $options = [
+    protected array $options = [
         'type'      => self::AUTO, // Allowed type
         'separator' => '', // Separator character
     ];
@@ -92,11 +92,8 @@ final class Isbn extends AbstractValidator
 
     /**
      * Returns true if and only if $value is a valid ISBN.
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value) && ! is_int($value)) {
             $this->error(self::INVALID);

--- a/src/NotEmpty.php
+++ b/src/NotEmpty.php
@@ -73,8 +73,8 @@ final class NotEmpty extends AbstractValidator
         self::BOOLEAN,
     ];
 
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::IS_EMPTY => "Value is required and can't be empty",
         self::INVALID  => 'Invalid type given. String, integer, float, boolean or array expected',
     ];
@@ -188,11 +188,8 @@ final class NotEmpty extends AbstractValidator
 
     /**
      * Returns true if and only if $value is not an empty value.
-     *
-     * @param  mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (
             $value !== null

--- a/src/Sitemap/Changefreq.php
+++ b/src/Sitemap/Changefreq.php
@@ -25,9 +25,9 @@ final class Changefreq extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_VALID => 'The input is not a valid sitemap changefreq',
         self::INVALID   => 'Invalid type given. String expected',
     ];
@@ -53,9 +53,8 @@ final class Changefreq extends AbstractValidator
      * @link http://www.sitemaps.org/protocol.php#changefreqdef <changefreq>
      *
      * @param  string  $value  value to validate
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::INVALID);

--- a/src/Sitemap/Lastmod.php
+++ b/src/Sitemap/Lastmod.php
@@ -37,7 +37,7 @@ final class Lastmod extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_VALID => 'The input is not a valid sitemap lastmod',
         self::INVALID   => 'Invalid type given. String expected',
     ];
@@ -48,9 +48,8 @@ final class Lastmod extends AbstractValidator
      * @link http://www.sitemaps.org/protocol.php#lastmoddef <lastmod>
      *
      * @param  string  $value  value to validate
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_string($value)) {
             $this->error(self::INVALID);

--- a/src/Sitemap/Loc.php
+++ b/src/Sitemap/Loc.php
@@ -31,7 +31,7 @@ final class Loc extends AbstractValidator
      *
      * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_VALID => 'The input is not a valid sitemap location',
         self::INVALID   => 'Invalid type given. String expected',
         self::TOO_LONG  => 'Sitemap URIs cannot be greater than 2048 characters',

--- a/src/Sitemap/Priority.php
+++ b/src/Sitemap/Priority.php
@@ -24,9 +24,9 @@ final class Priority extends AbstractValidator
     /**
      * Validation failure message template definitions
      *
-     * @var array
+     * @var array<string, string>
      */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::NOT_VALID => 'The input is not a valid sitemap priority',
         self::INVALID   => 'Invalid type given. Numeric string, integer or float expected',
     ];
@@ -37,9 +37,8 @@ final class Priority extends AbstractValidator
      * @link http://www.sitemaps.org/protocol.php#prioritydef <priority>
      *
      * @param  string  $value  value to validate
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_numeric($value)) {
             $this->error(self::INVALID);

--- a/src/Step.php
+++ b/src/Step.php
@@ -22,8 +22,8 @@ final class Step extends AbstractValidator
     public const INVALID  = 'typeInvalid';
     public const NOT_STEP = 'stepInvalid';
 
-    /** @var array */
-    protected $messageTemplates = [
+    /** @var array<string, string> */
+    protected array $messageTemplates = [
         self::INVALID  => 'Invalid value given. Scalar expected',
         self::NOT_STEP => 'The input is not a valid step',
     ];
@@ -109,11 +109,8 @@ final class Step extends AbstractValidator
 
     /**
      * Returns true if $value is a scalar and a valid step value
-     *
-     * @param mixed $value
-     * @return bool
      */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         if (! is_numeric($value)) {
             $this->error(self::INVALID);

--- a/src/UndisclosedPassword.php
+++ b/src/UndisclosedPassword.php
@@ -37,7 +37,7 @@ final class UndisclosedPassword extends AbstractValidator
     // phpcs:disable Generic.Files.LineLength.TooLong
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         self::PASSWORD_BREACHED => 'The provided password was found in previous breaches, please create another password',
         self::NOT_A_STRING      => 'The provided password is not a string, please provide a correct password',
     ];
@@ -48,13 +48,10 @@ final class UndisclosedPassword extends AbstractValidator
         parent::__construct();
     }
 
-    // The following rule is buggy for parameters attributes
-    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
-
     /** {@inheritDoc} */
     public function isValid(
         #[SensitiveParameter]
-        $value
+        mixed $value
     ): bool {
         if (! is_string($value)) {
             $this->error(self::NOT_A_STRING);
@@ -68,8 +65,6 @@ final class UndisclosedPassword extends AbstractValidator
 
         return true;
     }
-
-    // phpcs:enable SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing.NoSpaceBetweenTypeHintAndParameter
 
     private function isPwnedPassword(
         #[SensitiveParameter]

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -242,11 +242,9 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * Validators are run in the order in which they were added to the chain (FIFO).
      *
-     * @param  mixed $value
      * @param  mixed $context Extra "context" to provide the validator
-     * @return bool
      */
-    public function isValid($value, $context = null)
+    public function isValid(mixed $value, $context = null): bool
     {
         $this->messages = [];
         $result         = true;

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -21,11 +21,9 @@ interface ValidatorInterface
      * getMessages() will return an array of messages that explain why the
      * validation failed.
      *
-     * @param  mixed $value
-     * @return bool
      * @throws Exception\RuntimeException If validation of $value is impossible.
      */
-    public function isValid($value);
+    public function isValid(mixed $value): bool;
 
     /**
      * Returns an array of messages that explain why the most recent isValid()

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -212,7 +212,6 @@ final class IbanTest extends TestCase
     {
         $validator = new IbanValidator();
 
-        /** @psalm-suppress MixedArgument */
         self::assertFalse($validator->isValid($value));
     }
 }

--- a/test/TestAsset/ConcreteValidator.php
+++ b/test/TestAsset/ConcreteValidator.php
@@ -12,16 +12,12 @@ final class ConcreteValidator extends AbstractValidator
     public const BAR_MESSAGE = 'barMessage';
 
     /** @var array<string, string> */
-    protected $messageTemplates = [
+    protected array $messageTemplates = [
         'fooMessage' => '%value% was passed',
         'barMessage' => '%value% was wrong',
     ];
 
-    /**
-     * @param mixed $value
-     * @return bool
-     */
-    public function isValid($value)
+    public function isValid(mixed $value): bool
     {
         $this->setValue($value);
         $this->error(self::FOO_MESSAGE);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

The main change here is changing the signature of `ValidatorInterface::isValid()` to `public function isValid(mixed $value): bool;`

The patch includes some other miscellaneous clean up:

- Add property types to common props such as `$messageTemplates`
- converts some protected static props to private constants

