### PR TITLE
Remove cyclic dependency workaround

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Temporary workaround for cyclic dependencies - can be removed once 3.0 has been released
-
-echo "Branch as 2.99.x in Pre-Install"
-
-git checkout -b 2.99.x


### PR DESCRIPTION
Now that `i18n` is no longer required in dev, the CI script can be removed

Closes #247 