### PR TITLE
Refactor `Date` and `DateStep` Validators

### DIFF
--- a/docs/book/v3/validators/date.md
+++ b/docs/book/v3/validators/date.md
@@ -7,7 +7,7 @@
 The following options are supported for `Laminas\Validator\Date`:
 
 - `format`: Sets the format which is used to write the date.
-- `locale`: Sets the locale which will be used to validate date values.
+- `strict`: Ensures that string input exactly matches the generated date when formatted
 
 ## Default date validation
 
@@ -36,14 +36,12 @@ $validator->isValid('May');  // returns false
 
 ## Strict mode
 
-- **Since 2.13.0**
-
 By default, `Laminas\Validator\Date` only validates that it can convert the
 provided value to a valid `DateTime` value.
 
 If you want to require that the date is specified in a specific format, you can
 provide both the [date format](#specifying-a-date-format) and the `strict`
-options. In such a scenario, the value must both be covertable to a `DateTime`
+options. In such a scenario, the value must both be convertable to a `DateTime`
 value **and** be in the same format as provided to the validator. (Generally,
 this will mean the value must be a string.)
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -37,6 +37,7 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -84,43 +85,11 @@
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$temp['format']]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
   </file>
   <file src="src/DateStep.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$intervalParts]]></code>
     </ArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$temp['baseValue']]]></code>
-      <code><![CDATA[$temp['format']]]></code>
-      <code><![CDATA[$temp['step']]]></code>
-      <code><![CDATA[$temp['timezone']]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setStep]]></code>
-    </PossiblyUnusedMethod>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$step]]></code>
-      <code><![CDATA[$timezone]]></code>
-    </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType>
-      <code><![CDATA[$baseDate instanceof DateTimeImmutable]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/EmailAddress.php">
     <LessSpecificImplementedReturnType>
@@ -133,7 +102,7 @@
       <code><![CDATA[$this->abstractOptions]]></code>
     </MixedPropertyTypeCoercion>
     <TypeDoesNotContainType>
-      <code><![CDATA[false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')]]></code>
+      <code><![CDATA[UConverter::transcode($localPart, 'UTF-8', 'UTF-8') === false]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Exception/BadMethodCallException.php">
@@ -1035,6 +1004,7 @@
   <file src="test/DateTest.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[datesDataProvider]]></code>
+      <code><![CDATA[manualFormatProvider]]></code>
     </PossiblyUnusedMethod>
     <UnusedParam>
       <code><![CDATA[$result]]></code>

--- a/src/Date.php
+++ b/src/Date.php
@@ -7,27 +7,23 @@ namespace Laminas\Validator;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Traversable;
 
-use function array_shift;
-use function func_get_args;
 use function gettype;
 use function implode;
-use function is_array;
-use function iterator_to_array;
 
 /**
- * Validates that a given value is a DateTime instance or can be converted into one.
+ * Validates that a given value is a DateTimeInterface instance or can be converted into one.
+ *
+ * @psalm-type OptionsArgument = array{
+ *     format?: string|null,
+ *     strict?: bool,
+ * }
  */
 class Date extends AbstractValidator
 {
-    /**#@+
-     * Validity constants
-     */
     public const INVALID      = 'dateInvalid';
     public const INVALID_DATE = 'dateInvalidDate';
     public const FALSEFORMAT  = 'dateFalseFormat';
-    /**#@-*/
 
     /**
      * Default format constant
@@ -50,83 +46,38 @@ class Date extends AbstractValidator
         'format' => 'format',
     ];
 
-    /** @var string */
-    protected $format = self::FORMAT_DEFAULT;
-
-    /** @var bool */
-    protected $strict = false;
+    protected readonly string $format;
+    protected readonly bool $strict;
 
     /**
      * Sets validator options
      *
-     * @param string|array|Traversable $options OPTIONAL
+     * @param OptionsArgument $options
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        if ($options instanceof Traversable) {
-            $options = iterator_to_array($options);
-        } elseif (! is_array($options)) {
-            $options        = func_get_args();
-            $temp['format'] = array_shift($options);
-            $options        = $temp;
-        }
+        $this->format = $options['format'] ?? self::FORMAT_DEFAULT;
+        $this->strict = $options['strict'] ?? false;
+
+        unset($options['format'], $options['strict']);
 
         parent::__construct($options);
     }
 
     /**
-     * Returns the format option
-     *
-     * @return string
-     */
-    public function getFormat()
-    {
-        return $this->format;
-    }
-
-    /**
-     * Sets the format option
-     *
-     * Format cannot be null.  It will always default to 'Y-m-d', even
-     * if null is provided.
-     *
-     * @param string|null $format
-     * @return $this provides a fluent interface
-     * @todo   validate the format
-     */
-    public function setFormat($format = self::FORMAT_DEFAULT)
-    {
-        $this->format = $format === null || $format === '' ? self::FORMAT_DEFAULT : $format;
-        return $this;
-    }
-
-    public function setStrict(bool $strict): self
-    {
-        $this->strict = $strict;
-        return $this;
-    }
-
-    public function isStrict(): bool
-    {
-        return $this->strict;
-    }
-
-    /**
      * Returns true if $value is a DateTimeInterface instance or can be converted into one.
-     *
-     * @param  string|numeric|array|DateTimeInterface $value
      */
     public function isValid(mixed $value): bool
     {
         $this->setValue($value);
 
         $date = $this->convertToDateTime($value);
-        if (! $date) {
+        if (! $date instanceof DateTimeInterface) {
             $this->error(self::INVALID_DATE);
             return false;
         }
 
-        if ($this->isStrict() && $date->format($this->getFormat()) !== $value) {
+        if ($this->strict && $date->format($this->format) !== $value) {
             $this->error(self::FALSEFORMAT);
             return false;
         }
@@ -136,19 +87,11 @@ class Date extends AbstractValidator
 
     /**
      * Attempts to convert an int, string, or array to a DateTime object
-     *
-     * @param string|numeric|array|DateTimeInterface $param
-     * @param bool $addErrors
-     * @return false|DateTime
      */
-    protected function convertToDateTime($param, $addErrors = true)
+    protected function convertToDateTime(mixed $param, bool $addErrors = true): DateTimeInterface|false
     {
-        if ($param instanceof DateTime) {
+        if ($param instanceof DateTimeInterface) {
             return $param;
-        }
-
-        if ($param instanceof DateTimeImmutable) {
-            return DateTime::createFromImmutable($param);
         }
 
         $type = gettype($param);
@@ -156,9 +99,8 @@ class Date extends AbstractValidator
             case 'string':
                 return $this->convertString($param, $addErrors);
             case 'integer':
-                return $this->convertInteger($param);
             case 'double':
-                return $this->convertDouble($param);
+                return $this->convertNumeric($param, $addErrors);
             case 'array':
                 return $this->convertArray($param, $addErrors);
         }
@@ -172,36 +114,23 @@ class Date extends AbstractValidator
 
     /**
      * Attempts to convert an integer into a DateTime object
-     *
-     * @param integer $value
-     * @return false|DateTime
      */
-    protected function convertInteger($value)
+    private function convertNumeric(int|float $value, bool $addErrors = true): DateTimeImmutable|false
     {
-        return DateTime::createFromFormat('U', (string) $value);
-    }
+        $date = DateTimeImmutable::createFromFormat('U', (string) $value);
+        if ($date === false && $addErrors) {
+            $this->error(self::INVALID_DATE);
+        }
 
-    /**
-     * Attempts to convert an double into a DateTime object
-     *
-     * @param double $value
-     * @return false|DateTime
-     */
-    protected function convertDouble($value)
-    {
-        return DateTime::createFromFormat('U', (string) $value);
+        return $date;
     }
 
     /**
      * Attempts to convert a string into a DateTime object
-     *
-     * @param string $value
-     * @param bool $addErrors
-     * @return false|DateTime
      */
-    protected function convertString($value, $addErrors = true)
+    protected function convertString(string $value, bool $addErrors = true): DateTimeImmutable|false
     {
-        $date = DateTime::createFromFormat($this->format, $value);
+        $date = DateTimeImmutable::createFromFormat($this->format, $value);
 
         // Invalid dates can show up as warnings (ie. "2007-02-99")
         // and still return a DateTime object.
@@ -222,12 +151,8 @@ class Date extends AbstractValidator
 
     /**
      * Implodes the array into a string and proxies to {@link convertString()}.
-     *
-     * @param bool $addErrors
-     * @return false|DateTime
-     * @todo   enhance the implosion
      */
-    protected function convertArray(array $value, $addErrors = true)
+    private function convertArray(array $value, bool $addErrors = true): DateTimeImmutable|false
     {
         return $this->convertString(implode('-', $value), $addErrors);
     }

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -46,7 +46,7 @@ final class DateStep extends Date
     /**
      * Default format constant
      */
-    public const FORMAT_DEFAULT = DateTime::ISO8601;
+    public const FORMAT_DEFAULT = DateTimeInterface::ATOM;
 
     /**
      * Validation failure message template definitions

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -9,20 +9,17 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use Laminas\Stdlib\ArrayUtils;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_combine;
 use function array_count_values;
 use function array_map;
-use function array_shift;
 use function ceil;
-use function date_default_timezone_get;
 use function explode;
 use function floor;
-use function func_get_args;
 use function in_array;
 use function is_array;
+use function is_string;
 use function max;
 use function min;
 use function preg_match;
@@ -31,6 +28,14 @@ use function str_starts_with;
 
 use const PHP_INT_MAX;
 
+/**
+ * @psalm-type OptionsArgument = array{
+ *     format?: string|null,
+ *     strict?: bool,
+ *     baseValue?: string|DateTimeInterface,
+ *     step?: string|DateInterval,
+ * }
+ */
 final class DateStep extends Date
 {
     /**
@@ -57,147 +62,67 @@ final class DateStep extends Date
 
     /**
      * Optional base date value
-     *
-     * @var string|int|DateTimeInterface
      */
-    protected $baseValue = '1970-01-01T00:00:00Z';
-
+    protected readonly DateTimeInterface $baseValue;
     /**
      * Date step interval (defaults to 1 day).
      * Uses the DateInterval specification.
-     *
-     * @var DateInterval
      */
-    protected $step;
-
-    /**
-     * Optional timezone to be used when the baseValue
-     * and validation values do not contain timezone info
-     *
-     * @var DateTimeZone
-     */
-    protected $timezone;
+    protected readonly DateInterval $step;
 
     /**
      * Set default options for this instance
      *
-     * @param string|array|Traversable $options
+     * @param OptionsArgument $options
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        } elseif (! is_array($options)) {
-            $options           = func_get_args();
-            $temp              = [];
-            $temp['baseValue'] = array_shift($options);
-            if (! empty($options)) {
-                $temp['step'] = array_shift($options);
-            }
-            if (! empty($options)) {
-                $temp['format'] = array_shift($options);
-            }
-            if (! empty($options)) {
-                $temp['timezone'] = array_shift($options);
-            }
+        $step      = $options['step'] ?? 'P1D';
+        $baseValue = $options['baseValue'] ?? null;
 
-            $options = $temp;
-        }
-
-        if (! isset($options['step'])) {
-            $options['step'] = new DateInterval('P1D');
-        }
-        if (! isset($options['timezone'])) {
-            $options['timezone'] = new DateTimeZone(date_default_timezone_get());
-        }
+        unset(
+            $options['step'],
+            $options['baseValue'],
+        );
 
         parent::__construct($options);
-    }
 
-    /**
-     * Sets the base value from which the step should be computed
-     *
-     * @param string|int|DateTimeInterface $baseValue
-     * @return $this
-     */
-    public function setBaseValue($baseValue)
-    {
-        $this->baseValue = $baseValue;
-        return $this;
-    }
-
-    /**
-     * Returns the base value from which the step should be computed
-     *
-     * @return string|int|DateTimeInterface
-     */
-    public function getBaseValue()
-    {
-        return $this->baseValue;
-    }
-
-    /**
-     * Sets the step date interval
-     *
-     * @return $this
-     */
-    public function setStep(DateInterval $step)
-    {
+        if (! $step instanceof DateInterval) {
+            $step = new DateInterval($step);
+        }
         $this->step = $step;
-        return $this;
-    }
 
-    /**
-     * Returns the step date interval
-     *
-     * @return DateInterval
-     */
-    public function getStep()
-    {
-        return $this->step;
-    }
+        if (! $baseValue instanceof DateTimeInterface && is_string($baseValue)) {
+            $baseValue = $this->convertToDateTime($baseValue, false);
+        }
 
-    /**
-     * Returns the timezone option
-     *
-     * @return DateTimeZone
-     */
-    public function getTimezone()
-    {
-        return $this->timezone;
-    }
+        if (! $baseValue instanceof DateTimeInterface) {
+            $baseValue = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, '1970-01-01T00:00:00Z');
+        }
 
-    /**
-     * Sets the timezone option
-     *
-     * @return $this
-     */
-    public function setTimezone(DateTimeZone $timezone)
-    {
-        $this->timezone = $timezone;
-        return $this;
+        if ($baseValue === false) {
+            throw new InvalidArgumentException(
+                'The given base value is not in the expected format, or is an invalid date time string',
+            );
+        }
+
+        $this->baseValue = $baseValue;
     }
 
     /**
      * Supports formats with ISO week (W) definitions
-     *
-     * @see Date::convertString()
-     *
-     * @param string $value
-     * @param bool $addErrors
-     * @return DateTime|false
      */
-    protected function convertString($value, $addErrors = true)
+    protected function convertString(string $value, bool $addErrors = true): false|DateTimeImmutable
     {
         // Custom week format support
         if (
             str_starts_with($this->format, 'Y-\WW')
-            && preg_match('/^([0-9]{4})\-W([0-9]{2})/', $value, $matches)
+            && preg_match('/^([0-9]{4})-W([0-9]{2})/', $value, $matches)
         ) {
-            $date = new DateTime();
-            $date->setISODate((int) $matches[1], (int) $matches[2]);
+            $date = new DateTimeImmutable();
+            $date = $date->setISODate((int) $matches[1], (int) $matches[2]);
         } else {
-            $date = DateTime::createFromFormat($this->format, $value, new DateTimeZone('UTC'));
+            $date = DateTimeImmutable::createFromFormat($this->format, $value, new DateTimeZone('UTC'));
         }
 
         // Invalid dates can show up as warnings (ie. "2007-02-99")
@@ -216,8 +141,7 @@ final class DateStep extends Date
     /**
      * Returns true if a date is within a valid step
      *
-     * @param string|int|DateTimeInterface $value
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function isValid(mixed $value): bool
     {
@@ -232,7 +156,7 @@ final class DateStep extends Date
             return false;
         }
 
-        $step = $this->getStep();
+        $step = $this->step;
 
         // Same date?
         // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
@@ -381,7 +305,7 @@ final class DateStep extends Date
      *
      * @param int[] $intervalParts
      * @param int[] $diffParts
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     private function fallbackIncrementalIterationLogic(
         DateTimeInterface $baseDate,
@@ -394,11 +318,8 @@ final class DateStep extends Date
         $minimumInterval                 = $this->computeMinimumInterval($intervalParts, $minSteps);
         $isIncrementalStepping           = $baseDate < $valueDate;
 
-        if (! ($baseDate instanceof DateTime || $baseDate instanceof DateTimeImmutable)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Function %s requires the baseDate to be a DateTime or DateTimeImmutable instance.',
-                __FUNCTION__
-            ));
+        if ($baseDate instanceof DateTime) {
+            $baseDate = DateTimeImmutable::createFromMutable($baseDate);
         }
 
         for ($offsetIterations = 0; $offsetIterations < $requiredIterations; $offsetIterations += 1) {

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -8,7 +8,6 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
-use DateTimeZone;
 use Laminas\Validator\DateStep;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -33,58 +32,58 @@ final class DateStepTest extends TestCase
     {
         return [
             //    interval format            baseValue               value                  isValid
-            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z', true],
-            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
-            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:02Z', true],
-            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:01Z', false],
-            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:16Z', true],
-            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:00:02Z', true],
+            ['PT2S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:00:01Z', false],
+            ['PT2S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:00:16Z', true],
+            ['PT2S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
             // minutes
-            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
-            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
-            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:02:00Z', true],
-            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:01:00Z', false],
-            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:16:00Z', true],
-            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
+            ['PT1M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:02:00Z', true],
+            ['PT2M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:01:00Z', false],
+            ['PT2M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T00:16:00Z', true],
+            ['PT2M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
             ['PT1M', 'H:i:s',           '00:00:00',             '12:34:00',             true],
             ['PT2M', 'H:i:s',           '00:00:00',             '12:34:00',             true],
             ['PT2M', 'H:i:s',           '00:00:00',             '12:35:00',             false],
             // hours
-            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
-            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
-            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T02:00:00Z', true],
-            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T01:00:00Z', false],
-            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T16:00:00Z', true],
-            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
+            ['PT1H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T02:00:00Z', true],
+            ['PT2H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T01:00:00Z', false],
+            ['PT2H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-01T16:00:00Z', true],
+            ['PT2H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
             // days
-            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2014-08-12T00:00:00Z', true],
-            ['P2D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-02T00:00:00Z', false],
-            ['P2D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-15T00:00:00Z', true],
-            ['P2D',  DateTimeInterface::ISO8601, '1971-01-01T00:00:00Z', '1973-01-01T00:00:00Z', false],
-            ['P2D',  DateTimeInterface::ISO8601, '2000-01-01T00:00:00Z', '2001-01-01T00:00:00Z', true], // leap year
+            ['P1D',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1D',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P1D',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '2014-08-12T00:00:00Z', true],
+            ['P2D',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-02T00:00:00Z', false],
+            ['P2D',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-15T00:00:00Z', true],
+            ['P2D',  DateTimeInterface::ATOM, '1971-01-01T00:00:00Z', '1973-01-01T00:00:00Z', false],
+            ['P2D',  DateTimeInterface::ATOM, '2000-01-01T00:00:00Z', '2001-01-01T00:00:00Z', true], // leap year
             // weeks
-            ['P1W',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-29T00:00:00Z', true],
+            ['P1W',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-01-29T00:00:00Z', true],
             // months
-            ['P1M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P2M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false],
-            ['P2M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true],
+            ['P1M',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1M',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P2M',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false],
+            ['P2M',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true],
             ['P1M',  'Y-m',             '1970-01',              '1970-10',              true],
             ['P2M',  '!Y-m',            '1970-01',              '1970-11',              true],
             ['P2M',  'Y-m',             '1970-01',              '1970-10',              false],
             // years
-            ['P1Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P2Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1971-01-01T00:00:00Z', false],
-            ['P2Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1976-01-01T00:00:00Z', true],
+            ['P1Y',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1Y',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P2Y',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1971-01-01T00:00:00Z', false],
+            ['P2Y',  DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1976-01-01T00:00:00Z', true],
             // complex
-            ['P2M2DT12H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true],
-            ['P2M2DT12M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false],
+            ['P2M2DT12H', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true],
+            ['P2M2DT12M', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false],
             // long interval
-            ['PT1M20S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:40Z', true], // 20,000,000 steps
-            ['PT1M20S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:41Z', false],
+            ['PT1M20S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '2020-09-13T12:26:40Z', true],
+            ['PT1M20S', DateTimeInterface::ATOM, '1970-01-01T00:00:00Z', '2020-09-13T12:26:41Z', false],
             ['P2W',  'Y-\WW',           '1970-W01',             '1973-W16',             true],
             ['P2W',  'Y-\WW',           '1970-W01',             '1973-W17',             false],
         ];
@@ -114,7 +113,7 @@ final class DateStepTest extends TestCase
     public function testWithDateTimeType(): void
     {
         $validator = new DateStep([
-            'format'    => DateTimeInterface::ISO8601,
+            'format'    => DateTimeInterface::ATOM,
             'baseValue' => new DateTime('1970-01-01T00:00:00Z'),
             'step'      => new DateInterval('PT2S'),
         ]);
@@ -129,7 +128,7 @@ final class DateStepTest extends TestCase
     public function testWithDateTimeImmutableType(): void
     {
         $validator = new DateStep([
-            'format'    => DateTimeInterface::ISO8601,
+            'format'    => DateTimeInterface::ATOM,
             'baseValue' => new DateTimeImmutable('1970-01-01T00:00:00Z'),
             'step'      => new DateInterval('PT2S'),
         ]);

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Validator;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use Laminas\Validator\DateStep;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -32,58 +33,58 @@ final class DateStepTest extends TestCase
     {
         return [
             //    interval format            baseValue               value                  isValid
-            ['PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z', true],
-            ['PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
-            ['PT1S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:02Z', true],
-            ['PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:01Z', false],
-            ['PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:16Z', true],
-            ['PT2S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
+            ['PT1S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:02Z', true],
+            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:01Z', false],
+            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:00:16Z', true],
+            ['PT2S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-03T00:00:00Z', true],
             // minutes
-            ['PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
-            ['PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
-            ['PT1M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:02:00Z', true],
-            ['PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:01:00Z', false],
-            ['PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:16:00Z', true],
-            ['PT2M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
+            ['PT1M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:02:00Z', true],
+            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:01:00Z', false],
+            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T00:16:00Z', true],
+            ['PT2M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
             ['PT1M', 'H:i:s',           '00:00:00',             '12:34:00',             true],
             ['PT2M', 'H:i:s',           '00:00:00',             '12:34:00',             true],
             ['PT2M', 'H:i:s',           '00:00:00',             '12:35:00',             false],
             // hours
-            ['PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
-            ['PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
-            ['PT1H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T02:00:00Z', true],
-            ['PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T01:00:00Z', false],
-            ['PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T16:00:00Z', true],
-            ['PT2H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
+            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:30Z', false],
+            ['PT1H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T02:00:00Z', true],
+            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T01:00:00Z', false],
+            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-01T16:00:00Z', true],
+            ['PT2H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-01T00:00:00Z', true],
             // days
-            ['P1D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P1D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '2014-08-12T00:00:00Z', true],
-            ['P2D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-02T00:00:00Z', false],
-            ['P2D',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-15T00:00:00Z', true],
-            ['P2D',  DateTime::ISO8601, '1971-01-01T00:00:00Z', '1973-01-01T00:00:00Z', false],
-            ['P2D',  DateTime::ISO8601, '2000-01-01T00:00:00Z', '2001-01-01T00:00:00Z', true], // leap year
+            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P1D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2014-08-12T00:00:00Z', true],
+            ['P2D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-02T00:00:00Z', false],
+            ['P2D',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-15T00:00:00Z', true],
+            ['P2D',  DateTimeInterface::ISO8601, '1971-01-01T00:00:00Z', '1973-01-01T00:00:00Z', false],
+            ['P2D',  DateTimeInterface::ISO8601, '2000-01-01T00:00:00Z', '2001-01-01T00:00:00Z', true], // leap year
             // weeks
-            ['P1W',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-01-29T00:00:00Z', true],
+            ['P1W',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-01-29T00:00:00Z', true],
             // months
-            ['P1M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false],
-            ['P2M',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true],
+            ['P1M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P2M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-02-01T00:00:00Z', false],
+            ['P2M',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1971-05-01T00:00:00Z', true],
             ['P1M',  'Y-m',             '1970-01',              '1970-10',              true],
             ['P2M',  '!Y-m',            '1970-01',              '1970-11',              true],
             ['P2M',  'Y-m',             '1970-01',              '1970-10',              false],
             // years
-            ['P1Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
-            ['P1Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
-            ['P2Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1971-01-01T00:00:00Z', false],
-            ['P2Y',  DateTime::ISO8601, '1970-01-01T00:00:00Z', '1976-01-01T00:00:00Z', true],
+            ['P1Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:00Z', true],
+            ['P1Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1973-01-01T00:00:30Z', false],
+            ['P2Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1971-01-01T00:00:00Z', false],
+            ['P2Y',  DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1976-01-01T00:00:00Z', true],
             // complex
-            ['P2M2DT12H', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true],
-            ['P2M2DT12M', DateTime::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false],
+            ['P2M2DT12H', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', true],
+            ['P2M2DT12M', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '1970-03-03T12:00:00Z', false],
             // long interval
-            ['PT1M20S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:40Z', true], // 20,000,000 steps
-            ['PT1M20S', DateTime::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:41Z', false],
+            ['PT1M20S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:40Z', true], // 20,000,000 steps
+            ['PT1M20S', DateTimeInterface::ISO8601, '1970-01-01T00:00:00Z', '2020-09-13T12:26:41Z', false],
             ['P2W',  'Y-\WW',           '1970-W01',             '1973-W16',             true],
             ['P2W',  'Y-\WW',           '1970-W01',             '1973-W17',             false],
         ];
@@ -113,7 +114,7 @@ final class DateStepTest extends TestCase
     public function testWithDateTimeType(): void
     {
         $validator = new DateStep([
-            'format'    => DateTime::ISO8601,
+            'format'    => DateTimeInterface::ISO8601,
             'baseValue' => new DateTime('1970-01-01T00:00:00Z'),
             'step'      => new DateInterval('PT2S'),
         ]);
@@ -128,7 +129,7 @@ final class DateStepTest extends TestCase
     public function testWithDateTimeImmutableType(): void
     {
         $validator = new DateStep([
-            'format'    => DateTime::ISO8601,
+            'format'    => DateTimeInterface::ISO8601,
             'baseValue' => new DateTimeImmutable('1970-01-01T00:00:00Z'),
             'step'      => new DateInterval('PT2S'),
         ]);
@@ -192,7 +193,6 @@ final class DateStepTest extends TestCase
             'format'    => 'd-m-Y',
             'baseValue' => date('d-m-Y', 0),
             'step'      => new DateInterval('P1D'),
-            'timezone'  => new DateTimeZone('Europe/Moscow'),
         ]);
 
         self::assertTrue($validator->isValid($dateToValidate));
@@ -200,46 +200,29 @@ final class DateStepTest extends TestCase
 
     public function testCanSetBaseValue(): void
     {
-        $validator = new DateStep();
+        $validator = new DateStep([
+            'baseValue' => '2013-01-23',
+            'step'      => 'P2D',
+        ]);
 
-        $newBaseValue = '2013-01-23';
-        $validator->setBaseValue($newBaseValue);
-
-        $retrievedBaseValue = $validator->getBaseValue();
-
-        self::assertSame($newBaseValue, $retrievedBaseValue);
+        self::assertFalse($validator->isValid('2013-01-24'));
+        self::assertTrue($validator->isValid('2013-01-25'));
     }
 
-    public function testCanRetrieveTimezone(): void
+    public function testCanProvideOptionsToConstructor(): void
     {
-        $validator = new DateStep();
-
-        $newTimezone = new DateTimeZone('Europe/Vienna');
-        $validator->setTimezone($newTimezone);
-
-        $retrievedTimezone = $validator->getTimezone();
-
-        self::assertSame($newTimezone, $retrievedTimezone);
-    }
-
-    public function testCanProvideOptionsToConstructorAsDiscreteArguments(): void
-    {
-        $baseValue = '2012-01-23';
-        $step      = new DateInterval('P1D');
+        $baseValue = '23-01-2012';
+        $step      = new DateInterval('P2D');
         $format    = 'd-m-Y';
-        $timezone  = new DateTimeZone('Europe/Vienna');
 
-        $validator = new DateStep($baseValue, $step, $format, $timezone);
+        $validator = new DateStep([
+            'baseValue' => $baseValue,
+            'step'      => $step,
+            'format'    => $format,
+        ]);
 
-        $retrievedBaseValue = $validator->getBaseValue();
-        $retrievedStep      = $validator->getStep();
-        $retrievedFormat    = $validator->getFormat();
-        $retrievedTimezone  = $validator->getTimezone();
-
-        self::assertSame($baseValue, $retrievedBaseValue);
-        self::assertSame($step, $retrievedStep);
-        self::assertSame($format, $retrievedFormat);
-        self::assertSame($timezone, $retrievedTimezone);
+        self::assertFalse($validator->isValid('24-01-2012'));
+        self::assertTrue($validator->isValid('25-01-2012'));
     }
 
     public function testConvertStringDoesNotRaiseErrorOnInvalidValue(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Remove setters and getters
- Add types
- Only accepts options arrays to constructors
- Removes unused timezone option from DateStep
- Clean up and QA
- Changes default format in DateStep from `DATE_ISO8601` (Deprecated) to `DATE_W3C`
