### PR TITLE
Refactor `Hostname` validator

### DIFF
--- a/docs/book/v3/validators/hostname.md
+++ b/docs/book/v3/validators/hostname.md
@@ -13,8 +13,7 @@ The following options are supported for `Laminas\Validator\Hostname`:
   [See below](#validating-different-types-of-hostnames) for details.
 - `idn`: Defines if IDN domains are allowed or not. This option defaults to
   `true`.
-- `ip`: Allows defining a custom IP validator. This option defaults to a new
-  instance of `Laminas\Validator\Ip`.
+- `ipValidator`: Allows defining an [IP validator](ip.md) with custom configuration
 - `tld`: Defines if TLDs are validated. This option defaults to `true`.
 
 ## Basic usage
@@ -63,7 +62,7 @@ To check for IP addresses only, you can use the example below:
 ```php
 use Laminas\Validator\Hostname;
 
-$validator = new Hostname(Hostname::ALLOW_IP);
+$validator = new Hostname(['allow' => Hostname::ALLOW_IP]);
 
 if ($validator->isValid($hostname)) {
     // hostname appears to be valid
@@ -82,7 +81,9 @@ Local hostnames:
 ```php
 use Laminas\Validator\Hostname;
 
-$validator = new Hostname(Hostname::ALLOW_DNS | Hostname::ALLOW_IP);
+$validator = new Hostname([
+    'allow' => Hostname::ALLOW_DNS | Hostname::ALLOW_IP,
+]);
 ```
 
 ## Validating International Domains Names
@@ -104,7 +105,7 @@ You can disable IDN validation by passing a second parameter to the
 ```php
 $validator = new Laminas\Validator\Hostname([
     'allow' => Laminas\Validator\Hostname::ALLOW_DNS,
-    'useIdnCheck'   => false,
+    'useIdnCheck' => false,
 ]);
 ```
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -176,9 +176,6 @@
       <code><![CDATA['']]></code>
       <code><![CDATA[is_string($value)]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument>
-      <code><![CDATA[$this->getAllow()]]></code>
-    </InvalidArgument>
     <LessSpecificImplementedReturnType>
       <code><![CDATA[AbstractValidator]]></code>
     </LessSpecificImplementedReturnType>
@@ -198,7 +195,7 @@
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
-      <code><![CDATA[int]]></code>
+      <code><![CDATA[int-mask-of<Hostname::ALLOW_*>]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
       <code><![CDATA[setAllow]]></code>
@@ -987,59 +984,12 @@
     </MixedArgument>
   </file>
   <file src="src/Hostname.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($options)]]></code>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$regexChar]]></code>
-      <code><![CDATA[$regexKey]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code><![CDATA[$partRegexChars]]></code>
       <code><![CDATA[$regexChar]]></code>
-      <code><![CDATA[$regexChars]]></code>
-      <code><![CDATA[$regexKey]]></code>
-      <code><![CDATA[$temp['allow']]]></code>
-      <code><![CDATA[$temp['ipValidator']]]></code>
-      <code><![CDATA[$temp['useIdnCheck']]]></code>
-      <code><![CDATA[$temp['useTldCheck']]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[Ip]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$regexChars]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['allow']]]></code>
-      <code><![CDATA[$this->options['ipValidator']]]></code>
-      <code><![CDATA[$this->options['useIdnCheck']]]></code>
-      <code><![CDATA[$this->options['useTldCheck']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setAllow]]></code>
-      <code><![CDATA[setIpValidator]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $useIdnCheck]]></code>
-      <code><![CDATA[(bool) $useTldCheck]]></code>
-    </RedundantCastGivenDocblockType>
-    <UnresolvableInclude>
-      <code><![CDATA[include __DIR__ . '/' . $this->validIdns[$this->tld]]]></code>
-    </UnresolvableInclude>
   </file>
   <file src="src/Iban.php">
     <MixedArgument>
@@ -1305,8 +1255,6 @@
   </file>
   <file src="test/EmailAddressTest.php">
     <InvalidArgument>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
       <code><![CDATA[Hostname::ALLOW_ALL]]></code>
@@ -1617,25 +1565,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/HostnameTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[$option]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS]]></code>
-      <code><![CDATA[Hostname::ALLOW_URI]]></code>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidArgument>
-    <InvalidCast>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidCast>
     <MixedArrayOffset>
       <code><![CDATA[$translations[$code]]]></code>
     </MixedArrayOffset>

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -30,6 +30,16 @@ use function trim;
 
 use const INTL_IDNA_VARIANT_UTS46;
 
+/**
+ * @psalm-type Options = array{
+ *     useMxCheck?: bool,
+ *     useDeepMxCheck?: bool,
+ *     useDomainCheck?: bool,
+ *     allow?: int-mask-of<Hostname::ALLOW_*>,
+ *     strict?: bool,
+ *     hostnameValidator?: Hostname|null,
+ * }
+ */
 final class EmailAddress extends AbstractValidator
 {
     public const INVALID            = 'emailAddressInvalid';
@@ -81,7 +91,7 @@ final class EmailAddress extends AbstractValidator
     /**
      * Internal options array
      *
-     * @var array<string, mixed>
+     * @var Options
      */
     protected $options = [
         'useMxCheck'        => false,
@@ -158,7 +168,7 @@ final class EmailAddress extends AbstractValidator
     public function getHostnameValidator()
     {
         if (! isset($this->options['hostnameValidator'])) {
-            $this->options['hostnameValidator'] = new Hostname($this->getAllow());
+            $this->options['hostnameValidator'] = new Hostname(['allow' => $this->getAllow()]);
         }
 
         return $this->options['hostnameValidator'];
@@ -178,7 +188,7 @@ final class EmailAddress extends AbstractValidator
     /**
      * Returns the allow option of the attached hostname validator
      *
-     * @return int
+     * @return int-mask-of<Hostname::ALLOW_*>
      */
     public function getAllow()
     {
@@ -188,7 +198,7 @@ final class EmailAddress extends AbstractValidator
     /**
      * Sets the allow option of the hostname validator to use
      *
-     * @param int $allow
+     * @param int-mask-of<Hostname::ALLOW_*> $allow
      * @return $this Provides a fluent interface
      */
     public function setAllow($allow)

--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -413,10 +413,12 @@ final class EmailAddressTest extends TestCase
      */
     public function testHostnameSettings(): void
     {
-        $validator = new EmailAddress();
+        $validator = new EmailAddress([
+            'hostnameValidator' => new Hostname([
+                'useIdnCheck' => false,
+            ]),
+        ]);
 
-        // Check no IDN matching
-        $validator->getHostnameValidator()->useIdnCheck(false);
         $valuesExpected = [
             [false, ['name@b�rger.de', 'name@h�llo.de', 'name@h�llo.se']],
         ];
@@ -428,7 +430,11 @@ final class EmailAddressTest extends TestCase
         }
 
         // Check no TLD matching
-        $validator->getHostnameValidator()->useTldCheck(false);
+        $validator      = new EmailAddress([
+            'hostnameValidator' => new Hostname([
+                'useTldCheck' => false,
+            ]),
+        ]);
         $valuesExpected = [
             [true, ['name@domain.xx', 'name@domain.zz', 'name@domain.madeup']],
         ];
@@ -551,7 +557,7 @@ final class EmailAddressTest extends TestCase
 
         try {
             /** @psalm-suppress TooManyArguments */
-            $validator = new EmailAddress(Hostname::ALLOW_ALL, true, new Hostname(Hostname::ALLOW_ALL));
+            $validator = new EmailAddress(Hostname::ALLOW_ALL, true, new Hostname(['allow' => Hostname::ALLOW_ALL]));
             $options   = $validator->getOptions();
 
             self::assertSame(Hostname::ALLOW_ALL, $options['allow']);
@@ -573,7 +579,7 @@ final class EmailAddressTest extends TestCase
         self::assertSame('TestMessage', $messages[EmailAddress::INVALID]);
 
         $oldHostname = $this->validator->getHostnameValidator();
-        $this->validator->setOptions(['hostnameValidator' => new Hostname(Hostname::ALLOW_ALL)]);
+        $this->validator->setOptions(['hostnameValidator' => new Hostname(['allow' => Hostname::ALLOW_ALL])]);
         $hostname = $this->validator->getHostnameValidator();
 
         self::assertNotSame($oldHostname, $hostname);

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -46,16 +46,18 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensures that the validator follows expected behavior
+     *
+     * @param  int-mask-of<Hostname::ALLOW_*> $allow
      */
     #[DataProvider('basicDataProvider')]
-    public function testBasic(int $option, bool $expected, string $hostname): void
+    public function testBasic(int $allow, bool $expected, string $hostname): void
     {
-        $validator = new Hostname($option);
+        $validator = new Hostname(['allow' => $allow]);
 
         self::assertSame($expected, $validator->isValid($hostname));
     }
 
-    /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
+    /** @psalm-return array<array-key, array{0: int-mask-of<Hostname::ALLOW_*>, 1: bool, 2: string}> */
     public static function basicDataProvider(): array
     {
         return [
@@ -84,15 +86,16 @@ final class HostnameTest extends TestCase
         ];
     }
 
+    /** @param int-mask-of<Hostname::ALLOW_*> $allow */
     #[DataProvider('combinationDataProvider')]
-    public function testCombination(int $option, bool $expected, string $hostname): void
+    public function testCombination(int $allow, bool $expected, string $hostname): void
     {
-        $validator = new Hostname($option);
+        $validator = new Hostname(['allow' => $allow]);
 
         self::assertSame($expected, $validator->isValid($hostname));
     }
 
-    /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
+    /** @psalm-return array<array-key, array{0: int-mask-of<Hostname::ALLOW_*>, 1: bool, 2: string}> */
     public static function combinationDataProvider(): array
     {
         return [
@@ -110,16 +113,18 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure the dash character tests work as expected
+     *
+     * @param int-mask-of<Hostname::ALLOW_*> $allow
      */
     #[DataProvider('dashesDataProvider')]
-    public function testDashes(int $option, bool $expected, string $hostname): void
+    public function testDashes(int $allow, bool $expected, string $hostname): void
     {
-        $validator = new Hostname($option);
+        $validator = new Hostname(['allow' => $allow]);
 
         self::assertSame($expected, $validator->isValid($hostname));
     }
 
-    /** @psalm-return array<array-key, array{0: int, 1: bool, 2: string}> */
+    /** @psalm-return array<array-key, array{0: int-mask-of<Hostname::ALLOW_*>, 1: bool, 2: string}> */
     public static function dashesDataProvider(): array
     {
         return [
@@ -138,7 +143,7 @@ final class HostnameTest extends TestCase
     #[DataProvider('domainsWithUnderscores')]
     public function testValidatorHandlesUnderscoresInDomainsCorrectly(string $input, bool $expected): void
     {
-        $validator = new Hostname(Hostname::ALLOW_DNS);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_DNS]);
 
         self::assertSame($expected, $validator->isValid($input), implode("\n", $validator->getMessages()));
     }
@@ -215,9 +220,11 @@ final class HostnameTest extends TestCase
     #[DataProvider('idnNoMatchingDataProvider')]
     public function testIdnNoMatching(string $input): void
     {
-        $this->validator->useIdnCheck(false);
+        $validator = new Hostname([
+            'useIdnCheck' => false,
+        ]);
 
-        self::assertFalse($this->validator->isValid($input));
+        self::assertFalse($validator->isValid($input));
     }
 
     /**
@@ -226,7 +233,10 @@ final class HostnameTest extends TestCase
     #[DataProvider('idnNoMatchingDataProvider')]
     public function testIdnNoMatchingOptionConstructor(string $input): void
     {
-        $validator = new Hostname(Hostname::ALLOW_DNS, false);
+        $validator = new Hostname([
+            'allow'       => Hostname::ALLOW_DNS,
+            'useIdnCheck' => false,
+        ]);
 
         self::assertFalse($validator->isValid($input));
     }
@@ -267,9 +277,11 @@ final class HostnameTest extends TestCase
     #[DataProvider('tldNoMatchingDataProvider')]
     public function testTldNoMatching(string $input): void
     {
-        $this->validator->useTldCheck(false);
+        $validator = new Hostname([
+            'useTldCheck' => false,
+        ]);
 
-        self::assertTrue($this->validator->isValid($input));
+        self::assertTrue($validator->isValid($input));
     }
 
     /**
@@ -278,7 +290,10 @@ final class HostnameTest extends TestCase
     #[DataProvider('tldNoMatchingDataProvider')]
     public function testTldNoMatchingOptionConstructor(string $input): void
     {
-        $validator = new Hostname(Hostname::ALLOW_DNS, true, false);
+        $validator = new Hostname([
+            'allow'       => Hostname::ALLOW_DNS,
+            'useTldCheck' => false,
+        ]);
 
         self::assertTrue($validator->isValid($input));
     }
@@ -291,14 +306,6 @@ final class HostnameTest extends TestCase
             ['domain.zz'],
             ['domain.madeup'],
         ];
-    }
-
-    /**
-     * Ensures that getAllow() returns expected default value
-     */
-    public function testGetAllow(): void
-    {
-        self::assertSame(Hostname::ALLOW_DNS, $this->validator->getAllow());
     }
 
     /**
@@ -438,7 +445,7 @@ final class HostnameTest extends TestCase
     #[Group('Laminas-10267')]
     public function testURI(string $input, bool $expected): void
     {
-        $validator = new Hostname(Hostname::ALLOW_URI);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_URI]);
 
         self::assertSame($expected, $validator->isValid($input));
     }
@@ -462,17 +469,19 @@ final class HostnameTest extends TestCase
 
     /**
      * Ensure that a trailing "." in a local hostname is permitted
+     *
+     * @param int-mask-of<Hostname::ALLOW_*> $allow
      */
     #[DataProvider('trailingDotDataProvider')]
     #[Group('Laminas-6363')]
-    public function testTrailingDot(int $option, bool $expected, string $hostname): void
+    public function testTrailingDot(int $allow, bool $expected, string $hostname): void
     {
-        $validator = new Hostname($option);
+        $validator = new Hostname(['allow' => $allow]);
 
         self::assertSame($expected, $validator->isValid($hostname));
     }
 
-    /** @psalm-return array<string, array{0: int, 1: bool, 2: string}> */
+    /** @psalm-return array<string, array{0: int-mask-of<Hostname::ALLOW_*>, 1: bool, 2: string}> */
     public static function trailingDotDataProvider(): array
     {
         return [
@@ -491,7 +500,7 @@ final class HostnameTest extends TestCase
     #[Group('Laminas-11334')]
     public function testSupportsIpv6AddressesWhichContainHexDigitF(): void
     {
-        $validator = new Hostname(Hostname::ALLOW_ALL);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_ALL]);
 
         self::assertTrue($validator->isValid('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210'));
         self::assertTrue($validator->isValid('1080:0:0:0:8:800:200C:417A'));
@@ -508,7 +517,7 @@ final class HostnameTest extends TestCase
     #[Group('Laminas-11751')]
     public function testExtendedGreek(): void
     {
-        $validator = new Hostname(Hostname::ALLOW_ALL);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_ALL]);
 
         self::assertTrue($validator->isValid('ῆὧὰῧῲ.com'));
     }
@@ -529,7 +538,7 @@ final class HostnameTest extends TestCase
     #[Group('Laminas-11796')]
     public function testIDNSI(string $value, bool $expected): void
     {
-        $validator = new Hostname(Hostname::ALLOW_ALL);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_ALL]);
 
         self::assertSame($expected, $validator->isValid($value));
     }
@@ -538,7 +547,7 @@ final class HostnameTest extends TestCase
     #[Group('Issue #5894 - Add .il IDN domain checking; add new TLDs')]
     public function testIDNIL(string $input, bool $expected): void
     {
-        $validator = new Hostname(Hostname::ALLOW_ALL);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_ALL]);
 
         self::assertSame($expected, $validator->isValid($input));
     }
@@ -614,7 +623,7 @@ final class HostnameTest extends TestCase
 
     public function testIDNIT(): void
     {
-        $validator = new Hostname(Hostname::ALLOW_ALL);
+        $validator = new Hostname(['allow' => Hostname::ALLOW_ALL]);
 
         self::assertTrue($validator->isValid('plainascii.it'));
         self::assertTrue($validator->isValid('città-caffè.it'));


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Only allow a well known array shape as options for the constructor
- Add types everywhere
- Replace internal options array with RO props
- Remove option setters and getters