### PR TITLE
Clean up usage of `$this->options`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -853,15 +853,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/NumberComparison.php">
-    <MixedAssignment>
-      <code><![CDATA[$inclusiveMax]]></code>
-      <code><![CDATA[$inclusiveMin]]></code>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-    </MixedAssignment>
-  </file>
   <file src="src/ValidatorChain.php">
     <MixedPropertyTypeCoercion>
       <code><![CDATA[new PriorityQueue()]]></code>

--- a/src/Ip.php
+++ b/src/Ip.php
@@ -23,14 +23,7 @@ use function substr_count;
  *     allowipv6?: bool,
  *     allowipvfuture?: bool,
  *     allowliteral?: bool,
- *     ...<string, mixed>,
  * }
- * @psalm-type Options = array{
- *      allowipv4: bool,
- *      allowipv6: bool,
- *      allowipvfuture: bool,
- *      allowliteral: bool,
- *  }
  */
 final class Ip extends AbstractValidator
 {
@@ -43,29 +36,33 @@ final class Ip extends AbstractValidator
         self::NOT_IP_ADDRESS => 'The input does not appear to be a valid IP address',
     ];
 
-    /** @var Options */
-    protected array $options = [
-        'allowipv4'      => true, // Enable IPv4 Validation
-        'allowipv6'      => true, // Enable IPv6 Validation
-        'allowipvfuture' => false, // Enable IPvFuture Validation
-        'allowliteral'   => true, // Enable IPs in literal format (only IPv6 and IPvFuture)
-    ];
+    private readonly bool $allowipv4;      // Enable IPv4 Validation
+    private readonly bool $allowipv6;      // Enable IPv6 Validation
+    private readonly bool $allowipvfuture; // Enable IPvFuture Validation
+    private readonly bool $allowliteral;   // Enable IPs in literal format (only IPv6 and IPvFuture)
 
     /** @param OptionsArgument $options */
     public function __construct(array $options = [])
     {
-        $this->options['allowipv4']      = $options['allowipv4'] ?? true;
-        $this->options['allowipv6']      = $options['allowipv6'] ?? true;
-        $this->options['allowipvfuture'] = $options['allowipvfuture'] ?? false;
-        $this->options['allowliteral']   = $options['allowliteral'] ?? true;
+        $this->allowipv4      = $options['allowipv4'] ?? true;
+        $this->allowipv6      = $options['allowipv6'] ?? true;
+        $this->allowipvfuture = $options['allowipvfuture'] ?? false;
+        $this->allowliteral   = $options['allowliteral'] ?? true;
 
         if (
-            $this->options['allowipv4'] === false
-            && $this->options['allowipv6'] === false
-            && $this->options['allowipvfuture'] === false
+            $this->allowipv4 === false
+            && $this->allowipv6 === false
+            && $this->allowipvfuture === false
         ) {
             throw new Exception\InvalidArgumentException('Nothing to validate. Check your options');
         }
+
+        unset(
+            $options['allowipv4'],
+            $options['allowipv6'],
+            $options['allowipvfuture'],
+            $options['allowliteral'],
+        );
 
         parent::__construct($options);
     }
@@ -82,18 +79,18 @@ final class Ip extends AbstractValidator
 
         $this->setValue($value);
 
-        if ($this->options['allowipv4'] && $this->validateIPv4($value)) {
+        if ($this->allowipv4 && $this->validateIPv4($value)) {
             return true;
         } else {
-            if ($this->options['allowliteral']) {
+            if ($this->allowliteral) {
                 if (preg_match('/^\[(.*)\]$/', $value, $matches)) {
                     $value = $matches[1];
                 }
             }
 
             if (
-                ($this->options['allowipv6'] && $this->validateIPv6($value)) ||
-                ($this->options['allowipvfuture'] && $this->validateIPvFuture($value))
+                ($this->allowipv6 && $this->validateIPv6($value)) ||
+                ($this->allowipvfuture && $this->validateIPvFuture($value))
             ) {
                 return true;
             }

--- a/src/NumberComparison.php
+++ b/src/NumberComparison.php
@@ -14,13 +14,6 @@ use function is_numeric;
  *     max?: numeric|null,
  *     inclusiveMin?: bool,
  *     inclusiveMax?: bool,
- *     ...<string, mixed>
- * }
- * @psalm-type Options = array{
- *     min: numeric|null,
- *     max: numeric|null,
- *     inclusiveMin: bool,
- *     inclusiveMax: bool,
  * }
  */
 final class NumberComparison extends AbstractValidator
@@ -40,25 +33,22 @@ final class NumberComparison extends AbstractValidator
         self::ERROR_NOT_LESS              => 'Values must be less than %max%. Received "%value%"',
     ];
 
-    /** @var array<string, array<string, string>> */
+    /** @var array<string, string> */
     protected array $messageVariables = [
-        'min' => ['options' => 'min'],
-        'max' => ['options' => 'max'],
+        'min' => 'min',
+        'max' => 'max',
     ];
 
-    /** @var Options */
-    protected array $options = [
-        'min'          => null,
-        'max'          => null,
-        'inclusiveMin' => true,
-        'inclusiveMax' => true,
-    ];
+    /** @var numeric|null */
+    protected readonly int|float|string|null $min;
+    /** @var numeric|null */
+    protected readonly int|float|string|null $max;
+    private readonly bool $inclusiveMin;
+    private readonly bool $inclusiveMax;
 
     /** @param OptionsArgument $options */
     public function __construct(array $options = [])
     {
-        parent::__construct($options);
-
         $min = $options['min'] ?? null;
         $max = $options['max'] ?? null;
 
@@ -74,10 +64,19 @@ final class NumberComparison extends AbstractValidator
             );
         }
 
-        $this->options['min']          = $min;
-        $this->options['max']          = $max;
-        $this->options['inclusiveMin'] = $options['inclusiveMin'] ?? true;
-        $this->options['inclusiveMax'] = $options['inclusiveMax'] ?? true;
+        $this->min          = $min;
+        $this->max          = $max;
+        $this->inclusiveMin = $options['inclusiveMin'] ?? true;
+        $this->inclusiveMax = $options['inclusiveMax'] ?? true;
+
+        unset(
+            $options['min'],
+            $options['max'],
+            $options['inclusiveMin'],
+            $options['inclusiveMax'],
+        );
+
+        parent::__construct($options);
     }
 
     public function isValid(mixed $value): bool
@@ -90,30 +89,25 @@ final class NumberComparison extends AbstractValidator
 
         $this->setValue($value);
 
-        $min          = $this->options['min'];
-        $max          = $this->options['max'];
-        $inclusiveMin = $this->options['inclusiveMin'];
-        $inclusiveMax = $this->options['inclusiveMax'];
-
-        if ($min !== null && $inclusiveMin && $value < $min) {
+        if ($this->min !== null && $this->inclusiveMin && $value < $this->min) {
             $this->error(self::ERROR_NOT_GREATER_INCLUSIVE);
 
             return false;
         }
 
-        if ($min !== null && ! $inclusiveMin && $value <= $min) {
+        if ($this->min !== null && ! $this->inclusiveMin && $value <= $this->min) {
             $this->error(self::ERROR_NOT_GREATER);
 
             return false;
         }
 
-        if ($max !== null && $inclusiveMax && $value > $max) {
+        if ($this->max !== null && $this->inclusiveMax && $value > $this->max) {
             $this->error(self::ERROR_NOT_LESS_INCLUSIVE);
 
             return false;
         }
 
-        if ($max !== null && ! $inclusiveMax && $value >= $max) {
+        if ($this->max !== null && ! $this->inclusiveMax && $value >= $this->max) {
             $this->error(self::ERROR_NOT_LESS);
 
             return false;

--- a/src/StringLength.php
+++ b/src/StringLength.php
@@ -42,14 +42,6 @@ final class StringLength extends AbstractValidator
     private readonly string $encoding;
     protected ?int $length = null;
 
-    /** @var array<string, mixed> */
-    protected array $options = [
-        'min'      => 0, // Minimum length
-        'max'      => null, // Maximum length, null if there is no length limitation
-        'encoding' => 'UTF-8', // Encoding to use
-        'length'   => 0, // Actual length
-    ];
-
     /**
      * Sets validator options
      *


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

`StringLength::$options` was completely unused

`Ip` and `NumberComparison` validators have been refactored internally to use typed instance properties instead of `$options` array