### PR TITLE
 Refactor `WordCount` validator

### DIFF
--- a/docs/book/v3/validators/file/word-count.md
+++ b/docs/book/v3/validators/file/word-count.md
@@ -16,14 +16,11 @@ The following set of options are supported:
 use Laminas\Validator\File\WordCount;
 
 // Limit the amount of words to a maximum of 2000:
-$validator = new WordCount(2000);
+$validator = new WordCount(['max' => 2000]);
 
 // Limit the amount of words to between 100 and 5000:
-$validator = new WordCount(100, 5000);
-
-// ... or use options notation:
 $validator = new WordCount([
-    'min' => 1000,
+    'min' => 100,
     'max' => 5000,
 ]);
 
@@ -32,3 +29,14 @@ if ($validator->isValid('./myfile.txt')) {
     // file is valid
 }
 ```
+
+One of `min` or `max` is required. Omitting both options will cause an exception.
+Additionally, the `min` option must be numerically less than the `max` option. 
+
+## Validating Uploaded Files
+
+This validator accepts and validates 3 types of argument:
+
+- A string that represents a path to an existing file
+- An array that represents an uploaded file as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instance

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -42,6 +42,7 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -279,7 +280,6 @@
     </MixedAssignment>
     <PossiblyInvalidArgument>
       <code><![CDATA[$fileInfo['file']]]></code>
-      <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
@@ -529,42 +529,6 @@
     </MoreSpecificImplementedParamType>
     <RedundantConditionGivenDocblockType>
       <code><![CDATA[is_string($value)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="src/File/WordCount.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($options)]]></code>
-    </DocblockTypeContradiction>
-    <MixedArgument>
-      <code><![CDATA[$fileInfo['file']]]></code>
-      <code><![CDATA[$fileInfo['file']]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['max']]]></code>
-      <code><![CDATA[$this->options['min']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$count]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->getMax() !== null]]></code>
-      <code><![CDATA[$this->getMax() !== null]]></code>
-      <code><![CDATA[$this->getMin() !== null]]></code>
-      <code><![CDATA[$this->getMin() !== null]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/GpsPoint.php">
@@ -945,14 +909,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/WordCountTest.php">
-    <MixedArgument>
-      <code><![CDATA[$isValidParam['tmp_name']]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicBehaviorDataProvider]]></code>
-      <code><![CDATA[invalidMinMaxValues]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/GPSPointTest.php">

--- a/src/File/WordCount.php
+++ b/src/File/WordCount.php
@@ -5,26 +5,21 @@ declare(strict_types=1);
 namespace Laminas\Validator\File;
 
 use Laminas\Validator\AbstractValidator;
-use Laminas\Validator\Exception;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
-use function array_shift;
 use function file_get_contents;
-use function func_get_args;
-use function func_num_args;
-use function is_array;
-use function is_numeric;
-use function is_readable;
-use function is_string;
 use function str_word_count;
 
 /**
  * Validator for counting all words in a file
+ *
+ * @psalm-type OptionsArgument = array{
+ *     min?: numeric,
+ *     max?: numeric,
+ * }
  */
 final class WordCount extends AbstractValidator
 {
-    use FileInformationTrait;
-
     /**
      * @const string Error constants
      */
@@ -39,163 +34,79 @@ final class WordCount extends AbstractValidator
         self::NOT_FOUND => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string> */
     protected array $messageVariables = [
-        'min'   => ['options' => 'min'],
-        'max'   => ['options' => 'max'],
+        'min'   => 'min',
+        'max'   => 'max',
         'count' => 'count',
     ];
 
     /**
      * Word count
-     *
-     * @var int
      */
-    protected $count;
+    protected ?int $count = null;
 
-    /**
-     * Options for this validator
-     *
-     * @var array
-     */
-    protected $options = [
-        'min' => null, // Minimum word count, if null there is no minimum word count
-        'max' => null, // Maximum word count, if null there is no maximum word count
-    ];
+    protected readonly int|null $min;
+    protected readonly int|null $max;
 
     /**
      * Sets validator options
      *
-     * Min limits the word count, when used with max=null it is the maximum word count
-     * It also accepts an array with the keys 'min' and 'max'
-     *
-     * If $options is an integer, it will be used as maximum word count
-     * As Array is accepts the following keys:
-     * 'min': Minimum word count
-     * 'max': Maximum word count
-     *
-     * @param int|array|Traversable $options Options for the adapter
+     * @param OptionsArgument $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options = [])
     {
-        if (1 < func_num_args()) {
-            $args    = func_get_args();
-            $options = [
-                'min' => array_shift($args),
-                'max' => array_shift($args),
-            ];
+        $min = $options['min'] ?? null;
+        $max = $options['max'] ?? null;
+
+        if ($min === null && $max === null) {
+            throw new InvalidArgumentException('A minimum or maximum word count must be set');
         }
 
-        if (is_string($options) || is_numeric($options)) {
-            $options = ['max' => $options];
+        $min = $min !== null ? (int) $min : null;
+        $max = $max !== null ? (int) $max : null;
+
+        if ($min !== null && $max !== null && $min > $max) {
+            throw new InvalidArgumentException('The minimum word count should be less than the maximum word count');
         }
+
+        unset($options['min'], $options['max']);
+
+        $this->min = $min;
+        $this->max = $max;
 
         parent::__construct($options);
     }
 
     /**
-     * Returns the minimum word count
-     *
-     * @return int
-     */
-    public function getMin()
-    {
-        return $this->options['min'];
-    }
-
-    /**
-     * Sets the minimum word count
-     *
-     * @param  int|array $min The minimum word count
-     * @return $this Provides a fluent interface
-     * @throws Exception\InvalidArgumentException When min is greater than max.
-     */
-    public function setMin($min)
-    {
-        if (is_array($min) && isset($min['min'])) {
-            $min = $min['min'];
-        }
-
-        if (! is_numeric($min)) {
-            throw new Exception\InvalidArgumentException('Invalid options to validator provided');
-        }
-
-        $min = (int) $min;
-        if (($this->getMax() !== null) && ($min > $this->getMax())) {
-            throw new Exception\InvalidArgumentException(
-                "The minimum must be less than or equal to the maximum word count, but $min > {$this->getMax()}"
-            );
-        }
-
-        $this->options['min'] = $min;
-        return $this;
-    }
-
-    /**
-     * Returns the maximum word count
-     *
-     * @return int
-     */
-    public function getMax()
-    {
-        return $this->options['max'];
-    }
-
-    /**
-     * Sets the maximum file count
-     *
-     * @param  int|array $max The maximum word count
-     * @return $this Provides a fluent interface
-     * @throws Exception\InvalidArgumentException When max is smaller than min.
-     */
-    public function setMax($max)
-    {
-        if (is_array($max) && isset($max['max'])) {
-            $max = $max['max'];
-        }
-
-        if (! is_numeric($max)) {
-            throw new Exception\InvalidArgumentException('Invalid options to validator provided');
-        }
-
-        $max = (int) $max;
-        if (($this->getMin() !== null) && ($max < $this->getMin())) {
-            throw new Exception\InvalidArgumentException(
-                "The maximum must be greater than or equal to the minimum word count, but $max < {$this->getMin()}"
-            );
-        }
-
-        $this->options['max'] = $max;
-        return $this;
-    }
-
-    /**
      * Returns true if and only if the counted words are at least min and
      * not bigger than max (when max is not null).
-     *
-     * @param  string|array $value Filename to check for word count
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
      */
-    public function isValid(mixed $value, $file = null): bool
+    public function isValid(mixed $value): bool
     {
-        $fileInfo = $this->getFileInfo($value, $file);
-
-        $this->setValue($fileInfo['filename']);
-
-        // Is file readable ?
-        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
+        if (! FileInformation::isPossibleFile($value)) {
             $this->error(self::NOT_FOUND);
+
             return false;
         }
 
-        $content     = file_get_contents($fileInfo['file']);
+        $file = FileInformation::factory($value);
+
+        if (! $file->readable) {
+            $this->error(self::NOT_FOUND);
+
+            return false;
+        }
+
+        $content     = file_get_contents($file->path);
         $this->count = str_word_count($content);
-        if (($this->getMax() !== null) && ($this->count > $this->getMax())) {
+
+        if (($this->max !== null) && ($this->count > $this->max)) {
             $this->error(self::TOO_MUCH);
             return false;
         }
 
-        if (($this->getMin() !== null) && ($this->count < $this->getMin())) {
+        if (($this->min !== null) && ($this->count < $this->min)) {
             $this->error(self::TOO_LESS);
             return false;
         }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -18,6 +18,7 @@ use Laminas\Validator\File\Extension;
 use Laminas\Validator\File\FilesSize;
 use Laminas\Validator\File\MimeType;
 use Laminas\Validator\File\Size;
+use Laminas\Validator\File\WordCount;
 use Laminas\Validator\InArray;
 use Laminas\Validator\IsInstanceOf;
 use Laminas\Validator\NumberComparison;
@@ -52,6 +53,7 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         MimeType::class,
         ExcludeMimeType::class,
         Size::class,
+        WordCount::class,
     ];
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes

### Description

 - Removes option setters and getters
 - Exceptions no longer thrown for non-existent or un-readable files (Validation failure instead)
 - Constructor only accepts an options array
 - Drops legacy `Laminas\File\Transfer` compat

