### PR TITLE
Fix TLD updater script

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
-  <file src="bin/update_hostname_validator.php">
-    <MissingClosureParamType>
-      <code><![CDATA[$domain]]></code>
-      <code><![CDATA[$encode]]></code>
-    </MissingClosureParamType>
-    <MissingClosureReturnType>
-      <code><![CDATA[function ($encode) use ($hostnameValidator, $decodePunyCode) {]]></code>
-    </MissingClosureReturnType>
-    <MixedArgument>
-      <code><![CDATA[$decodePunycode(strtolower($line))]]></code>
-      <code><![CDATA[$domain]]></code>
-      <code><![CDATA[$encode]]></code>
-      <code><![CDATA[$encode]]></code>
-    </MixedArgument>
-  </file>
   <file src="src/AbstractValidator.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| QA            | yes

### Description

In #298 the `$validTlds` property declaration was changed but the regex in the script was not.

This patch also removes the check for `ext-intl` which is already available in CI, and instead outputs an error when not available. This has the side effect of 100% type coverage.

Also relevant: #325 
