### PR TITLE
Refactor `Size` and `FilesSize` Validators

### DIFF
--- a/docs/book/v3/validators/file/files-size.md
+++ b/docs/book/v3/validators/file/files-size.md
@@ -36,3 +36,11 @@ if ($validator->isValid($_FILES)) {
     // > 1kB, < 10MB in aggregate
 }
 ```
+
+## Accepted Uploaded File Types
+
+This validator accepts and validates 3 types of argument:
+
+- A list of strings that represents paths to existing files
+- An array that represents uploaded files as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A list of PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instances

--- a/docs/book/v3/validators/file/size.md
+++ b/docs/book/v3/validators/file/size.md
@@ -10,7 +10,7 @@ The following set of options are supported:
   indicates no minimum required.
 - `max`: maximum file size in integer bytes, or in string SI notation; `null`
   indicates no maximum required.
-- `useByteString`: Boolean flag indicating whether to dispaly error messages
+- `useByteString`: Boolean flag indicating whether to display error messages
   using SI notation (default, `true`), or in bytes (`false`).
 
 SI units supported are: kB, MB, GB, TB, PB, and EB. All sizes are converted
@@ -22,7 +22,7 @@ using 1024 as the base value (ie. 1kB == 1024 bytes, 1MB == 1024kB).
 use Laminas\Validator\File\Size;
 
 // Limit the file size to 40000 bytes
-$validator = new Size(40000);
+$validator = new Size(['max' => 40000]);
 
 // Limit the file size to between 10kB and 4MB
 $validator = new Size([
@@ -35,3 +35,11 @@ if ($validator->isValid('./myfile.txt')) {
     // file is valid
 }
 ```
+
+## Validating Uploaded Files
+
+This validator accepts and validates 3 types of argument:
+
+- A string that represents a path to an existing file
+- An array that represents an uploaded file as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instance

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -740,6 +740,12 @@
       <code><![CDATA[$errstr]]></code>
     </UnusedParam>
   </file>
+  <file src="test/File/BytesTest.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[bytesToSiUnitDataProvider]]></code>
+      <code><![CDATA[siUnitToBytesProvider]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/File/CountTest.php">
     <MixedArgument>
       <code><![CDATA[$max]]></code>
@@ -832,12 +838,6 @@
       <code><![CDATA[basicBehaviorDataProvider]]></code>
       <code><![CDATA[getExtensionProvider]]></code>
       <code><![CDATA[setExtensionProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/File/FileInformationTest.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[bytesToSiUnitDataProvider]]></code>
-      <code><![CDATA[siUnitToBytesProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/FilesSizeTest.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -290,55 +290,11 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$fileInfo['file']]]></code>
       <code><![CDATA[$value]]></code>
     </PossiblyInvalidCast>
-  </file>
-  <file src="src/File/FilesSize.php">
-    <InvalidClassConstantType>
-      <code><![CDATA[TOO_BIG]]></code>
-      <code><![CDATA[TOO_SMALL]]></code>
-    </InvalidClassConstantType>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->toByteString($size)]]></code>
-      <code><![CDATA[$this->toByteString($size)]]></code>
-    </InvalidPropertyAssignmentValue>
-    <MixedArgument>
-      <code><![CDATA[$files]]></code>
-      <code><![CDATA[$files]]></code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->files[$files]]]></code>
-      <code><![CDATA[$this->files[$files]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$files]]></code>
-      <code><![CDATA[$files]]></code>
-      <code><![CDATA[$options['max']]]></code>
-      <code><![CDATA[$options['useByteString']]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[false]]></code>
-    </PossiblyUnusedReturnValue>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[FilesSize]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$max !== null]]></code>
-      <code><![CDATA[$min !== null]]></code>
-      <code><![CDATA[is_array($value)]]></code>
-      <code><![CDATA[is_string($file)]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Hash.php">
     <DocblockTypeContradiction>
@@ -492,73 +448,6 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MoreSpecificImplementedParamType>
-  </file>
-  <file src="src/File/Size.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[! is_string($max) && ! is_numeric($max)]]></code>
-      <code><![CDATA[! is_string($min) && ! is_numeric($min)]]></code>
-      <code><![CDATA[is_string($options)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidArrayOffset>
-      <code><![CDATA[$sizes[$i]]]></code>
-    </InvalidArrayOffset>
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->toByteString($size)]]></code>
-      <code><![CDATA[$this->toByteString($size)]]></code>
-    </InvalidPropertyAssignmentValue>
-    <MixedArgument>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-      <code><![CDATA[$options['max']]]></code>
-      <code><![CDATA[$options['useByteString']]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[int|string]]></code>
-      <code><![CDATA[int|string]]></code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$sizes[$i]]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-      <code><![CDATA[$min]]></code>
-      <code><![CDATA[$this->options['useByteString']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-      <code><![CDATA[$min]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidArrayAssignment>
-      <code><![CDATA[$options['max']]]></code>
-      <code><![CDATA[$options['useByteString']]]></code>
-    </PossiblyInvalidArrayAssignment>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$size]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $byteString]]></code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$max !== null]]></code>
-      <code><![CDATA[$max !== null]]></code>
-      <code><![CDATA[$min !== null]]></code>
-      <code><![CDATA[$min !== null]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Upload.php">
     <DocblockTypeContradiction>
@@ -945,16 +834,16 @@
       <code><![CDATA[setExtensionProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/File/FileInformationTest.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[bytesToSiUnitDataProvider]]></code>
+      <code><![CDATA[siUnitToBytesProvider]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/File/FilesSizeTest.php">
-    <MixedArgument>
-      <code><![CDATA[$options]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$multipleOptionsDetected]]></code>
-    </PossiblyUnusedProperty>
   </file>
   <file src="test/File/HashTest.php">
     <MixedArgument>
@@ -1038,15 +927,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/SizeTest.php">
-    <MixedArgument>
-      <code><![CDATA[$isValidParam['tmp_name']]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicBehaviorDataProvider]]></code>
-      <code><![CDATA[invalidMinMaxValues]]></code>
-      <code><![CDATA[setMaxProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/UploadFileTest.php">

--- a/src/File/Bytes.php
+++ b/src/File/Bytes.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator\File;
+
+use function assert;
+use function ctype_digit;
+use function is_numeric;
+use function is_string;
+use function round;
+use function strtoupper;
+use function substr;
+use function trim;
+
+use const PHP_INT_MAX;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class Bytes
+{
+    private function __construct(
+        public readonly int $bytes,
+    ) {
+    }
+
+    public static function fromInteger(int $bytes): self
+    {
+        return new self($bytes);
+    }
+
+    /**
+     * Format filesize in bytes to an SI Unit
+     */
+    public function toSiUnit(): string
+    {
+        $size  = $this->bytes;
+        $sizes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        for ($i = 0; $size >= 1024 && $i < 9; $i++) {
+            $size /= 1024;
+        }
+
+        $suffix = $sizes[$i] ?? null;
+
+        assert(is_string($suffix));
+
+        return round($size, 2) . $suffix;
+    }
+
+    /**
+     * Create a new instance from an SI unit string such as "10 GB"
+     */
+    public static function fromSiUnit(string $size): self
+    {
+        if (ctype_digit($size)) {
+            return self::fromInteger((int) $size);
+        }
+
+        $type = trim(substr($size, -2, 1));
+
+        $value = substr($size, 0, -1);
+        if (! is_numeric($value)) {
+            $value = trim(substr($value, 0, -1));
+        }
+
+        assert(is_numeric($value));
+
+        switch (strtoupper($type)) {
+            case 'Y':
+                //$value *= 1024 ** 8;
+                $value = PHP_INT_MAX;
+                break;
+            case 'Z':
+                //$value *= 1024 ** 7;
+                $value = PHP_INT_MAX;
+                break;
+            case 'E':
+                if ($value > 7) {
+                    $value = PHP_INT_MAX;
+                    break;
+                }
+                $value *= 1024 ** 6;
+                break;
+            case 'P':
+                $value *= 1024 ** 5;
+                break;
+            case 'T':
+                $value *= 1024 ** 4;
+                break;
+            case 'G':
+                $value *= 1024 ** 3;
+                break;
+            case 'M':
+                $value *= 1024 ** 2;
+                break;
+            case 'K':
+                $value *= 1024;
+                break;
+            default:
+                break;
+        }
+
+        return self::fromInteger((int) $value);
+    }
+}

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -10,8 +10,10 @@ use Psr\Http\Message\UploadedFileInterface;
 use function assert;
 use function basename;
 use function file_exists;
+use function filesize;
 use function finfo_open;
 use function is_array;
+use function is_int;
 use function is_readable;
 use function is_string;
 
@@ -28,10 +30,20 @@ final class FileInformation
         public readonly string $path,
         public readonly ?string $clientFileName,
         public readonly ?string $clientMediaType,
+        private int|null $size,
     ) {
         $this->readable  = is_readable($this->path);
         $this->baseName  = basename($this->path);
         $this->mediaType = null;
+    }
+
+    public function size(): int
+    {
+        if ($this->size === null) {
+            $this->size = filesize($this->path);
+        }
+
+        return $this->size;
     }
 
     public function detectMimeType(): string
@@ -64,11 +76,12 @@ final class FileInformation
                 $path,
                 $value->getClientFilename(),
                 $value->getClientMediaType(),
+                $value->getSize(),
             );
         }
 
         if (is_string($value)) {
-            return new self($value, null, null);
+            return new self($value, null, null, null);
         }
 
         return self::fromSapiArray($value);
@@ -79,12 +92,14 @@ final class FileInformation
         $clientName = $value['name'] ?? null;
         $clientType = $value['type'] ?? null;
         $path       = $value['tmp_name'] ?? null;
+        $size       = $value['size'] ?? null;
 
         assert(is_string($path));
         assert(is_string($clientName));
         assert(is_string($clientType));
+        assert(is_int($size) || $size === null);
 
-        return new self($path, $clientName, $clientType);
+        return new self($path, $clientName, $clientType, $size);
     }
 
     public static function isPossibleFile(mixed $value): bool

--- a/src/File/FilesSize.php
+++ b/src/File/FilesSize.php
@@ -4,30 +4,25 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
-use Laminas\Stdlib\ArrayUtils;
-use Laminas\Stdlib\ErrorHandler;
-use Laminas\Validator\Exception;
+use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
-use Traversable;
+use Psr\Http\Message\UploadedFileInterface;
 
-use function array_key_exists;
-use function array_shift;
-use function filesize;
-use function func_get_args;
-use function func_num_args;
+use function in_array;
 use function is_array;
-use function is_readable;
-use function is_scalar;
 use function is_string;
 
 /**
- * Validator for the size of all files which will be validated in sum
+ * Validate the cumulative size of multiple files
+ *
+ * @psalm-type OptionsArgument = array{
+ *     min?: string|numeric|null,
+ *     max?: string|numeric|null,
+ *     useByteString?: bool,
+ * }
  */
-final class FilesSize extends Size
+final class FilesSize extends AbstractValidator
 {
-    /**
-     * @const string Error constants
-     */
     public const TOO_BIG      = 'fileFilesSizeTooBig';
     public const TOO_SMALL    = 'fileFilesSizeTooSmall';
     public const NOT_READABLE = 'fileFilesSizeNotReadable';
@@ -39,43 +34,71 @@ final class FilesSize extends Size
         self::NOT_READABLE => 'One or more files can not be read',
     ];
 
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
+        'min'  => 'minString',
+        'max'  => 'maxString',
+        'size' => 'size',
+    ];
+
     /**
-     * Internal file array
-     *
-     * @var array
+     * Detected size
      */
-    protected $files;
+    protected string $size = '';
+    protected readonly string $minString;
+    protected readonly string $maxString;
+
+    protected readonly int|null $min;
+    protected readonly int|null $max;
+    private readonly bool $useByteString;
 
     /**
      * Sets validator options
      *
-     * Min limits the used disk space for all files, when used with max=null it is the maximum file size
-     * It also accepts an array with the keys 'min' and 'max'
+     * $options accepts the following keys:
+     * 'min': Minimum file size
+     * 'max': Maximum file size
+     * 'useByteString': Use bytestring or real size for messages
      *
-     * @param  int|array|Traversable $options Options for this validator
-     * @throws InvalidArgumentException
+     * @param OptionsArgument $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options = [])
     {
-        $this->files = [];
-        $this->setSize(0);
+        $min                 = $options['min'] ?? null;
+        $max                 = $options['max'] ?? null;
+        $this->useByteString = $options['useByteString'] ?? true;
 
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        } elseif (is_scalar($options)) {
-            $options = ['max' => $options];
-        } elseif (! is_array($options)) {
-            throw new Exception\InvalidArgumentException('Invalid options to validator provided');
+        if ($min === null && $max === null) {
+            throw new InvalidArgumentException('One of `min` or `max` options are required');
         }
 
-        if (1 < func_num_args()) {
-            $argv = func_get_args();
-            array_shift($argv);
-            $options['max'] = array_shift($argv);
-            if (! empty($argv)) {
-                $options['useByteString'] = array_shift($argv);
-            }
+        if (is_string($min)) {
+            $min = FileInformation::siUnitToBytes($min);
         }
+
+        if (is_string($max)) {
+            $max = FileInformation::siUnitToBytes($max);
+        }
+
+        $this->min = $min !== null ? (int) $min : null;
+        $this->max = $max !== null ? (int) $max : null;
+
+        if ($this->min !== null && $this->max !== null && $this->min > $this->max) {
+            throw new InvalidArgumentException('The `min` option cannot exceed the `max` option');
+        }
+
+        unset(
+            $options['min'],
+            $options['max'],
+            $options['useByteString'],
+        );
+
+        $this->minString = $this->min !== null && $this->useByteString
+            ? FileInformation::bytesToSiUnit($this->min)
+            : (string) $this->min;
+        $this->maxString = $this->max !== null && $this->useByteString
+            ? FileInformation::bytesToSiUnit($this->max)
+            : (string) $this->max;
 
         parent::__construct($options);
     }
@@ -83,103 +106,62 @@ final class FilesSize extends Size
     /**
      * Returns true if and only if the disk usage of all files is at least min and
      * not bigger than max (when max is not null).
-     *
-     * @param  string|array $value Real file to check for size
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer
      */
-    public function isValid(mixed $value, $file = null): bool
+    public function isValid(mixed $value): bool
     {
-        if (is_string($value)) {
-            $value = [$value];
-        } elseif (is_array($value) && isset($value['tmp_name'])) {
+        if (is_array($value) && isset($value['tmp_name'])) {
             $value = [$value];
         }
 
-        $min  = $this->getMin(true);
-        $max  = $this->getMax(true);
-        $size = $this->getSize();
-        foreach ($value as $files) {
-            if (is_array($files)) {
-                if (! isset($files['tmp_name']) || ! isset($files['name'])) {
-                    throw new Exception\InvalidArgumentException(
-                        'Value array must be in $_FILES format'
-                    );
-                }
-                $file  = $files;
-                $files = $files['tmp_name'];
+        if (is_string($value) || $value instanceof UploadedFileInterface) {
+            $value = [$value];
+        }
+
+        $paths = [];
+        $size  = 0;
+
+        /** @psalm-suppress MixedAssignment $possibleFile - Yep. This is `mixed` */
+        foreach ($value as $possibleFile) {
+            if (! FileInformation::isPossibleFile($possibleFile)) {
+                $this->error(self::NOT_READABLE);
+
+                return false;
             }
+
+            $file = FileInformation::factory($possibleFile);
 
             // Is file readable ?
-            if (empty($files) || false === is_readable($files)) {
-                $this->throwError($file, self::NOT_READABLE);
-                continue;
+            if (! $file->readable) {
+                $this->error(self::NOT_READABLE);
+
+                return false;
             }
 
-            if (! isset($this->files[$files])) {
-                $this->files[$files] = $files;
-            } else {
-                // file already counted... do not count twice
-                continue;
+            if (in_array($file->path, $paths, true)) {
+                continue; // Skip duplicate entries
             }
 
-            // limited to 2GB files
-            ErrorHandler::start();
-            $size += filesize($files);
-            ErrorHandler::stop();
-            $this->size = $size;
-            if (($max !== null) && ($max < $size)) {
-                if ($this->getByteString()) {
-                    $this->options['max'] = $this->toByteString($max);
-                    $this->size           = $this->toByteString($size);
-                    $this->throwError($file, self::TOO_BIG);
-                    $this->options['max'] = $max;
-                    $this->size           = $size;
-                } else {
-                    $this->throwError($file, self::TOO_BIG);
-                }
-            }
+            $paths[] = $file->path;
+
+            $size += $file->size();
         }
 
-        // Check that aggregate files are >= minimum size
-        if (($min !== null) && ($size < $min)) {
-            if ($this->getByteString()) {
-                $this->options['min'] = $this->toByteString($min);
-                $this->size           = $this->toByteString($size);
-                $this->throwError($file, self::TOO_SMALL);
-                $this->options['min'] = $min;
-                $this->size           = $size;
-            } else {
-                $this->throwError($file, self::TOO_SMALL);
-            }
+        $this->size = $this->useByteString
+            ? FileInformation::bytesToSiUnit($size)
+            : (string) $size;
+
+        if ($this->min !== null && $size < $this->min) {
+            $this->error(self::TOO_SMALL);
+
+            return false;
         }
 
-        if ($this->getMessages()) {
+        if ($this->max !== null && $size > $this->max) {
+            $this->error(self::TOO_BIG);
+
             return false;
         }
 
         return true;
-    }
-
-    /**
-     * Throws an error of the given type
-     *
-     * @param  string|null|array $file
-     * @param  string $errorType
-     * @return false
-     */
-    protected function throwError($file, $errorType)
-    {
-        if ($file !== null) {
-            if (is_array($file)) {
-                if (array_key_exists('name', $file)) {
-                    $this->value = $file['name'];
-                }
-            } elseif (is_string($file)) {
-                $this->value = $file;
-            }
-        }
-
-        $this->error($errorType);
-        return false;
     }
 }

--- a/src/File/FilesSize.php
+++ b/src/File/FilesSize.php
@@ -73,11 +73,11 @@ final class FilesSize extends AbstractValidator
         }
 
         if (is_string($min)) {
-            $min = FileInformation::siUnitToBytes($min);
+            $min = Bytes::fromSiUnit($min)->bytes;
         }
 
         if (is_string($max)) {
-            $max = FileInformation::siUnitToBytes($max);
+            $max = Bytes::fromSiUnit($max)->bytes;
         }
 
         $this->min = $min !== null ? (int) $min : null;
@@ -94,10 +94,10 @@ final class FilesSize extends AbstractValidator
         );
 
         $this->minString = $this->min !== null && $this->useByteString
-            ? FileInformation::bytesToSiUnit($this->min)
+            ? Bytes::fromInteger($this->min)->toSiUnit()
             : (string) $this->min;
         $this->maxString = $this->max !== null && $this->useByteString
-            ? FileInformation::bytesToSiUnit($this->max)
+            ? Bytes::fromInteger($this->max)->toSiUnit()
             : (string) $this->max;
 
         parent::__construct($options);
@@ -143,11 +143,11 @@ final class FilesSize extends AbstractValidator
 
             $paths[] = $file->path;
 
-            $size += $file->size();
+            $size += $file->size()->bytes;
         }
 
         $this->size = $this->useByteString
-            ? FileInformation::bytesToSiUnit($size)
+            ? Bytes::fromInteger($size)->toSiUnit()
             : (string) $size;
 
         if ($this->min !== null && $size < $this->min) {

--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -70,11 +70,11 @@ final class Size extends AbstractValidator
         }
 
         if (is_string($min)) {
-            $min = FileInformation::siUnitToBytes($min);
+            $min = Bytes::fromSiUnit($min)->bytes;
         }
 
         if (is_string($max)) {
-            $max = FileInformation::siUnitToBytes($max);
+            $max = Bytes::fromSiUnit($max)->bytes;
         }
 
         $this->min = $min !== null ? (int) $min : null;
@@ -91,10 +91,10 @@ final class Size extends AbstractValidator
         );
 
         $this->minString = $this->min !== null && $this->useByteString
-            ? FileInformation::bytesToSiUnit($this->min)
+            ? Bytes::fromInteger($this->min)->toSiUnit()
             : (string) $this->min;
         $this->maxString = $this->max !== null && $this->useByteString
-            ? FileInformation::bytesToSiUnit($this->max)
+            ? Bytes::fromInteger($this->max)->toSiUnit()
             : (string) $this->max;
 
         parent::__construct($options);
@@ -121,9 +121,9 @@ final class Size extends AbstractValidator
             return false;
         }
 
-        $size       = $file->size();
+        $size       = $file->size()->bytes;
         $this->size = $this->useByteString
-            ? $file->sizeAsSiUnit()
+            ? $file->size()->toSiUnit()
             : (string) $size;
 
         if ($this->min !== null && $size < $this->min) {

--- a/test/File/BytesTest.php
+++ b/test/File/BytesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator\File;
+
+use Laminas\Validator\File\Bytes;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use const PHP_INT_MAX;
+
+/** @psalm-suppress InternalClass, InternalMethod, InternalProperty */
+class BytesTest extends TestCase
+{
+    /** @return list<array{0: int, 1: string}> */
+    public static function bytesToSiUnitDataProvider(): array
+    {
+        return [
+            [10, '10B'],
+            [1536, '1.5kB'],
+            [2_621_440, '2.5MB'],
+            [1_073_741_824, '1GB'],
+            [6_442_450_944, '6GB'],
+            [6_597_069_766_656, '6TB'],
+            [6_755_399_441_055_744, '6PB'],
+        ];
+    }
+
+    #[DataProvider('bytesToSiUnitDataProvider')]
+    public function testBytesToSiUnit(int $input, string $expect): void
+    {
+        self::assertSame($expect, Bytes::fromInteger($input)->toSiUnit());
+    }
+
+    public static function siUnitToBytesProvider(): array
+    {
+        return [
+            [10, '10b'],
+            [1536, '1.5kB'],
+            [2_621_440, '2.5MB'],
+            [1_073_741_824, '1GB'],
+            [6_442_450_944, '6GB'],
+            [6_597_069_766_656, '6TB'],
+            [10, '10 b'],
+            [1536, '1.5 kB'],
+            [1536, '1.5 kb'],
+            [2_621_440, '2.5 MB'],
+            [1_073_741_824, '1 GB'],
+            [6_442_450_944, '6 GB'],
+            [6_597_069_766_656, '6 TB'],
+            [6_755_399_441_055_744, '6 PB'],
+            [8_070_450_532_247_928_832, '7EB'],
+            [PHP_INT_MAX, '8EB'],
+            [PHP_INT_MAX, '1ZB'],
+            [PHP_INT_MAX, '10YB'],
+        ];
+    }
+
+    #[DataProvider('siUnitToBytesProvider')]
+    public function testSiUnitToBytes(int $expect, string $input): void
+    {
+        self::assertSame($expect, Bytes::fromSiUnit($input)->bytes);
+    }
+
+    public function testThatFromSiUnitAcceptsNumericString(): void
+    {
+        $bytes = Bytes::fromSiUnit('1024');
+
+        self::assertSame(1024, $bytes->bytes);
+        self::assertSame('1kB', $bytes->toSiUnit());
+    }
+}

--- a/test/File/FileInformationTest.php
+++ b/test/File/FileInformationTest.php
@@ -32,6 +32,7 @@ class FileInformationTest extends TestCase
             'tmp_name' => 'Foo',
             'name'     => 'Foo',
             'type'     => 'text/plain',
+            'size'     => 0,
         ]);
     }
 
@@ -46,6 +47,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
+        self::assertSame(filesize($path), $file->size());
     }
 
     public function testExpectedValuesForUploadedFile(): void
@@ -68,6 +70,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
+        self::assertSame(filesize($path), $file->size());
     }
 
     public function testExpectedValuesForSapiFilesArray(): void
@@ -90,6 +93,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
+        self::assertSame(filesize($path), $file->size());
     }
 
     public function testUnReadableFile(): void

--- a/test/File/FileInformationTest.php
+++ b/test/File/FileInformationTest.php
@@ -6,7 +6,6 @@ namespace LaminasTest\Validator\File;
 
 use Laminas\Diactoros\UploadedFile;
 use Laminas\Validator\File\FileInformation;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function chmod;
@@ -14,7 +13,6 @@ use function filesize;
 use function touch;
 use function unlink;
 
-use const PHP_INT_MAX;
 use const UPLOAD_ERR_OK;
 
 /** @psalm-suppress InternalClass,InternalMethod,InternalProperty */
@@ -49,7 +47,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
-        self::assertSame(filesize($path), $file->size());
+        self::assertSame(filesize($path), $file->size()->bytes);
     }
 
     public function testExpectedValuesForUploadedFile(): void
@@ -72,7 +70,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
-        self::assertSame(filesize($path), $file->size());
+        self::assertSame(filesize($path), $file->size()->bytes);
     }
 
     public function testExpectedValuesForSapiFilesArray(): void
@@ -95,7 +93,7 @@ class FileInformationTest extends TestCase
         self::assertTrue($file->readable);
         self::assertSame('image/jpeg', $file->detectMimeType());
         self::assertSame('picture.jpg', $file->baseName);
-        self::assertSame(filesize($path), $file->size());
+        self::assertSame(filesize($path), $file->size()->bytes);
     }
 
     public function testUnReadableFile(): void
@@ -109,55 +107,5 @@ class FileInformationTest extends TestCase
         } finally {
             unlink($path);
         }
-    }
-
-    /** @return list<array{0: int, 1: string}> */
-    public static function bytesToSiUnitDataProvider(): array
-    {
-        return [
-            [10, '10B'],
-            [1536, '1.5kB'],
-            [2_621_440, '2.5MB'],
-            [1_073_741_824, '1GB'],
-            [6_442_450_944, '6GB'],
-            [6_597_069_766_656, '6TB'],
-            [6_755_399_441_055_744, '6PB'],
-        ];
-    }
-
-    #[DataProvider('bytesToSiUnitDataProvider')]
-    public function testBytesToSiUnit(int $input, string $expect): void
-    {
-        self::assertSame($expect, FileInformation::bytesToSiUnit($input));
-    }
-
-    public static function siUnitToBytesProvider(): array
-    {
-        return [
-            [10, '10b'],
-            [1536, '1.5kB'],
-            [2_621_440, '2.5MB'],
-            [1_073_741_824, '1GB'],
-            [6_442_450_944, '6GB'],
-            [6_597_069_766_656, '6TB'],
-            [10, '10 b'],
-            [1536, '1.5 kB'],
-            [1536, '1.5 kb'],
-            [2_621_440, '2.5 MB'],
-            [1_073_741_824, '1 GB'],
-            [6_442_450_944, '6 GB'],
-            [6_597_069_766_656, '6 TB'],
-            [6_755_399_441_055_744, '6 PB'],
-            [8_070_450_532_247_928_832, '7EB'],
-            [PHP_INT_MAX, '8EB'],
-            [PHP_INT_MAX, '1ZB'],
-            [PHP_INT_MAX, '10YB'],
-        ];
-    }
-
-    #[DataProvider('siUnitToBytesProvider')]
-    public function testSiUnitToBytes(int $expect, string $input): void
-    {
-        self::assertSame($expect, FileInformation::siUnitToBytes($input));
     }
 }

--- a/test/File/FilesSizeTest.php
+++ b/test/File/FilesSizeTest.php
@@ -10,49 +10,48 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function basename;
+use function chmod;
 use function current;
 use function filesize;
+use function json_encode;
+use function touch;
+use function unlink;
 
 use const UPLOAD_ERR_NO_FILE;
 
+/** @psalm-import-type OptionsArgument from FilesSize */
 final class FilesSizeTest extends TestCase
 {
-    public bool $multipleOptionsDetected;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->multipleOptionsDetected = false;
-    }
-
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @param array|int $options
+     * @param OptionsArgument $options
      */
     #[DataProvider('basicDataProvider')]
-    public function testBasic($options, bool $expected1, bool $expected2, bool $expected3): void
+    public function testBasic(array $options, bool $expected1, bool $expected2, bool $expected3): void
     {
-        $validator = new FilesSize(...$options);
+        $validator = new FilesSize($options);
 
         self::assertSame(
             $expected1,
-            $validator->isValid(__DIR__ . '/_files/testsize.mo')
+            $validator->isValid(__DIR__ . '/_files/testsize.mo'),
+            json_encode($validator->getMessages()),
         );
         self::assertSame(
             $expected2,
-            $validator->isValid(__DIR__ . '/_files/testsize2.mo')
+            $validator->isValid(__DIR__ . '/_files/testsize2.mo'),
+            json_encode($validator->getMessages()),
         );
         self::assertSame(
             $expected3,
-            $validator->isValid(__DIR__ . '/_files/testsize3.mo')
+            $validator->isValid(__DIR__ . '/_files/picture.jpg'),
+            json_encode($validator->getMessages()),
         );
     }
 
     /**
      * @psalm-return array<string, array{
-     *     0: array,
+     *     0: OptionsArgument,
      *     1: bool,
      *     2: bool,
      *     3: bool,
@@ -62,14 +61,14 @@ final class FilesSizeTest extends TestCase
     {
         return [
             // phpcs:disable
-            'minimum: 0 byte; maximum: 500 bytes; integer'  => [[500],                            false, false, false],
-            'minimum: 0 byte; maximum: 500 bytes; array'    => [[['min' => 0, 'max' => 500]],     false, false, false],
-            'minimum: 0 byte; maximum: 2000 bytes; integer' => [[2000],                           true,  true,  false],
-            'minimum: 0 byte; maximum: 2000 bytes; array'   => [[['min' => 0, 'max' => 2000]],    true,  true,  false],
-            'minimum: 0 byte; maximum: 500 kilobytes'       => [[['min' => 0, 'max' => 500000]],  true,  true,  true],
-            'minimum: 0 byte; maximum: 2 megabytes; 2 MB'   => [[['min' => 0, 'max' => '2 MB']],  true,  true,  true],
-            'minimum: 0 byte; maximum: 2 megabytes; 2MB'    => [[['min' => 0, 'max' => '2MB']],   true,  true,  true],
-            'minimum: 0 byte; maximum: 2 megabytes; 2  MB'  => [[['min' => 0, 'max' => '2  MB']], true,  true,  true],
+            'minimum: 0 byte; maximum: 500 bytes; integer'  => [['max' => 500],                 false, false, false],
+            'minimum: 0 byte; maximum: 500 bytes; array'    => [['min' => 0, 'max' => 500],     false, false, false],
+            'minimum: 0 byte; maximum: 2000 bytes; integer' => [['max' => 2000],                true,  true,  false],
+            'minimum: 0 byte; maximum: 2000 bytes; array'   => [['min' => 0, 'max' => 2000],    true,  true,  false],
+            'minimum: 0 byte; maximum: 500 kilobytes'       => [['min' => 0, 'max' => 500000],  true,  true,  true],
+            'minimum: 0 byte; maximum: 2 megabytes; 2 MB'   => [['min' => 0, 'max' => '2 MB'],  true,  true,  true],
+            'minimum: 0 byte; maximum: 2 megabytes; 2MB'    => [['min' => 0, 'max' => '2MB'],   true,  true,  true],
+            'minimum: 0 byte; maximum: 2 megabytes; 2  MB'  => [['min' => 0, 'max' => '2  MB'], true,  true,  true],
             // phpcs:enable
         ];
     }
@@ -90,78 +89,7 @@ final class FilesSizeTest extends TestCase
         $validator = new FilesSize(['min' => 0, 'max' => 200]);
 
         self::assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        self::assertArrayHasKey('fileFilesSizeNotReadable', $validator->getMessages());
-    }
-
-    /**
-     * Ensures that getMin() returns expected value
-     */
-    public function testGetMin(): void
-    {
-        $validator = new FilesSize(['min' => 1, 'max' => 100]);
-
-        self::assertSame('1B', $validator->getMin());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('greater than or equal');
-
-        new FilesSize(['min' => 100, 'max' => 1]);
-    }
-
-    /**
-     * Ensures that setMin() returns expected value
-     */
-    public function testSetMin(): void
-    {
-        $validator = new FilesSize(['min' => 1000, 'max' => 10000]);
-        $validator->setMin(100);
-
-        self::assertSame('100B', $validator->getMin());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('less than or equal');
-
-        $validator->setMin(20000);
-    }
-
-    /**
-     * Ensures that getMax() returns expected value
-     */
-    public function testGetMax(): void
-    {
-        $validator = new FilesSize(['min' => 1, 'max' => 100]);
-
-        self::assertSame('100B', $validator->getMax());
-
-        $validator = new FilesSize(['min' => 1, 'max' => 100000]);
-
-        self::assertSame('97.66kB', $validator->getMax());
-
-        $validator = new FilesSize(2000);
-        $validator->useByteString(false);
-        $test = $validator->getMax();
-
-        self::assertSame(2000, $test);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('greater than or equal');
-
-        new FilesSize(['min' => 100, 'max' => 1]);
-    }
-
-    /**
-     * Ensures that setMax() returns expected value
-     */
-    public function testSetMax(): void
-    {
-        $validator = new FilesSize(['min' => 1000, 'max' => 10000]);
-        $validator->setMax(1_000_000);
-
-        self::assertSame('976.56kB', $validator->getMax());
-
-        $validator->setMin(100);
-
-        self::assertSame('976.56kB', $validator->getMax());
+        self::assertArrayHasKey(FilesSize::NOT_READABLE, $validator->getMessages());
     }
 
     /**
@@ -173,7 +101,7 @@ final class FilesSizeTest extends TestCase
 
         self::assertFalse($validator->isValid([
             __DIR__ . '/_files/testsize.mo',
-            __DIR__ . '/_files/testsize.mo',
+            __DIR__ . '/_files/testsize.mo', // Duplicate Path
             __DIR__ . '/_files/testsize2.mo',
         ]));
 
@@ -186,7 +114,7 @@ final class FilesSizeTest extends TestCase
 
         self::assertFalse($validator->isValid([
             __DIR__ . '/_files/testsize.mo',
-            __DIR__ . '/_files/testsize.mo',
+            __DIR__ . '/_files/testsize.mo', // Duplicate Path
             __DIR__ . '/_files/testsize2.mo',
         ]));
 
@@ -198,7 +126,7 @@ final class FilesSizeTest extends TestCase
 
     public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage(): void
     {
-        $validator = new FilesSize(0);
+        $validator = new FilesSize(['min' => 0]);
 
         self::assertFalse($validator->isValid(''));
         self::assertArrayHasKey(FilesSize::NOT_READABLE, $validator->getMessages());
@@ -226,10 +154,10 @@ final class FilesSizeTest extends TestCase
             $validator->isValid($this->createFileInfo(__DIR__ . '/_files/testsize2.mo'))
         );
         self::assertFalse(
-            $validator->isValid($this->createFileInfo(__DIR__ . '/_files/testsize3.mo'))
+            $validator->isValid($this->createFileInfo(__DIR__ . '/_files/picture.jpg'))
         );
 
-        $validator = new FilesSize(['min' => 0, 'max' => 500000]);
+        $validator = new FilesSize(['min' => 0, 'max' => '2kb']);
 
         self::assertTrue($validator->isValid([
             $this->createFileInfo(__DIR__ . '/_files/testsize.mo'),
@@ -242,9 +170,8 @@ final class FilesSizeTest extends TestCase
     {
         $validator = new FilesSize(['min' => 0, 'max' => 2000]);
 
-        $this->expectException(InvalidArgumentException::class);
-
-        $validator->isValid([['error' => 0]]);
+        self::assertFalse($validator->isValid([['error' => 0]]));
+        self::assertArrayHasKey(FilesSize::NOT_READABLE, $validator->getMessages());
     }
 
     /**
@@ -261,27 +188,33 @@ final class FilesSizeTest extends TestCase
         ];
     }
 
-    public function testConstructorCanAcceptAllOptionsAsDiscreteArguments(): void
+    public function testMinOrMaxMustBeSet(): void
     {
-        $min              = 0;
-        $max              = 10;
-        $useBytesAsString = false;
-
-        $validator = new FilesSize($min, $max, $useBytesAsString);
-
-        self::assertNull($validator->getMin(true));
-        self::assertSame($max, $validator->getMax(true));
-        self::assertSame($useBytesAsString, $validator->getByteString());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('One of `min` or `max` options are required');
+        new FilesSize([]);
     }
 
-    public function testIsValidRaisesExceptionForArrayValueNotInFilesFormat(): void
+    public function testMinMustBeLessThanMax(): void
     {
-        $validator = new FilesSize(['min' => 0, 'max' => 2000]);
-        $value     = [['foo' => 'bar']];
-
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Value array must be in $_FILES format');
+        $this->expectExceptionMessage('The `min` option cannot exceed the `max` option');
+        new FilesSize(['min' => 500, 'max' => 100]);
+    }
 
-        $validator->isValid($value);
+    public function testUnreadableFile(): void
+    {
+        $validator = new FilesSize(['min' => 0, 'max' => '10MB']);
+
+        $path = __DIR__ . '/_files/no-read.txt';
+        touch($path);
+        chmod($path, 0333);
+        try {
+            self::assertFalse($validator->isValid($path));
+            $messages = $validator->getMessages();
+            self::assertArrayHasKey(FilesSize::NOT_READABLE, $messages);
+        } finally {
+            unlink($path);
+        }
     }
 }

--- a/test/File/FilesSizeTest.php
+++ b/test/File/FilesSizeTest.php
@@ -69,6 +69,7 @@ final class FilesSizeTest extends TestCase
             'minimum: 0 byte; maximum: 2 megabytes; 2 MB'   => [['min' => 0, 'max' => '2 MB'],  true,  true,  true],
             'minimum: 0 byte; maximum: 2 megabytes; 2MB'    => [['min' => 0, 'max' => '2MB'],   true,  true,  true],
             'minimum: 0 byte; maximum: 2 megabytes; 2  MB'  => [['min' => 0, 'max' => '2  MB'], true,  true,  true],
+            'minimum: 1k; maximum: 2 megabytes; 2  MB'      => [['min' => '1k', 'max' => '2  MB'], true,  true,  true],
             // phpcs:enable
         ];
     }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -17,6 +17,7 @@ use Laminas\Validator\File\ExcludeMimeType;
 use Laminas\Validator\File\Extension;
 use Laminas\Validator\File\FilesSize;
 use Laminas\Validator\File\MimeType;
+use Laminas\Validator\File\Size;
 use Laminas\Validator\InArray;
 use Laminas\Validator\IsInstanceOf;
 use Laminas\Validator\NumberComparison;
@@ -50,6 +51,7 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         InArray::class,
         MimeType::class,
         ExcludeMimeType::class,
+        Size::class,
     ];
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes options setters and getters
- Adds types
- Drops compat with legacy `Laminas\File\Transfer` api
- Moves SI unit parsing and formatting to FileInformation class