### PR TITLE
Refactor `NotEmpty` validator

### DIFF
--- a/docs/book/v3/validators/not-empty.md
+++ b/docs/book/v3/validators/not-empty.md
@@ -64,17 +64,14 @@ constants, or you can provide a textual string. See the following examples:
 use Laminas\Validator\NotEmpty;
 
 // Returns false on 0
-$validator = new NotEmpty(NotEmpty::INTEGER);
+$validator = new NotEmpty(['type' => NotEmpty::INTEGER]);
 
 // Returns false on 0 or '0'
-$validator = new NotEmpty( NotEmpty::INTEGER | NotEmpty::ZERO);
+$validator = new NotEmpty(['type' => NotEmpty::INTEGER | NotEmpty::ZERO]);
 
 // Returns false on 0 or '0'
-$validator = new NotEmpty([ NotEmpty::INTEGER, NotEmpty::ZERO ]);
+$validator = new NotEmpty(['type' => [ NotEmpty::INTEGER, NotEmpty::ZERO ]]);
 
 // Returns false on 0 or '0'
-$validator = new NotEmpty(['integer', 'zero']);
+$validator = new NotEmpty(['type' => ['integer', 'zero']]);
 ```
-
-You can also provide an instance of `Traversable` to set the desired types. To
-set types after instantiation, use the `setType()` method.

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1132,27 +1132,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/NotEmpty.php">
-    <MixedAssignment>
-      <code><![CDATA[$temp['type']]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['type']]]></code>
-    </MixedReturnStatement>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$type]]></code>
-    </PossiblyNullArgument>
-    <RedundantCondition>
-      <code><![CDATA[is_object($value) && method_exists($value, '__toString') && (string) $value === '']]></code>
-    </RedundantCondition>
-  </file>
   <file src="src/NumberComparison.php">
     <MixedAssignment>
       <code><![CDATA[$inclusiveMax]]></code>
@@ -1780,20 +1759,17 @@
     </UndefinedThisPropertyFetch>
   </file>
   <file src="test/NotEmptyTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA['boolean']]></code>
-      <code><![CDATA['boolean']]></code>
-      <code><![CDATA[true]]></code>
-    </InvalidArgument>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+            'type' => [$string, $string],
+        ]]]></code>
+    </ArgumentTypeCoercion>
     <PossiblyUnusedMethod>
-      <code><![CDATA[arrayConfigNotationProvider]]></code>
       <code><![CDATA[arrayConfigNotationWithoutKeyProvider]]></code>
       <code><![CDATA[arrayConstantNotationProvider]]></code>
       <code><![CDATA[arrayOnlyProvider]]></code>
       <code><![CDATA[basicProvider]]></code>
       <code><![CDATA[booleanProvider]]></code>
-      <code><![CDATA[configObjectProvider]]></code>
       <code><![CDATA[constructorWithTypeArrayProvider]]></code>
       <code><![CDATA[duplicateStringSettingProvider]]></code>
       <code><![CDATA[floatOnlyProvider]]></code>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes all option setters and getters
- Removes duplicate tests
- Adds types
- Only accept an array to the constructor
