### PR TITLE
`CreditCard` validator deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -545,6 +545,14 @@
     </DeprecatedClass>
   </file>
   <file src="src/CreditCard.php">
+    <DeprecatedMethod>
+      <code><![CDATA[addType]]></code>
+      <code><![CDATA[getService]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[setService]]></code>
+      <code><![CDATA[setType]]></code>
+    </DeprecatedMethod>
     <InvalidOperand>
       <code><![CDATA[$value[$i]]]></code>
     </InvalidOperand>
@@ -2478,6 +2486,26 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/CreditCardTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[addType]]></code>
+      <code><![CDATA[addType]]></code>
+      <code><![CDATA[getService]]></code>
+      <code><![CDATA[getService]]></code>
+      <code><![CDATA[getService]]></code>
+      <code><![CDATA[getService]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[setService]]></code>
+      <code><![CDATA[setService]]></code>
+      <code><![CDATA[setType]]></code>
+      <code><![CDATA[setType]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[[self::class, 'nocallback']]]></code>
     </InvalidArgument>

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -279,6 +279,8 @@ class CreditCard extends AbstractValidator
     /**
      * Returns a list of accepted CCIs
      *
+     * @deprecated Since 2.61.0 - All getters and setters will be removed in 3.0
+     *
      * @return array
      */
     public function getType()
@@ -289,7 +291,9 @@ class CreditCard extends AbstractValidator
     /**
      * Sets CCIs which are accepted by validation
      *
-     * @param  string|array $type Type to allow for validation
+     * @deprecated Since 2.61.0 - All getters and setters will be removed in 3.0
+     *
+     * @param string|array $type Type to allow for validation
      * @return CreditCard Provides a fluid interface
      */
     public function setType($type)
@@ -300,6 +304,8 @@ class CreditCard extends AbstractValidator
 
     /**
      * Adds a CCI to be accepted by validation
+     *
+     * @deprecated Since 2.61.0 - All getters and setters will be removed in 3.0
      *
      * @param  string|array $type Type to allow for validation
      * @return $this Provides a fluid interface
@@ -333,6 +339,8 @@ class CreditCard extends AbstractValidator
     /**
      * Returns the actual set service
      *
+     * @deprecated Since 2.61.0 - All getters and setters will be removed in 3.0
+     *
      * @return callable
      */
     public function getService()
@@ -343,7 +351,9 @@ class CreditCard extends AbstractValidator
     /**
      * Sets a new callback for service validation
      *
-     * @param  callable $service
+     * @deprecated Since 2.61.0 - All getters and setters will be removed in 3.0
+     *
+     * @param callable $service
      * @return $this
      * @throws InvalidArgumentException On invalid service callback.
      */


### PR DESCRIPTION
Deprecates all option getters and setters

See #327 