### PR TITLE
Remove libs from `suggest` that are already in `require`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,9 +50,7 @@
     },
     "suggest": {
         "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
-        "laminas/laminas-i18n-resources": "Translations of validator messages",
-        "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-        "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+        "laminas/laminas-i18n-resources": "Translations of validator messages"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Service manager and PSR-7 are already in require so there's no need to suggest them