### PR TITLE
Refactor `IsJsonString`

### DIFF
--- a/docs/book/v3/validators/is-json-string.md
+++ b/docs/book/v3/validators/is-json-string.md
@@ -39,16 +39,6 @@ The `allow` option is a bit mask of the `ALLOW_*` constants in `IsJsonString`:
 - `IsJsonString::ALLOW_OBJECT` - Accept JSON objects such as `{"Some":"Object"}`
 - `IsJsonString::ALLOW_ALL` - A convenience constant allowing all of the above _(Also the default)_.
 
-The `allow` option also has a companion setter method `setAllow`. For example, to only accept arrays and objects:
-
-```php
-use Laminas\Validator\IsJsonString;
-
-$validator = new IsJsonString();
-$validator->setAllow(IsJsonString::ALLOW_ARRAY | IsJsonString::ALLOW_OBJECT);
-$validator->isValid('1.234'); // false
-```
-
 ## Restricting Max Object or Array Nesting Level
 
 If you wish to restrict the nesting level of arrays and objects that are considered valid, the validator accepts a `maxDepth` option. The default value of this option is `512` - the same default value as `json_decode`.
@@ -56,11 +46,4 @@ If you wish to restrict the nesting level of arrays and objects that are conside
 ```php
 $validator = new Laminas\Validator\IsJsonString(['maxDepth' => 2]);
 $validator->isValid('{"nested": {"object: "here"}}'); // false
-```
-
-Again, the max nesting level allowed has a companion setter method:
-
-```php
-$validator = new Laminas\Validator\IsJsonString();
-$validator->setMaxDepth(10);
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -133,7 +133,7 @@
       <code><![CDATA[$this->abstractOptions]]></code>
     </MixedPropertyTypeCoercion>
     <TypeDoesNotContainType>
-      <code><![CDATA[false === UConverter::transcode($localPart, 'UTF-8', 'UTF-8')]]></code>
+      <code><![CDATA[UConverter::transcode($localPart, 'UTF-8', 'UTF-8') === false]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Exception/BadMethodCallException.php">

--- a/src/IsJsonString.php
+++ b/src/IsJsonString.php
@@ -18,12 +18,10 @@ use const JSON_ERROR_DEPTH;
 use const JSON_THROW_ON_ERROR;
 
 /**
- * @psalm-type CustomOptions = array{
- *     allow: int-mask-of<self::ALLOW_*>,
- *     maxDepth: positive-int,
+ * @psalm-type OptionsArgument = array{
+ *     allow?: int-mask-of<self::ALLOW_*>,
+ *     maxDepth?: positive-int,
  * }
- * @psalm-import-type AbstractOptions from AbstractValidator
- * @psalm-type Options = AbstractOptions|CustomOptions
  */
 final class IsJsonString extends AbstractValidator
 {
@@ -55,20 +53,19 @@ final class IsJsonString extends AbstractValidator
 
     protected ?string $type = null;
     /** @var int-mask-of<self::ALLOW_*> */
-    protected int $allow = self::ALLOW_ALL;
+    private readonly int $allow;
     /** @var positive-int */
-    protected int $maxDepth = 512;
+    protected readonly int $maxDepth;
 
-    /** @param int-mask-of<self::ALLOW_*> $type */
-    public function setAllow(int $type): void
+    /** @param OptionsArgument $options */
+    public function __construct(array $options = [])
     {
-        $this->allow = $type;
-    }
+        $this->allow    = $options['allow'] ?? self::ALLOW_ALL;
+        $this->maxDepth = $options['maxDepth'] ?? 512;
 
-    /** @param positive-int $maxDepth */
-    public function setMaxDepth(int $maxDepth): void
-    {
-        $this->maxDepth = $maxDepth;
+        unset($options['allow'], $options['maxDepth']);
+
+        parent::__construct($options);
     }
 
     public function isValid(mixed $value): bool

--- a/test/IsJsonStringTest.php
+++ b/test/IsJsonStringTest.php
@@ -51,10 +51,11 @@ class IsJsonStringTest extends TestCase
     #[DataProvider('allowProvider')]
     public function testBasicBehaviour(int $allowed, string $input, bool $expect, string|null $expectedErrorKey): void
     {
-        $validator = new IsJsonString();
-        $validator->setAllow($allowed);
-        $result = $validator->isValid($input);
-        self::assertSame($expect, $result);
+        $validator = new IsJsonString([
+            'allow' => $allowed,
+        ]);
+
+        self::assertSame($expect, $validator->isValid($input));
         if ($expectedErrorKey !== null) {
             self::assertArrayHasKey($expectedErrorKey, $validator->getMessages());
         }
@@ -87,7 +88,9 @@ class IsJsonStringTest extends TestCase
 
     public function testThatMaxDepthCanBeExceeded(): void
     {
-        $validator = new IsJsonString();
+        $validator = new IsJsonString([
+            'maxDepth' => 1,
+        ]);
         $input     = json_encode([
             'foo' => [
                 'bar' => [
@@ -96,7 +99,6 @@ class IsJsonStringTest extends TestCase
             ],
         ]);
 
-        $validator->setMaxDepth(1);
         self::assertFalse($validator->isValid($input));
         self::assertArrayHasKey(IsJsonString::ERROR_MAX_DEPTH_EXCEEDED, $validator->getMessages());
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes

### Description

- Removes setters
- Only allow an options array to the constructor
