### PR TITLE
Refactor `ImageSize` validator

### DIFF
--- a/docs/book/v3/validators/file/image-size.md
+++ b/docs/book/v3/validators/file/image-size.md
@@ -22,9 +22,6 @@ The following set of options are supported:
 use Laminas\Validator\File\ImageSize;
 
 // Is image size between 320x200 (min) and 640x480 (max)?
-$validator = new ImageSize(320, 200, 640, 480);
-
-// ...or with array notation
 $validator = new ImageSize([
     'minWidth' => 320,
     'minHeight' => 200,
@@ -50,22 +47,10 @@ if ($validator->isValid('./myfile.jpg')) {
 }
 ```
 
-## Public Methods
+## Validating Uploaded Files
 
-### getImageMin
+This validator accepts and validates 3 types of argument:
 
-```php
-getImageMin() : array
-```
-
-Returns the minimum valid dimensions as an array with the keys `width` and
-`height`.
-
-### getImageMax
-
-```php
-getImageMax() : array
-```
-
-Returns the maximum valid dimensions as an array with the keys `width` and
-`height`.
+- A string that represents a path to an existing file
+- An array that represents an uploaded file as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instance

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -43,6 +43,7 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -289,7 +290,6 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$fileInfo['file']]]></code>
@@ -332,63 +332,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$options]]></code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="src/File/ImageSize.php">
-    <MixedArgument>
-      <code><![CDATA[$fileInfo['file']]]></code>
-      <code><![CDATA[$fileInfo['file']]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$options['maxHeight']]]></code>
-      <code><![CDATA[$options['maxWidth']]]></code>
-      <code><![CDATA[$options['minHeight']]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['maxHeight']]]></code>
-      <code><![CDATA[$this->options['maxWidth']]]></code>
-      <code><![CDATA[$this->options['minHeight']]]></code>
-      <code><![CDATA[$this->options['minWidth']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$options]]></code>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setMaxHeight]]></code>
-      <code><![CDATA[setMaxWidth]]></code>
-      <code><![CDATA[setMinHeight]]></code>
-      <code><![CDATA[setMinWidth]]></code>
-    </PossiblyUnusedMethod>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$height]]></code>
-      <code><![CDATA[$width]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(int) $maxHeight]]></code>
-      <code><![CDATA[(int) $maxWidth]]></code>
-      <code><![CDATA[(int) $minHeight]]></code>
-      <code><![CDATA[(int) $minWidth]]></code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->getMaxHeight() !== null]]></code>
-      <code><![CDATA[$this->getMaxHeight() !== null]]></code>
-      <code><![CDATA[$this->getMaxWidth() !== null]]></code>
-      <code><![CDATA[$this->getMaxWidth() !== null]]></code>
-      <code><![CDATA[$this->getMinHeight() !== null]]></code>
-      <code><![CDATA[$this->getMinWidth() !== null]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/Md5.php">
     <InvalidClassConstantType>
@@ -827,15 +770,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ImageSizeTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$minWidth]]></code>
-    </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$isValidParam['tmp_name']]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicBehaviorDataProvider]]></code>
-      <code><![CDATA[imageMaxProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/IsCompressedTest.php">

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -4,25 +4,24 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
-use Laminas\Stdlib\ErrorHandler;
 use Laminas\Validator\AbstractValidator;
-use Laminas\Validator\Exception;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
-use function array_shift;
-use function func_get_args;
-use function func_num_args;
+use function count;
 use function getimagesize;
-use function is_array;
-use function is_readable;
 
 /**
  * Validator for the image size of an image file
+ *
+ * @psalm-type OptionsArgument = array{
+ *     minWidth?: int|null,
+ *     maxWidth?: int|null,
+ *     minHeight?: int|null,
+ *     maxHeight?: int|null,
+ * }
  */
 final class ImageSize extends AbstractValidator
 {
-    use FileInformationTrait;
-
     /**
      * @const string Error constants
      */
@@ -43,333 +42,122 @@ final class ImageSize extends AbstractValidator
         self::NOT_READABLE     => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string> */
     protected array $messageVariables = [
-        'minwidth'  => ['options' => 'minWidth'],
-        'maxwidth'  => ['options' => 'maxWidth'],
-        'minheight' => ['options' => 'minHeight'],
-        'maxheight' => ['options' => 'maxHeight'],
+        'minwidth'  => 'minWidth',
+        'maxwidth'  => 'maxWidth',
+        'minheight' => 'minHeight',
+        'maxheight' => 'maxHeight',
         'width'     => 'width',
         'height'    => 'height',
     ];
 
     /**
      * Detected width
-     *
-     * @var int
      */
-    protected $width;
+    protected int|null $width;
 
     /**
      * Detected height
-     *
-     * @var int
      */
-    protected $height;
+    protected int|null $height;
 
-    /**
-     * Options for this validator
-     *
-     * @var array
-     */
-    protected $options = [
-        'minWidth'  => null, // Minimum image width
-        'maxWidth'  => null, // Maximum image width
-        'minHeight' => null, // Minimum image height
-        'maxHeight' => null, // Maximum image height
-    ];
+    protected readonly int $minWidth;
+    protected readonly int|null $maxWidth;
+    protected readonly int $minHeight;
+    protected readonly int|null $maxHeight;
 
     /**
      * Sets validator options
      *
      * Accepts the following option keys:
-     * - minheight
-     * - minwidth
-     * - maxheight
-     * - maxwidth
+     * - minHeight
+     * - minWidth
+     * - maxHeight
+     * - maxWidth
      *
-     * @param null|array|Traversable $options
+     * @param OptionsArgument $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options)
     {
-        if (1 < func_num_args()) {
-            if (! is_array($options)) {
-                $options = ['minWidth' => $options];
-            }
+        $minWidth  = $options['minWidth'] ?? 0;
+        $maxWidth  = $options['maxWidth'] ?? null;
+        $minHeight = $options['minHeight'] ?? 0;
+        $maxHeight = $options['maxHeight'] ?? null;
 
-            $argv = func_get_args();
-            array_shift($argv);
-            $options['minHeight'] = array_shift($argv);
-            if (! empty($argv)) {
-                $options['maxWidth'] = array_shift($argv);
-                if (! empty($argv)) {
-                    $options['maxHeight'] = array_shift($argv);
-                }
-            }
+        if ($minWidth === 0 && $maxWidth === null && $minHeight === 0 && $maxHeight === null) {
+            throw new InvalidArgumentException(
+                'At least one size constraint is required',
+            );
         }
+
+        if (($minWidth > (int) $maxWidth) || ($minHeight > (int) $maxHeight)) {
+            throw new InvalidArgumentException(
+                'Max width or height must exceed the minimum equivalent',
+            );
+        }
+
+        $this->minWidth  = $minWidth;
+        $this->maxWidth  = $maxWidth;
+        $this->minHeight = $minHeight;
+        $this->maxHeight = $maxHeight;
+        $this->width     = null;
+        $this->height    = null;
+
+        unset($options['minWidth'], $options['maxWidth'], $options['minHeight'], $options['maxHeight']);
 
         parent::__construct($options);
     }
 
     /**
-     * Returns the minimum allowed width
-     *
-     * @return int
-     */
-    public function getMinWidth()
-    {
-        return $this->options['minWidth'];
-    }
-
-    /**
-     * Sets the minimum allowed width
-     *
-     * @param  int $minWidth
-     * @return $this Provides a fluid interface
-     * @throws Exception\InvalidArgumentException When minwidth is greater than maxwidth.
-     */
-    public function setMinWidth($minWidth)
-    {
-        if (($this->getMaxWidth() !== null) && ($minWidth > $this->getMaxWidth())) {
-            throw new Exception\InvalidArgumentException(
-                'The minimum image width must be less than or equal to the '
-                . " maximum image width, but {$minWidth} > {$this->getMaxWidth()}"
-            );
-        }
-
-        $this->options['minWidth'] = (int) $minWidth;
-        return $this;
-    }
-
-    /**
-     * Returns the maximum allowed width
-     *
-     * @return int
-     */
-    public function getMaxWidth()
-    {
-        return $this->options['maxWidth'];
-    }
-
-    /**
-     * Sets the maximum allowed width
-     *
-     * @param  int $maxWidth
-     * @return $this Provides a fluid interface
-     * @throws Exception\InvalidArgumentException When maxwidth is less than minwidth.
-     */
-    public function setMaxWidth($maxWidth)
-    {
-        if (($this->getMinWidth() !== null) && ($maxWidth < $this->getMinWidth())) {
-            throw new Exception\InvalidArgumentException(
-                'The maximum image width must be greater than or equal to the '
-                . "minimum image width, but {$maxWidth} < {$this->getMinWidth()}"
-            );
-        }
-
-        $this->options['maxWidth'] = (int) $maxWidth;
-        return $this;
-    }
-
-    /**
-     * Returns the minimum allowed height
-     *
-     * @return int
-     */
-    public function getMinHeight()
-    {
-        return $this->options['minHeight'];
-    }
-
-    /**
-     * Sets the minimum allowed height
-     *
-     * @param  int $minHeight
-     * @return $this Provides a fluid interface
-     * @throws Exception\InvalidArgumentException When minheight is greater than maxheight.
-     */
-    public function setMinHeight($minHeight)
-    {
-        if (($this->getMaxHeight() !== null) && ($minHeight > $this->getMaxHeight())) {
-            throw new Exception\InvalidArgumentException(
-                'The minimum image height must be less than or equal to the '
-                . " maximum image height, but {$minHeight} > {$this->getMaxHeight()}"
-            );
-        }
-
-        $this->options['minHeight'] = (int) $minHeight;
-        return $this;
-    }
-
-    /**
-     * Returns the maximum allowed height
-     *
-     * @return int
-     */
-    public function getMaxHeight()
-    {
-        return $this->options['maxHeight'];
-    }
-
-    /**
-     * Sets the maximum allowed height
-     *
-     * @param  int $maxHeight
-     * @return $this Provides a fluid interface
-     * @throws Exception\InvalidArgumentException When maxheight is less than minheight.
-     */
-    public function setMaxHeight($maxHeight)
-    {
-        if (($this->getMinHeight() !== null) && ($maxHeight < $this->getMinHeight())) {
-            throw new Exception\InvalidArgumentException(
-                'The maximum image height must be greater than or equal to the '
-                . "minimum image height, but {$maxHeight} < {$this->getMinHeight()}"
-            );
-        }
-
-        $this->options['maxHeight'] = (int) $maxHeight;
-        return $this;
-    }
-
-    /**
-     * Returns the set minimum image sizes
-     *
-     * @return array
-     */
-    public function getImageMin()
-    {
-        return ['minWidth' => $this->getMinWidth(), 'minHeight' => $this->getMinHeight()];
-    }
-
-    /**
-     * Returns the set maximum image sizes
-     *
-     * @return array
-     */
-    public function getImageMax()
-    {
-        return ['maxWidth' => $this->getMaxWidth(), 'maxHeight' => $this->getMaxHeight()];
-    }
-
-    /**
-     * Returns the set image width sizes
-     *
-     * @return array
-     */
-    public function getImageWidth()
-    {
-        return ['minWidth' => $this->getMinWidth(), 'maxWidth' => $this->getMaxWidth()];
-    }
-
-    /**
-     * Returns the set image height sizes
-     *
-     * @return array
-     */
-    public function getImageHeight()
-    {
-        return ['minHeight' => $this->getMinHeight(), 'maxHeight' => $this->getMaxHeight()];
-    }
-
-    /**
-     * Sets the minimum image size
-     *
-     * @param  array $options                 The minimum image dimensions
-     * @return $this Provides a fluent interface
-     */
-    public function setImageMin($options)
-    {
-        $this->setOptions($options);
-        return $this;
-    }
-
-    /**
-     * Sets the maximum image size
-     *
-     * @param array|Traversable $options The maximum image dimensions
-     * @return $this Provides a fluent interface
-     */
-    public function setImageMax($options)
-    {
-        $this->setOptions($options);
-        return $this;
-    }
-
-    /**
-     * Sets the minimum and maximum image width
-     *
-     * @param  array $options               The image width dimensions
-     * @return $this Provides a fluent interface
-     */
-    public function setImageWidth($options)
-    {
-        $this->setImageMin($options);
-        $this->setImageMax($options);
-
-        return $this;
-    }
-
-    /**
-     * Sets the minimum and maximum image height
-     *
-     * @param  array $options               The image height dimensions
-     * @return $this Provides a fluent interface
-     */
-    public function setImageHeight($options)
-    {
-        $this->setImageMin($options);
-        $this->setImageMax($options);
-
-        return $this;
-    }
-
-    /**
      * Returns true if and only if the image size of $value is at least min and
      * not bigger than max
-     *
-     * @param  string|array $value Real file to check for image size
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
      */
-    public function isValid(mixed $value, $file = null): bool
+    public function isValid(mixed $value): bool
     {
-        $fileInfo = $this->getFileInfo($value, $file);
+        $this->width  = null;
+        $this->height = null;
 
-        $this->setValue($fileInfo['filename']);
-
-        // Is file readable ?
-        if (empty($fileInfo['file']) || false === is_readable($fileInfo['file'])) {
+        if (! FileInformation::isPossibleFile($value)) {
             $this->error(self::NOT_READABLE);
             return false;
         }
 
-        ErrorHandler::start();
-        $size = getimagesize($fileInfo['file']);
-        ErrorHandler::stop();
+        $file = FileInformation::factory($value);
 
-        if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {
+        if (! $file->readable) {
+            $this->error(self::NOT_READABLE);
+            return false;
+        }
+
+        $this->value = $file->clientFileName ?? $file->baseName;
+
+        $size = getimagesize($file->path);
+
+        if ($size === false || ($size[0] === 0) || ($size[1] === 0)) {
             $this->error(self::NOT_DETECTED);
             return false;
         }
 
         $this->width  = $size[0];
         $this->height = $size[1];
-        if ($this->width < $this->getMinWidth()) {
+        if ($this->width < $this->minWidth) {
             $this->error(self::WIDTH_TOO_SMALL);
         }
 
-        if (($this->getMaxWidth() !== null) && ($this->getMaxWidth() < $this->width)) {
+        if ($this->maxWidth !== null && $this->width > $this->maxWidth) {
             $this->error(self::WIDTH_TOO_BIG);
         }
 
-        if ($this->height < $this->getMinHeight()) {
+        if ($this->height < $this->minHeight) {
             $this->error(self::HEIGHT_TOO_SMALL);
         }
 
-        if (($this->getMaxHeight() !== null) && ($this->getMaxHeight() < $this->height)) {
+        if ($this->maxHeight !== null && $this->height > $this->maxHeight) {
             $this->error(self::HEIGHT_TOO_BIG);
         }
 
-        if ($this->getMessages()) {
+        if (count($this->getMessages()) > 0) {
             return false;
         }
 

--- a/test/File/ImageSizeTest.php
+++ b/test/File/ImageSizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Validator\File;
 
+use Laminas\Diactoros\UploadedFile;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\File\ImageSize;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -12,101 +13,97 @@ use PHPUnit\Framework\TestCase;
 
 use function array_merge;
 use function basename;
+use function chmod;
 use function current;
-use function is_array;
+use function file_exists;
+use function touch;
+use function unlink;
 
 use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_OK;
 
+/** @psalm-import-type OptionsArgument from ImageSize */
 final class ImageSizeTest extends TestCase
 {
     /**
      * @psalm-return array<array-key, array{
-     *     0: array<string, int>,
-     *     1: string|array{
-     *         tmp_name: string,
-     *         name: string,
-     *         size: int,
-     *         error: int,
-     *         type: string
-     *     },
+     *     0: OptionsArgument,
+     *     1: mixed,
      *     2: bool,
-     *     3: string|string[]
+     *     3: null|list<string>
      * }>
      */
     public static function basicBehaviorDataProvider(): array
     {
         $testFile     = __DIR__ . '/_files/picture.jpg';
         $pictureTests = [
-            //    Options, isValid Param, Expected value, Expected message
             [
                 ['minWidth' => 0,   'minHeight' => 10,  'maxWidth' => 1000, 'maxHeight' => 2000],
                 $testFile,
                 true,
-                '',
+                null,
             ],
             [
                 ['minWidth' => 0,   'minHeight' => 0,   'maxWidth' => 200,  'maxHeight' => 200],
                 $testFile,
                 true,
-                '',
+                null,
             ],
             [
                 ['minWidth' => 150, 'minHeight' => 150, 'maxWidth' => 200,  'maxHeight' => 200],
                 $testFile,
                 false,
-                ['fileImageSizeWidthTooSmall', 'fileImageSizeHeightTooSmall'],
+                [ImageSize::WIDTH_TOO_SMALL, ImageSize::HEIGHT_TOO_SMALL],
             ],
             [
                 ['minWidth' => 80,  'minHeight' => 0,   'maxWidth' => 80,   'maxHeight' => 200],
                 $testFile,
                 true,
-                '',
+                null,
             ],
             [
                 ['minWidth' => 0,   'minHeight' => 0,   'maxWidth' => 60,   'maxHeight' => 200],
                 $testFile,
                 false,
-                'fileImageSizeWidthTooBig',
+                [ImageSize::WIDTH_TOO_BIG],
             ],
             [
                 ['minWidth' => 90,  'minHeight' => 0,   'maxWidth' => 200,  'maxHeight' => 200],
                 $testFile,
                 false,
-                'fileImageSizeWidthTooSmall',
+                [ImageSize::WIDTH_TOO_SMALL],
             ],
             [
                 ['minWidth' => 0,   'minHeight' => 0,   'maxWidth' => 200,  'maxHeight' => 80],
                 $testFile,
                 false,
-                'fileImageSizeHeightTooBig',
+                [ImageSize::HEIGHT_TOO_BIG],
             ],
             [
                 ['minWidth' => 0,   'minHeight' => 110, 'maxWidth' => 200,  'maxHeight' => 140],
                 $testFile,
                 false,
-                'fileImageSizeHeightTooSmall',
+                [ImageSize::HEIGHT_TOO_SMALL],
             ],
         ];
 
         $testFile    = __DIR__ . '/_files/nofile.mo';
         $noFileTests = [
-            //    Options, isValid Param, Expected value, message
             [
                 ['minWidth' => 0, 'minHeight' => 10, 'maxWidth' => 1000, 'maxHeight' => 2000],
                 $testFile,
                 false,
-                'fileImageSizeNotReadable',
+                [ImageSize::NOT_READABLE],
             ],
         ];
 
         $testFile    = __DIR__ . '/_files/badpicture.jpg';
         $badPicTests = [
-            //    Options, isValid Param, Expected value, message
             [
                 ['minWidth' => 0, 'minHeight' => 10, 'maxWidth' => 1000, 'maxHeight' => 2000],
                 $testFile,
                 false,
-                'fileImageSizeNotDetected',
+                [ImageSize::NOT_DETECTED],
             ],
         ];
 
@@ -117,10 +114,24 @@ final class ImageSizeTest extends TestCase
                 'tmp_name' => $data[1],
                 'name'     => basename($data[1]),
                 'size'     => 200,
-                'error'    => 0,
+                'error'    => UPLOAD_ERR_OK,
                 'type'     => 'text',
             ];
             $testData[] = [$data[0], $fileUpload, $data[2], $data[3]];
+
+            if (! file_exists($data[1])) {
+                continue; // Cannot use a non-existent file as a stream argument
+            }
+
+            $psrUpload = new UploadedFile(
+                $data[1],
+                200,
+                UPLOAD_ERR_OK,
+                basename($data[1]),
+                'image/jpg',
+            );
+
+            $testData[] = [$data[0], $psrUpload, $data[2], $data[3]];
         }
 
         return $testData;
@@ -129,216 +140,25 @@ final class ImageSizeTest extends TestCase
     /**
      * Ensures that the validator follows expected behavior
      *
-     * @param string|array $isValidParam
-     * @param string|string[] $messageKeys
+     * @param OptionsArgument $options
+     * @param list<string>|null $messageKeys
      */
     #[DataProvider('basicBehaviorDataProvider')]
-    public function testBasic(array $options, $isValidParam, bool $expected, $messageKeys): void
+    public function testBasic(array $options, mixed $isValidParam, bool $expected, array|null $messageKeys): void
     {
         $validator = new ImageSize($options);
 
         self::assertSame($expected, $validator->isValid($isValidParam));
 
-        if (! $expected) {
-            if (! is_array($messageKeys)) {
-                $messageKeys = [$messageKeys];
-            }
+        if ($messageKeys === null) {
+            self::assertSame([], $validator->getMessages());
 
-            foreach ($messageKeys as $messageKey) {
-                self::assertArrayHasKey($messageKey, $validator->getMessages());
-            }
-        }
-    }
-
-    /**
-     * Ensures that the validator follows expected behavior for legacy Laminas\Transfer API
-     *
-     * @param string|array $isValidParam
-     * @param string|string[] $messageKeys
-     */
-    #[DataProvider('basicBehaviorDataProvider')]
-    public function testLegacy(array $options, $isValidParam, bool $expected, $messageKeys): void
-    {
-        if (! is_array($isValidParam)) {
-            self::markTestSkipped('An array is expected for legacy compat tests');
+            return;
         }
 
-        $validator = new ImageSize($options);
-
-        self::assertSame($expected, $validator->isValid($isValidParam['tmp_name'], $isValidParam));
-
-        if (! $expected) {
-            if (! is_array($messageKeys)) {
-                $messageKeys = [$messageKeys];
-            }
-
-            foreach ($messageKeys as $messageKey) {
-                self::assertArrayHasKey($messageKey, $validator->getMessages());
-            }
+        foreach ($messageKeys as $messageKey) {
+            self::assertArrayHasKey($messageKey, $validator->getMessages());
         }
-    }
-
-    /**
-     * Ensures that getImageMin() returns expected value
-     */
-    public function testGetImageMin(): void
-    {
-        $validator = new ImageSize(['minWidth' => 1, 'minHeight' => 10, 'maxWidth' => 100, 'maxHeight' => 1000]);
-
-        self::assertSame(['minWidth' => 1, 'minHeight' => 10], $validator->getImageMin());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('greater than or equal');
-
-        new ImageSize(['minWidth' => 1000, 'minHeight' => 100, 'maxWidth' => 10, 'maxHeight' => 1]);
-    }
-
-    /**
-     * Ensures that setImageMin() returns expected value
-     */
-    public function testSetImageMin(): void
-    {
-        $validator = new ImageSize([
-            'minWidth'  => 100,
-            'minHeight' => 1000,
-            'maxWidth'  => 10000,
-            'maxHeight' => 100000,
-        ]);
-        $validator->setImageMin(['minWidth' => 10, 'minHeight' => 10]);
-
-        self::assertSame(['minWidth' => 10, 'minHeight' => 10], $validator->getImageMin());
-
-        $validator->setImageMin(['minWidth' => 9, 'minHeight' => 100]);
-
-        self::assertSame(['minWidth' => 9, 'minHeight' => 100], $validator->getImageMin());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('less than or equal');
-
-        $validator->setImageMin(['minWidth' => 20000, 'minHeight' => 20000]);
-    }
-
-    /**
-     * Ensures that getImageMax() returns expected value
-     */
-    public function testGetImageMax(): void
-    {
-        $validator = new ImageSize([
-            'minWidth'  => 10,
-            'minHeight' => 100,
-            'maxWidth'  => 1000,
-            'maxHeight' => 10000,
-        ]);
-
-        self::assertSame(['maxWidth' => 1000, 'maxHeight' => 10000], $validator->getImageMax());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('greater than or equal');
-
-        new ImageSize([
-            'minWidth'  => 10000,
-            'minHeight' => 1000,
-            'maxWidth'  => 100,
-            'maxHeight' => 10,
-        ]);
-    }
-
-    /** @psalm-return array<array{array<string, int>, array<string, int>}> */
-    public static function imageMaxProvider(): array
-    {
-        return [
-            [['maxWidth' => 100, 'maxHeight' => 100], ['maxWidth' => 100, 'maxHeight' => 100]],
-            [['maxWidth' => 110, 'maxHeight' => 1000], ['maxWidth' => 110, 'maxHeight' => 1000]],
-            [['maxHeight' => 1100], ['maxWidth' => 1000, 'maxHeight' => 1100]],
-            [['maxWidth' => 120], ['maxWidth' => 120, 'maxHeight' => 10000]],
-        ];
-    }
-
-    /**
-     * Ensures that setImageMax() returns expected value
-     *
-     * @param array<string, int> $imageMax
-     * @param array<string, int> $expected
-     */
-    #[DataProvider('imageMaxProvider')]
-    public function testSetImageMax(array $imageMax, array $expected): void
-    {
-        $validator = new ImageSize([
-            'minWidth'  => 10,
-            'minHeight' => 100,
-            'maxWidth'  => 1000,
-            'maxHeight' => 10000,
-        ]);
-        $validator->setImageMax($imageMax);
-
-        self::assertSame($expected, $validator->getImageMax());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('greater than or equal');
-
-        $validator->setImageMax(['maxWidth' => 10000, 'maxHeight' => 1]);
-    }
-
-    /**
-     * Ensures that getImageWidth() returns expected value
-     */
-    public function testGetImageWidth(): void
-    {
-        $validator = new ImageSize(['minWidth' => 1, 'minHeight' => 10, 'maxWidth' => 100, 'maxHeight' => 1000]);
-
-        self::assertSame(['minWidth' => 1, 'maxWidth' => 100], $validator->getImageWidth());
-    }
-
-    /**
-     * Ensures that setImageWidth() returns expected value
-     */
-    public function testSetImageWidth(): void
-    {
-        $validator = new ImageSize([
-            'minWidth'  => 100,
-            'minHeight' => 1000,
-            'maxWidth'  => 10000,
-            'maxHeight' => 100000,
-        ]);
-        $validator->setImageWidth(['minWidth' => 2000, 'maxWidth' => 2200]);
-
-        self::assertSame(['minWidth' => 2000, 'maxWidth' => 2200], $validator->getImageWidth());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('less than or equal');
-
-        $validator->setImageWidth(['minWidth' => 20000, 'maxWidth' => 200]);
-    }
-
-    /**
-     * Ensures that getImageHeight() returns expected value
-     */
-    public function testGetImageHeight(): void
-    {
-        $validator = new ImageSize(['minWidth' => 1, 'minHeight' => 10, 'maxWidth' => 100, 'maxHeight' => 1000]);
-
-        self::assertSame(['minHeight' => 10, 'maxHeight' => 1000], $validator->getImageHeight());
-    }
-
-    /**
-     * Ensures that setImageHeight() returns expected value
-     */
-    public function testSetImageHeight(): void
-    {
-        $validator = new ImageSize([
-            'minWidth'  => 100,
-            'minHeight' => 1000,
-            'maxWidth'  => 10000,
-            'maxHeight' => 100000,
-        ]);
-        $validator->setImageHeight(['minHeight' => 2000, 'maxHeight' => 2200]);
-
-        self::assertSame(['minHeight' => 2000, 'maxHeight' => 2200], $validator->getImageHeight());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('less than or equal');
-
-        $validator->setImageHeight(['minHeight' => 20000, 'maxHeight' => 200]);
     }
 
     #[Group('Laminas-11258')]
@@ -352,13 +172,13 @@ final class ImageSizeTest extends TestCase
         ]);
 
         self::assertFalse($validator->isValid(__DIR__ . '/_files/nofile.mo'));
-        self::assertArrayHasKey('fileImageSizeNotReadable', $validator->getMessages());
+        self::assertArrayHasKey(ImageSize::NOT_READABLE, $validator->getMessages());
         self::assertStringContainsString('does not exist', current($validator->getMessages()));
     }
 
     public function testEmptyFileShouldReturnFalseAndDisplayNotFoundMessage(): void
     {
-        $validator = new ImageSize();
+        $validator = new ImageSize(['maxWidth' => 100]);
 
         self::assertFalse($validator->isValid(''));
         self::assertArrayHasKey(ImageSize::NOT_READABLE, $validator->getMessages());
@@ -375,33 +195,43 @@ final class ImageSizeTest extends TestCase
         self::assertArrayHasKey(ImageSize::NOT_READABLE, $validator->getMessages());
     }
 
-    public function testConstructorCanAcceptAllOptionsAsDiscreteArguments(): void
+    public function testThatOptionsMustBeProvided(): void
     {
-        $minWidth  = 20;
-        $minHeight = 10;
-        $maxWidth  = 200;
-        $maxHeight = 100;
-        $validator = new ImageSize($minWidth, $minHeight, $maxWidth, $maxHeight);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one size constraint is required');
 
-        self::assertSame($minWidth, $validator->getMinWidth());
-        self::assertSame($minHeight, $validator->getMinHeight());
-        self::assertSame($maxWidth, $validator->getMaxWidth());
-        self::assertSame($maxHeight, $validator->getMaxHeight());
+        new ImageSize([]);
     }
 
-    public function testIsValidRaisesExceptionForArrayNotInFilesFormat(): void
+    public function testInvalidWidthConstraints(): void
     {
-        $validator = new ImageSize([
-            'minWidth'  => 100,
-            'minHeight' => 1000,
-            'maxWidth'  => 10000,
-            'maxHeight' => 100000,
-        ]);
-        $value     = ['foo' => 'bar'];
-
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Value array must be in $_FILES format');
+        $this->expectExceptionMessage('Max width or height must exceed the minimum equivalent');
 
-        $validator->isValid($value);
+        new ImageSize(['minWidth' => 100, 'maxWidth' => 50]);
+    }
+
+    public function testInvalidHeightConstraints(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Max width or height must exceed the minimum equivalent');
+
+        new ImageSize(['minHeight' => 100, 'maxHeight' => 50]);
+    }
+
+    public function testUnreadableFile(): void
+    {
+        $validator = new ImageSize(['minWidth' => 0, 'maxWidth' => 500]);
+
+        $path = __DIR__ . '/_files/no-read.txt';
+        touch($path);
+        chmod($path, 0333);
+        try {
+            self::assertFalse($validator->isValid($path));
+            $messages = $validator->getMessages();
+            self::assertArrayHasKey(ImageSize::NOT_READABLE, $messages);
+        } finally {
+            unlink($path);
+        }
     }
 }

--- a/test/ValidatorPluginManagerCompatibilityTest.php
+++ b/test/ValidatorPluginManagerCompatibilityTest.php
@@ -16,6 +16,7 @@ use Laminas\Validator\File\ExcludeExtension;
 use Laminas\Validator\File\ExcludeMimeType;
 use Laminas\Validator\File\Extension;
 use Laminas\Validator\File\FilesSize;
+use Laminas\Validator\File\ImageSize;
 use Laminas\Validator\File\MimeType;
 use Laminas\Validator\File\Size;
 use Laminas\Validator\File\WordCount;
@@ -54,6 +55,7 @@ final class ValidatorPluginManagerCompatibilityTest extends TestCase
         ExcludeMimeType::class,
         Size::class,
         WordCount::class,
+        ImageSize::class,
     ];
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes all getters and setters
- Require valid options up-front in the constructor
- Drops compat with legacy `Laminas\File\Transfer`
