### PR TITLE
Require `ext-intl`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "ext-intl": "*",
         "laminas/laminas-servicemanager": "^4.1.0",
         "laminas/laminas-stdlib": "^3.13",
         "laminas/laminas-translator": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd63fffe59f6f41b7e195b18b10dc733",
+    "content-hash": "8aaf3958941db97c785a85f7204003f6",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1960,16 +1960,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.24",
+            "version": "10.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015"
+                "reference": "831bf82312be6037e811833ddbea0b8de60ea314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f124e3e3e561006047b532fd0431bf5bb6b9015",
-                "reference": "5f124e3e3e561006047b532fd0431bf5bb6b9015",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/831bf82312be6037e811833ddbea0b8de60ea314",
+                "reference": "831bf82312be6037e811833ddbea0b8de60ea314",
                 "shasum": ""
             },
             "require": {
@@ -2041,7 +2041,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.25"
             },
             "funding": [
                 {
@@ -2057,7 +2057,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-20T13:09:54+00:00"
+            "time": "2024-07-03T05:49:17+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4395,7 +4395,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "ext-intl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/docs/book/v3/validators/email-address.md
+++ b/docs/book/v3/validators/email-address.md
@@ -21,14 +21,12 @@ if ($validator->isValid($email)) {
 }
 ```
 
-This will match the email address `$email` and on failure populate
-`getMessages()` with useful error messages.
+This will match the email address `$email` and on failure populate `getMessages()` with useful error messages.
 
 ## Supported Options
 
-`Laminas\Validator\EmailAddress` supports several options which can either be set
-at instantiation, by giving an array with the related options, or afterwards, by
-using `setOptions()`. The following options are supported:
+`Laminas\Validator\EmailAddress` supports several options which can either be set at instantiation, by giving an array with the related options.
+The following options are supported:
 
 - `allow`: Defines which type of domain names are accepted. This option is used
   in conjunction with the hostnameValidator option to set the hostname validator.
@@ -67,12 +65,12 @@ or a `\\` character in an email address).
 
 If you need `Laminas\Validator\EmailAddress` to check only the local part of an
 email address, and want to disable validation of the hostname, you can set the
-`domain` option to `false`. This forces `Laminas\Validator\EmailAddress` not to
+`useDomainCheck` option to `false`. This forces `Laminas\Validator\EmailAddress` not to
 validate the hostname part of the email address.
 
 ```php
 $validator = new Laminas\Validator\EmailAddress();
-$validator->setOptions(['domain' => FALSE]);
+$validator->setOptions(['useDomainCheck' => false]);
 ```
 
 ## Validating different types of hostnames
@@ -81,16 +79,16 @@ The hostname part of an email address is validated against the [Hostname validat
 By default only DNS hostnames of the form `domain.com` are accepted, though if
 you wish you can accept IP addresses and Local hostnames too.
 
-To do this you need to instantiate `Laminas\Validator\EmailAddress` passing a
-parameter to indicate the type of hostnames you want to accept. More details are
-included in `Laminas\Validator\Hostname`, though an example of how to accept both
-DNS and Local hostnames appears below:
+To do this you need to instantiate `Laminas\Validator\EmailAddress` passing a parameter to indicate the type of hostnames you want to accept.
+More details are included in the `Laminas\Validator\Hostname` [documentation](hostname.md), though an example of how to accept both DNS and Local hostnames appears below:
 
 ```php
 use Laminas\Validator\EmailAddress;
 use Laminas\Validator\Hostname;
 
-$validator = new EmailAddress( Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL);
+$validator = new EmailAddress([
+    'allow' => Hostname::ALLOW_DNS | Hostname::ALLOW_LOCAL 
+]);
 
 if ($validator->isValid($email)) {
     // email appears to be valid
@@ -116,12 +114,9 @@ second parameter to the `Laminas\Validator\EmailAddress` constructor.
 ```php
 $validator = new Laminas\Validator\EmailAddress([
     'allow' => Laminas\Validator\Hostname::ALLOW_DNS,
-    'useMxCheck'    => true,
+    'useMxCheck' => true,
 ]);
 ```
-
-Alternatively you can either pass `true` or `false` to `setValidateMx()` to
-enable or disable MX validation.
 
 By enabling this setting, network functions will be used to check for the
 presence of an MX record on the hostname of the email address you wish to
@@ -132,19 +127,15 @@ accepted. The reason behind this behaviour is, that servers can accept emails
 even if they do not provide a MX record. In this case they can provide `A`,
 `A6`, or `AAAA` records. To allow `Laminas\Validator\EmailAddress` to check also
 for these other records, you need to set deep MX validation. This can be done at
-initiation by setting the `deep` option or by using `setOptions()`.
+initiation by setting the `useDeepMxCheck` option to `true`.
 
 ```php
 $validator = new Laminas\Validator\EmailAddress([
     'allow' => Laminas\Validator\Hostname::ALLOW_DNS,
-    'useMxCheck'    => true,
-    'useDeepMxCheck'  => true,
+    'useMxCheck' => true,
+    'useDeepMxCheck' => true,
 ]);
 ```
-
-Sometimes it can be useful to get the server's MX information which have been
-used to do further processing. Simply use `getMXRecord()` after validation. This
-method returns the received MX record including weight and sorted by it.
 
 > ### Performance warning**
 >
@@ -158,35 +149,57 @@ method returns the received MX record including weight and sorted by it.
 > deep MX validation is enabled, then local IP addresses like `192.168.*` or
 > `169.254.*` are not accepted.
 
+## Controlling Hostname Validation Options
+
+The hostname validator provides a number of options that allow you to define what type of hosts or domains you will accept.
+Generally, providing the `allow` option to the email address validator is sufficient for most needs.
+If you find that you need to use other options specific to the `Hostname` validator, and provide a custom configured `Hostname` validator to the `EmailAddress` validator, it is important to note that the `allow` option will be ignored, therefore it must be passed directly to the `Hostname` validator.
+
+```php
+$validator = new Laminas\Validator\EmailAddress([
+    'allow' => Laminas\Validator\Hostname::ALLOW_DNS, // Ignored because a custom hostname validator is supplied
+    'hostnameValidator' => new Laminas\Validator\Hostname([
+        'allow' => Laminas\Validator\Hostname::ALLOW_ALL, // Used for hostname validation    
+    ]),
+]);
+```
+
 ## Validating International Domains Names
 
 `Laminas\Validator\EmailAddress` will also match international characters that
 exist in some domains. This is known as International Domain Name (IDN) support.
-This is enabled by default, though you can disable this by changing the setting
-via the internal `Laminas\Validator\Hostname` object that exists within
-`Laminas\Validator\EmailAddress`.
+This is enabled by default, though you can disable this by setting
+a custom `Laminas\Validator\Hostname` validator:
 
 ```php
-$validator->getHostnameValidator()->setValidateIdn(false);
+$validator = new Laminas\Validator\EmailAddress([
+    'hostnameValidator' => new Laminas\Validator\Hostname([
+        'allow' => Laminas\Validator\Hostname::ALLOW_DNS,
+        'useIdnCheck' => false,
+    ]),
+]);
 ```
 
-More information on the usage of `setValidateIdn()` appears in the
+More information on the usage of the `useIdnCheck` option appears in the
 [Hostname documentation](hostname.md).
 
 Please note IDNs are only validated if you allow DNS hostnames to be validated.
 
 ## Validating Top Level Domains
 
-By default a hostname will be checked against a list of known TLDs. This is
-enabled by default, though you can disable this by changing the setting via the
-internal `Laminas\Validator\Hostname` object that exists within
-`Laminas\Validator\EmailAddress`.
+By default the email hostname will be checked against a list of known TLDs.
+This is enabled by default, though you can disable this by providing a custom `Laminas\Validator\Hostname` validator:
 
 ```php
-$validator->getHostnameValidator()->setValidateTld(false);
+$validator = new Laminas\Validator\EmailAddress([
+    'hostnameValidator' => new Laminas\Validator\Hostname([
+        'allow' => Laminas\Validator\Hostname::ALLOW_DNS,
+        'useTldCheck' => false,
+    ]),
+]);
 ```
 
-More information on the usage of `setValidateTld()` appears in the
+More information on the usage of the `useTldCheck` option appears in the
 [Hostname documentation](hostname.md).
 
 Please note TLDs are only validated if you allow DNS hostnames to be validated.
@@ -198,8 +211,9 @@ check the hostname part of a given email address. You can specify messages for
 `Laminas\Validator\Hostname` from within `Laminas\Validator\EmailAddress`.
 
 ```php
-$validator = new Laminas\Validator\EmailAddress();
-$validator->setMessages([
-    Laminas\Validator\Hostname::UNKNOWN_TLD => 'I don\'t know the TLD you gave'
+$validator = new Laminas\Validator\EmailAddress([
+    'messages' => [
+        Laminas\Validator\Hostname::UNKNOWN_TLD => 'I don\'t know the TLD you gave'
+    ],
 ]);
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -40,6 +40,9 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$this->abstractOptions]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyUnusedMethod>
+      <code><![CDATA[getOptions]]></code>
+    </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code><![CDATA[$messageKey]]></code>
     </PossiblyUnusedParam>
@@ -172,72 +175,15 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/EmailAddress.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA['']]></code>
-      <code><![CDATA[is_string($value)]]></code>
-    </DocblockTypeContradiction>
     <LessSpecificImplementedReturnType>
       <code><![CDATA[AbstractValidator]]></code>
     </LessSpecificImplementedReturnType>
-    <MixedArgument>
-      <code><![CDATA[$this->getValue()]]></code>
-    </MixedArgument>
     <MixedArrayAssignment>
       <code><![CDATA[$this->abstractOptions['messages'][$code]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment>
-      <code><![CDATA[$temp['allow']]]></code>
-      <code><![CDATA[$temp['hostnameValidator']]]></code>
-      <code><![CDATA[$temp['useMxCheck']]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[Hostname]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[int-mask-of<Hostname::ALLOW_*>]]></code>
-    </MixedInferredReturnType>
-    <MixedMethodCall>
-      <code><![CDATA[setAllow]]></code>
-    </MixedMethodCall>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$this->abstractOptions]]></code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['allow']]]></code>
-      <code><![CDATA[$this->options['hostnameValidator']]]></code>
-      <code><![CDATA[$this->options['hostnameValidator']]]></code>
-      <code><![CDATA[$this->options['useDeepMxCheck']]]></code>
-      <code><![CDATA[$this->options['useDomainCheck']]]></code>
-      <code><![CDATA[$this->options['useMxCheck']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[idnToUtf8]]></code>
-      <code><![CDATA[setAllow]]></code>
-      <code><![CDATA[useDeepMxCheck]]></code>
-    </PossiblyUnusedMethod>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$hostname]]></code>
-      <code><![CDATA[$localPart]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $deep]]></code>
-      <code><![CDATA[(bool) $domain]]></code>
-      <code><![CDATA[(bool) $mx]]></code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[array_combine($mxHosts, $weight)]]></code>
-      <code><![CDATA[is_string($value)]]></code>
-    </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
       <code><![CDATA[false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')]]></code>
     </TypeDoesNotContainType>
@@ -1159,32 +1105,26 @@
   </file>
   <file src="test/EmailAddressTest.php">
     <InvalidArgument>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_ALL]]></code>
-      <code><![CDATA[Hostname::ALLOW_DNS | Hostname::ALLOW_IP]]></code>
-      <code><![CDATA[[$this, 'errorHandler']]]></code>
-      <code><![CDATA[[1 => 1]]]></code>
+      <code><![CDATA[[
+            'hostnameValidator' => $hostnameValidator,
+            'translator'        => new Translator($translations),
+        ]]]></code>
+      <code><![CDATA[[
+            'message'           => 'TestMessage',
+            'hostnameValidator' => $hostname,
+        ]]]></code>
+      <code><![CDATA[['messages' => [EmailAddress::INVALID => 'TestMessage']]]]></code>
     </InvalidArgument>
-    <InvalidCast>
-      <code><![CDATA[[1 => 1]]]></code>
-    </InvalidCast>
     <PossiblyUnusedMethod>
       <code><![CDATA[emailAddressesForMxChecks]]></code>
       <code><![CDATA[errorHandler]]></code>
       <code><![CDATA[invalidEmailAddresses]]></code>
       <code><![CDATA[validEmailAddresses]]></code>
     </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[assertIsArray]]></code>
-    </RedundantConditionGivenDocblockType>
     <UnusedParam>
       <code><![CDATA[$errno]]></code>
       <code><![CDATA[$errstr]]></code>
     </UnusedParam>
-    <UnusedPsalmSuppress>
-      <code><![CDATA[TooManyArguments]]></code>
-    </UnusedPsalmSuppress>
   </file>
   <file src="test/File/CountTest.php">
     <MixedArgument>

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -11,7 +11,6 @@ use function array_flip;
 use function array_keys;
 use function arsort;
 use function checkdnsrr;
-use function extension_loaded;
 use function gethostbynamel;
 use function getmxrr;
 use function idn_to_ascii;
@@ -185,10 +184,7 @@ final class EmailAddress extends AbstractValidator
      */
     protected function validateInternationalizedLocalPart(string $localPart): bool
     {
-        if (
-            extension_loaded('intl')
-            && false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')
-        ) {
+        if (UConverter::transcode($localPart, 'UTF-8', 'UTF-8') === false) {
             // invalid utf?
             return false;
         }
@@ -364,12 +360,8 @@ final class EmailAddress extends AbstractValidator
      */
     private static function idnToAscii(string $hostname): string
     {
-        if (extension_loaded('intl')) {
-            $value = idn_to_ascii($hostname, 0, INTL_IDNA_VARIANT_UTS46);
+        $value = idn_to_ascii($hostname, 0, INTL_IDNA_VARIANT_UTS46);
 
-            return $value !== false ? $value : $hostname;
-        }
-
-        return $hostname;
+        return $value !== false ? $value : $hostname;
     }
 }

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -4,23 +4,17 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Traversable;
 use UConverter;
 
 use function array_combine;
 use function array_flip;
 use function array_keys;
-use function array_shift;
 use function arsort;
 use function checkdnsrr;
-use function defined;
 use function extension_loaded;
-use function func_get_args;
-use function function_exists;
 use function gethostbynamel;
 use function getmxrr;
 use function idn_to_ascii;
-use function idn_to_utf8;
 use function is_array;
 use function is_string;
 use function preg_match;
@@ -75,32 +69,14 @@ final class EmailAddress extends AbstractValidator
         'localPart' => 'localPart',
     ];
 
-    /** @var string */
-    protected $hostname;
+    protected ?string $hostname  = null;
+    protected ?string $localPart = null;
 
-    /** @var string */
-    protected $localPart;
-
-    /**
-     * Returns the found mx record information
-     *
-     * @var array
-     */
-    protected $mxRecord = [];
-
-    /**
-     * Internal options array
-     *
-     * @var Options
-     */
-    protected $options = [
-        'useMxCheck'        => false,
-        'useDeepMxCheck'    => false,
-        'useDomainCheck'    => true,
-        'allow'             => Hostname::ALLOW_DNS,
-        'strict'            => true,
-        'hostnameValidator' => null,
-    ];
+    private readonly Hostname $hostnameValidator;
+    private readonly bool $useMxCheck;
+    private readonly bool $useDeepMxCheck;
+    private readonly bool $useDomainCheck;
+    private readonly bool $strict;
 
     /**
      * Instantiates hostname validator for local use
@@ -112,23 +88,25 @@ final class EmailAddress extends AbstractValidator
      * 'useMxCheck'        => If MX check should be enabled, boolean
      * 'useDeepMxCheck'    => If a deep MX check should be done, boolean
      *
-     * @param array|Traversable $options OPTIONAL
+     * @param Options $options
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        if (! is_array($options)) {
-            $options       = func_get_args();
-            $temp['allow'] = array_shift($options);
-            if (! empty($options)) {
-                $temp['useMxCheck'] = array_shift($options);
-            }
+        $allow                   = $options['allow'] ?? Hostname::ALLOW_DNS;
+        $this->hostnameValidator = $options['hostnameValidator'] ?? new Hostname(['allow' => $allow]);
+        $this->useMxCheck        = $options['useMxCheck'] ?? false;
+        $this->useDeepMxCheck    = $options['useDeepMxCheck'] ?? false;
+        $this->useDomainCheck    = $options['useDomainCheck'] ?? true;
+        $this->strict            = $options['strict'] ?? true;
 
-            if (! empty($options)) {
-                $temp['hostnameValidator'] = array_shift($options);
-            }
-
-            $options = $temp;
-        }
+        unset(
+            $options['allow'],
+            $options['hostnameValidator'],
+            $options['useMxCheck'],
+            $options['useDeepMxCheck'],
+            $options['useDomainCheck'],
+            $options['strict'],
+        );
 
         parent::__construct($options);
     }
@@ -144,13 +122,13 @@ final class EmailAddress extends AbstractValidator
     public function setMessage($messageString, $messageKey = null)
     {
         if ($messageKey === null) {
-            $this->getHostnameValidator()->setMessage($messageString);
+            $this->hostnameValidator->setMessage($messageString);
             parent::setMessage($messageString);
             return $this;
         }
 
         if (! isset($this->messageTemplates[$messageKey])) {
-            $this->getHostnameValidator()->setMessage($messageString, $messageKey);
+            $this->hostnameValidator->setMessage($messageString, $messageKey);
         } else {
             parent::setMessage($messageString, $messageKey);
         }
@@ -159,144 +137,9 @@ final class EmailAddress extends AbstractValidator
     }
 
     /**
-     * Returns the set hostname validator
-     *
-     * If was not previously set then lazy load a new one
-     *
-     * @return Hostname
-     */
-    public function getHostnameValidator()
-    {
-        if (! isset($this->options['hostnameValidator'])) {
-            $this->options['hostnameValidator'] = new Hostname(['allow' => $this->getAllow()]);
-        }
-
-        return $this->options['hostnameValidator'];
-    }
-
-    /**
-     * @param Hostname $hostnameValidator OPTIONAL
-     * @return $this Provides a fluent interface
-     */
-    public function setHostnameValidator(?Hostname $hostnameValidator = null)
-    {
-        $this->options['hostnameValidator'] = $hostnameValidator;
-
-        return $this;
-    }
-
-    /**
-     * Returns the allow option of the attached hostname validator
-     *
-     * @return int-mask-of<Hostname::ALLOW_*>
-     */
-    public function getAllow()
-    {
-        return $this->options['allow'];
-    }
-
-    /**
-     * Sets the allow option of the hostname validator to use
-     *
-     * @param int-mask-of<Hostname::ALLOW_*> $allow
-     * @return $this Provides a fluent interface
-     */
-    public function setAllow($allow)
-    {
-        $this->options['allow'] = $allow;
-        if (isset($this->options['hostnameValidator'])) {
-            $this->options['hostnameValidator']->setAllow($allow);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Whether MX checking via getmxrr is supported or not
-     *
-     * @return bool
-     */
-    public function isMxSupported()
-    {
-        return function_exists('getmxrr');
-    }
-
-    /**
-     * Returns the set validateMx option
-     *
-     * @return bool
-     */
-    public function getMxCheck()
-    {
-        return $this->options['useMxCheck'];
-    }
-
-    /**
-     * Set whether we check for a valid MX record via DNS
-     *
-     * This only applies when DNS hostnames are validated
-     *
-     * @param  bool $mx Set allowed to true to validate for MX records, and false to not validate them
-     * @return $this Fluid Interface
-     */
-    public function useMxCheck($mx)
-    {
-        $this->options['useMxCheck'] = (bool) $mx;
-        return $this;
-    }
-
-    /**
-     * Returns the set deepMxCheck option
-     *
-     * @return bool
-     */
-    public function getDeepMxCheck()
-    {
-        return $this->options['useDeepMxCheck'];
-    }
-
-    /**
-     * Use deep validation for MX records
-     *
-     * @param  bool $deep Set deep to true to perform a deep validation process for MX records
-     * @return $this Fluid Interface
-     */
-    public function useDeepMxCheck($deep)
-    {
-        $this->options['useDeepMxCheck'] = (bool) $deep;
-        return $this;
-    }
-
-    /**
-     * Returns the set domainCheck option
-     *
-     * @return bool
-     */
-    public function getDomainCheck()
-    {
-        return $this->options['useDomainCheck'];
-    }
-
-    /**
-     * Sets if the domain should also be checked
-     * or only the local part of the email address
-     *
-     * @param  bool $domain
-     * @return $this Fluid Interface
-     */
-    public function useDomainCheck($domain = true)
-    {
-        $this->options['useDomainCheck'] = (bool) $domain;
-        return $this;
-    }
-
-    /**
      * Returns whether the given host is a reserved IP, or a hostname that resolves to a reserved IP
-     *
-     * @param string $host
-     * @return bool Returns false when minimal one of the given addresses is not reserved
      */
-    protected function isReserved($host)
+    private function isReserved(string $host): bool
     {
         $validator = new HostWithPublicIPv4Address();
         return ! $validator->isValid($host);
@@ -304,10 +147,8 @@ final class EmailAddress extends AbstractValidator
 
     /**
      * Internal method to validate the local part of the email address
-     *
-     * @return bool
      */
-    protected function validateLocalPart()
+    private function validateLocalPart(string $localPart): bool
     {
         // First try to match the local part on the common dot-atom format
 
@@ -315,11 +156,11 @@ final class EmailAddress extends AbstractValidator
         // atext: ALPHA / DIGIT / and "!", "#", "$", "%", "&", "'", "*",
         //        "+", "-", "/", "=", "?", "^", "_", "`", "{", "|", "}", "~"
         $atext = 'a-zA-Z0-9\x21\x23\x24\x25\x26\x27\x2a\x2b\x2d\x2f\x3d\x3f\x5e\x5f\x60\x7b\x7c\x7d\x7e';
-        if (preg_match('/^[' . $atext . ']+(\x2e+[' . $atext . ']+)*$/', $this->localPart)) {
+        if (preg_match('/^[' . $atext . ']+(\x2e+[' . $atext . ']+)*$/', $localPart)) {
             return true;
         }
 
-        if ($this->validateInternationalizedLocalPart($this->localPart)) {
+        if ($this->validateInternationalizedLocalPart($localPart)) {
             return true;
         }
 
@@ -328,7 +169,7 @@ final class EmailAddress extends AbstractValidator
         // Quoted-string characters are: DQUOTE *(qtext/quoted-pair) DQUOTE
         $qtext      = '\x20-\x21\x23-\x5b\x5d-\x7e'; // %d32-33 / %d35-91 / %d93-126
         $quotedPair = '\x20-\x7e'; // %d92 %d32-126
-        if (preg_match('/^"([' . $qtext . ']|\x5c[' . $quotedPair . '])*"$/', $this->localPart)) {
+        if (preg_match('/^"([' . $qtext . ']|\x5c[' . $quotedPair . '])*"$/', $localPart)) {
             return true;
         }
 
@@ -341,9 +182,8 @@ final class EmailAddress extends AbstractValidator
 
     /**
      * @param string $localPart Address local part to validate.
-     * @return bool
      */
-    protected function validateInternationalizedLocalPart($localPart)
+    protected function validateInternationalizedLocalPart(string $localPart): bool
     {
         if (
             extension_loaded('intl')
@@ -361,39 +201,25 @@ final class EmailAddress extends AbstractValidator
     }
 
     /**
-     * Returns the found MX Record information after validation including weight for further processing
-     *
-     * @return array
-     */
-    public function getMXRecord()
-    {
-        return $this->mxRecord;
-    }
-
-    /**
      * Internal method to validate the servers MX records
-     *
-     * @return bool|string[]
-     * @psalm-return bool|list<string>
      */
-    protected function validateMXRecords()
+    protected function validateMXRecords(string $hostname): bool
     {
-        $mxHosts = [];
-        $weight  = [];
-        $result  = getmxrr($this->hostname, $mxHosts, $weight);
-        if (! empty($mxHosts) && ! empty($weight)) {
-            $this->mxRecord = array_combine($mxHosts, $weight) ?: [];
-        } else {
-            $this->mxRecord = [];
-        }
+        $mxHosts  = [];
+        $weight   = [];
+        $mxRecord = [];
+        $result   = getmxrr($hostname, $mxHosts, $weight);
 
-        arsort($this->mxRecord);
+        if ($result) {
+            $mxRecord = array_combine($mxHosts, $weight) ?: [];
+            arsort($mxRecord);
+        }
 
         // Fallback to IPv4 hosts if no MX record found (RFC 2821 SS 5).
         if (! $result) {
-            $result = gethostbynamel($this->hostname);
+            $result = gethostbynamel($hostname);
             if (is_array($result)) {
-                $this->mxRecord = array_flip($result);
+                $mxRecord = array_flip($result);
             }
         }
 
@@ -402,27 +228,27 @@ final class EmailAddress extends AbstractValidator
             return false;
         }
 
-        if (! $this->options['useDeepMxCheck']) {
-            return $result;
+        if (! $this->useDeepMxCheck) {
+            return true;
         }
 
         $validAddress = false;
         $reserved     = true;
-        foreach (array_keys($this->mxRecord) as $hostname) {
-            $res = $this->isReserved($hostname);
+        foreach (array_keys($mxRecord) as $mxHost) {
+            $res = $this->isReserved($mxHost);
             if (! $res) {
                 $reserved = false;
             }
 
-            if (trim($hostname) === '') {
+            if (trim($mxHost) === '') {
                 continue;
             }
 
             if (
                 ! $res
-                && (checkdnsrr($hostname, 'A')
-                || checkdnsrr($hostname, 'AAAA')
-                || checkdnsrr($hostname, 'A6'))
+                && (checkdnsrr($mxHost, 'A')
+                || checkdnsrr($mxHost, 'AAAA')
+                || checkdnsrr($mxHost, 'A6'))
             ) {
                 $validAddress = true;
                 break;
@@ -430,34 +256,33 @@ final class EmailAddress extends AbstractValidator
         }
 
         if (! $validAddress) {
-            $result = false;
-            $error  = $reserved ? self::INVALID_SEGMENT : self::INVALID_MX_RECORD;
+            $error = $reserved ? self::INVALID_SEGMENT : self::INVALID_MX_RECORD;
             $this->error($error);
+
+            return false;
         }
 
-        return $result;
+        return true;
     }
 
     /**
      * Internal method to validate the hostname part of the email address
-     *
-     * @return bool|string[]
-     * @psalm-return bool|list<string>
      */
-    protected function validateHostnamePart()
+    private function validateHostnamePart(string $hostname): bool
     {
-        $hostname = $this->getHostnameValidator();
-        $hostname->setTranslator($this->getTranslator());
-        $isValid = $hostname->isValid($this->hostname);
+        $this->hostnameValidator->setTranslator($this->getTranslator());
+        $isValid = $this->hostnameValidator->isValid($hostname);
         if (! $isValid) {
             $this->error(self::INVALID_HOSTNAME);
             // Get messages and errors from hostnameValidator
-            foreach ($hostname->getMessages() as $code => $message) {
+            foreach ($this->hostnameValidator->getMessages() as $code => $message) {
                 $this->abstractOptions['messages'][$code] = $message;
             }
-        } elseif ($this->options['useMxCheck']) {
+
+            return false;
+        } elseif ($this->useMxCheck) {
             // MX check on hostname
-            $isValid = $this->validateMXRecords();
+            $isValid = $this->validateMXRecords($hostname);
         }
 
         return $isValid;
@@ -466,13 +291,10 @@ final class EmailAddress extends AbstractValidator
     /**
      * Splits the given value in hostname and local part of the email address
      *
-     * @param string $value Email address to be split
-     * @return bool Returns false when the email can not be split
+     * @return array{localPart: string, hostname: string}|false Returns false when the email can not be split
      */
-    protected function splitEmailParts($value)
+    private static function splitEmailParts(string $value): array|false
     {
-        $value = is_string($value) ? $value : '';
-
         // Split email address up and disallow '..'
         if (
             str_contains($value, '..')
@@ -481,10 +303,10 @@ final class EmailAddress extends AbstractValidator
             return false;
         }
 
-        $this->localPart = $matches[1];
-        $this->hostname  = $this->idnToAscii($matches[2]);
-
-        return true;
+        return [
+            'localPart' => $matches[1],
+            'hostname'  => self::idnToAscii($matches[2]),
+        ];
     }
 
     /**
@@ -495,8 +317,6 @@ final class EmailAddress extends AbstractValidator
      *
      * @link   http://www.ietf.org/rfc/rfc2822.txt RFC2822
      * @link   http://www.columbia.edu/kermit/ascii.html US-ASCII characters
-     *
-     * @param  string $value
      */
     public function isValid(mixed $value): bool
     {
@@ -509,77 +329,47 @@ final class EmailAddress extends AbstractValidator
         $this->setValue($value);
 
         // Split email address up and disallow '..'
-        if (! $this->splitEmailParts($this->getValue())) {
+        $split = $this->splitEmailParts($value);
+        if ($split === false) {
             $this->error(self::INVALID_FORMAT);
             return false;
         }
 
-        if ($this->getOption('strict') && (strlen($this->localPart) > 64) || (strlen($this->hostname) > 255)) {
+        ['localPart' => $localPart, 'hostname' => $hostname] = $split;
+
+        $this->localPart = $localPart;
+        $this->hostname  = $hostname;
+
+        if ($this->strict && (strlen($localPart) > 64) || (strlen($hostname) > 255)) {
             $length = false;
             $this->error(self::LENGTH_EXCEEDED);
         }
 
         // Match hostname part
-        $hostname = false;
-        if ($this->options['useDomainCheck']) {
-            $hostname = $this->validateHostnamePart();
+        $hostnameValid = false;
+        if ($this->useDomainCheck) {
+            $hostnameValid = $this->validateHostnamePart($hostname);
         }
 
-        $local = $this->validateLocalPart();
+        $local = $this->validateLocalPart($localPart);
 
         // If both parts valid, return true
-        return ($local && $length) && (! $this->options['useDomainCheck'] || $hostname !== false);
+        return ($local && $length) && (! $this->useDomainCheck || $hostnameValid !== false);
     }
 
     /**
      * Safely convert UTF-8 encoded domain name to ASCII
      *
-     * @param string $email  the UTF-8 encoded email
-     * @return string
+     * @param string $hostname the UTF-8 encoded email
      */
-    protected function idnToAscii($email)
+    private static function idnToAscii(string $hostname): string
     {
         if (extension_loaded('intl')) {
-            if (defined('INTL_IDNA_VARIANT_UTS46')) {
-                $value = idn_to_ascii($email, 0, INTL_IDNA_VARIANT_UTS46);
+            $value = idn_to_ascii($hostname, 0, INTL_IDNA_VARIANT_UTS46);
 
-                return $value !== false ? $value : $email;
-            }
-            $value = idn_to_ascii($email);
-
-            return $value !== false ? $value : $email;
-        }
-        return $email;
-    }
-
-    /**
-     * Safely convert ASCII encoded domain name to UTF-8
-     *
-     * @param string $email the ASCII encoded email
-     * @return string
-     */
-    protected function idnToUtf8($email)
-    {
-        if (strlen($email) === 0) {
-            return $email;
+            return $value !== false ? $value : $hostname;
         }
 
-        if (extension_loaded('intl')) {
-            // The documentation does not clarify what kind of failure
-            // can happen in idn_to_utf8. One can assume if the source
-            // is not IDN encoded, it would fail, but it usually returns
-            // the source string in those cases.
-            // But not when the source string is long enough.
-            // Thus we default to source string ourselves.
-            if (defined('INTL_IDNA_VARIANT_UTS46')) {
-                $value = idn_to_utf8($email, 0, INTL_IDNA_VARIANT_UTS46);
-
-                return $value !== false ? $value : $email;
-            }
-            $value = idn_to_utf8($email);
-
-            return $value !== false ? $value : $email;
-        }
-        return $email;
+        return $hostname;
     }
 }


### PR DESCRIPTION
### Description

The email address validator relies on `ext-intl` for important parts of its job.

Also, the script that updates TLDs for the Hostname validator needs `idn_to_utf8`

This patch requires it and removes the `extension_loaded` calls

Cut from #324 