### PR TITLE
Refactor `Exists` and `NotExists` validators

### DIFF
--- a/docs/book/v3/validators/file/exists.md
+++ b/docs/book/v3/validators/file/exists.md
@@ -9,7 +9,8 @@ This validator is inversely related to the [NotExists validator](not-exists.md).
 
 The following set of options are supported:
 
-- `directory`: Array of directories, or comma-delimited string  of directories.
+- `directory`: Array of directories, or comma-delimited string of directories.
+- `all`: A boolean that when `true` _(default)_ requires that the filename is present in **all** the listed directories 
 
 ## Usage Examples
 
@@ -17,19 +18,55 @@ The following set of options are supported:
 use Laminas\Validator\File\Exists;
 
 // Only allow files that exist in ~both~ directories
-$validator = new Exists('/tmp,/var/tmp');
+$validator = new Exists(['directory' => '/tmp,/var/tmp']);
 
-// ...or with array notation
-$validator = new Exists(['/tmp', '/var/tmp']);
+if ($validator->isValid('myfile.txt')) {
+    // file is present in all directories
+} else {
+    // file was not present in at least 1 of the directories
+}
+```
 
-// Perform validation
-if ($validator->isValid('/tmp/myfile.txt')) {
-    // file is valid
+```php
+use Laminas\Validator\File\Exists;
+
+// Allow files that exist in any of the listed directories
+$validator = new Exists([
+    'directory' => ['/tmp', '/var/tmp'],
+    'all' => false,
+]);
+
+if ($validator->isValid('myfile.txt')) {
+    // file was found in at least 1 directory
+} else {
+    // file was not found in one of the directories
+}
+```
+
+```php
+use Laminas\Validator\File\Exists;
+
+// Check the value for existence without a directory option
+$validator = new Exists();
+
+if ($validator->isValid('/path/to/myfile.txt')) {
+    // file exists
 }
 ```
 
 > ### Checks against all directories
 >
-> This validator checks whether the specified file exists in **all** of the
+> By default, this validator checks whether the specified file exists in **all** of the
 > given directories; validation will fail if the file does not exist in one
-> or more of them.
+> or more of them. To change this behaviour, be sure to set the `all` option to false.
+
+## Validating Uploaded Files
+
+This validator accepts and validates 3 types of argument:
+
+- A string that represents a path or a file name
+- An array that represents an uploaded file as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instance
+
+Without a `directory` option, the validator will check any of the listed argument types to ensure they exist.
+For example, without a `directory` option, any successful upload will be deemed valid.

--- a/docs/book/v3/validators/file/not-exists.md
+++ b/docs/book/v3/validators/file/not-exists.md
@@ -9,29 +9,22 @@ This validator is inversely related to the [Exists validator](exists.md).
 
 The following set of options are supported:
 
-- `directory`: Array of directories or comma-delimited string of directories
-  against which to validate.
+- `directory`: Array of directories or comma-delimited string of directories against which to validate.
 
 ## Basic Usage
 
 ```php
 use Laminas\Validator\File\NotExists;
 
-// Only allow files that do not exist in ~either~ directories
-$validator = new NotExists('/tmp,/var/tmp');
+// Only allow files that do not exist in any of the given directories
+$validator = new NotExists([
+    'directory' => ['/tmp', '/var/tmp'],
+]);
 
-// ... or with array notation:
-$validator = new NotExists(['/tmp', '/var/tmp']);
-
-// ... or using options notation:
-$validator = new NotExists(['directory' => [
-    '/tmp',
-    '/var/tmp',
-]]);
-
-// Perform validation
-if ($validator->isValid('/home/myfile.txt')) {
-    // file is valid
+if ($validator->isValid('some-file.txt')) {
+    // File cannot be found in any of the directories provided
+} else {
+    // A file with the given name was found
 }
 ```
 
@@ -40,3 +33,35 @@ if ($validator->isValid('/home/myfile.txt')) {
 > This validator checks whether the specified file does not exist in **any** of
 > the given directories; validation will fail if the file exists in one (or
 > more) of the given directories.
+
+## Validating Uploaded Files
+
+This validator accepts and validates 3 types of argument:
+
+- A string that represents a path or a file name
+- An array that represents an uploaded file as per PHP's [`$_FILES`](https://www.php.net/manual/reserved.variables.files.php) superglobal
+- A PSR-7 [`UploadedFileInterface`](https://www.php-fig.org/psr/psr-7/#36-psrhttpmessageuploadedfileinterface) instance
+
+When provided with either a PSR-7 Uploaded File, or a normalised `$_FILES` upload, if the directory option is unset, validation will fail for successfully uploaded files, however, when a directory option is provided, the given directories are searched for the base name of the uploaded file path.
+
+In the following example, assume `$files` is an array that represents a single, successful file upload in PHP's `$_FILES` array format. 
+
+```php
+use Laminas\Validator\File\NotExists;
+
+$validator = new NotExists();
+$validator->isValid($files); // False - the uploaded file exists (Of course)
+
+$validator = new NotExists([
+    'directory' => [
+        '/home/files',
+        '/tmp',
+    ],
+]);
+
+if ($validator->isValid($files)) {
+    // The basename of the uploaded file could not be found in any of the directories
+} else {
+    // The basename of the uploaded file was located in at least 1 of the directories
+}
+```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -159,48 +159,6 @@
       <code><![CDATA[strrpos($fileInfo['filename'], '.')]]></code>
     </PossiblyFalseOperand>
   </file>
-  <file src="src/File/Exists.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($directory)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidIterator>
-      <code><![CDATA[$directories]]></code>
-    </InvalidIterator>
-    <InvalidReturnStatement>
-      <code><![CDATA[$directory]]></code>
-    </InvalidReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$fileInfo['file']]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$directories]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment>
-      <code><![CDATA[$dir]]></code>
-      <code><![CDATA[$directory]]></code>
-      <code><![CDATA[$directory]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[string|null]]></code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$directory]]></code>
-      <code><![CDATA[$fileInfo['basename']]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$directory]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$directories]]></code>
-      <code><![CDATA[$options]]></code>
-    </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $asArray]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/File/Extension.php">
     <MixedArgument>
       <code><![CDATA[$ext]]></code>
@@ -264,31 +222,11 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$fileInfo['file']]]></code>
       <code><![CDATA[$value]]></code>
     </PossiblyInvalidCast>
-  </file>
-  <file src="src/File/NotExists.php">
-    <InvalidIterator>
-      <code><![CDATA[$directories]]></code>
-    </InvalidIterator>
-    <MixedArgument>
-      <code><![CDATA[$fileInfo['file']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$directory]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code><![CDATA[$directory]]></code>
-      <code><![CDATA[$fileInfo['basename']]]></code>
-    </MixedOperand>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
   </file>
   <file src="src/File/Upload.php">
     <DocblockTypeContradiction>
@@ -581,20 +519,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExistsTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$value]]></code>
-    </ArgumentTypeCoercion>
-    <MixedArgument>
-      <code><![CDATA[$isValidParam['tmp_name']]]></code>
-    </MixedArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$value]]></code>
-    </PossiblyNullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicBehaviorDataProvider]]></code>
-      <code><![CDATA[getDirectoryProvider]]></code>
-      <code><![CDATA[invalidDirectoryArguments]]></code>
-      <code><![CDATA[setDirectoryProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExtensionTest.php">
@@ -655,20 +581,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/NotExistsTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$value]]></code>
-    </ArgumentTypeCoercion>
-    <MixedArgument>
-      <code><![CDATA[$isValidParam['tmp_name']]]></code>
-    </MixedArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$value]]></code>
-    </PossiblyNullArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicBehaviorDataProvider]]></code>
-      <code><![CDATA[getDirectoryProvider]]></code>
-      <code><![CDATA[invalidDirectoryArguments]]></code>
-      <code><![CDATA[setDirectoryProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/SizeTest.php">

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -4,20 +4,31 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Validator\AbstractValidator;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function explode;
 use function file_exists;
+use function implode;
+use function is_string;
+use function ltrim;
+use function rtrim;
+use function sprintf;
+use function trim;
 
 use const DIRECTORY_SEPARATOR;
 
 /**
  * Validator which checks if the destination file does not exist
+ *
+ * @psalm-type OptionsArgument = array{
+ *      directory?: string|list<string>,
+ *  }
  */
-final class NotExists extends Exists
+final class NotExists extends AbstractValidator
 {
-    use FileInformationTrait;
-
-    /**
-     * @const string Error constants
-     */
     public const DOES_EXIST = 'fileNotExistsDoesExist';
 
     /** @var array<string, string> */
@@ -25,45 +36,84 @@ final class NotExists extends Exists
         self::DOES_EXIST => 'File exists',
     ];
 
+    /** @var array<string, string|array> */
+    protected array $messageVariables = [
+        'directory' => 'directoriesAsString',
+    ];
+
+    protected readonly string $directoriesAsString;
+
+    /** @var list<string> */
+    private readonly array $directories;
+
+    /**
+     * Sets validator options
+     *
+     * @param OptionsArgument $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->directories         = $this->resolveDirectories($options['directory'] ?? null);
+        $this->directoriesAsString = implode(', ', $this->directories);
+
+        parent::__construct($options);
+    }
+
     /**
      * Returns true if and only if the file does not exist in the set destinations
-     *
-     * @param  string|array $value Real file to check for existence
-     * @param  array        $file  File data from \Laminas\File\Transfer\Transfer (optional)
      */
-    public function isValid(mixed $value, $file = null): bool
+    public function isValid(mixed $value): bool
     {
-        $fileInfo = $this->getFileInfo($value, $file, false, true);
-
-        $this->setValue($fileInfo['filename']);
-
-        $check       = false;
-        $directories = $this->getDirectory(true);
-        if (! isset($directories)) {
-            $check = true;
-            if (file_exists($fileInfo['file'])) {
+        if (FileInformation::isPossibleFile($value)) {
+            if ($this->directories === []) {
                 $this->error(self::DOES_EXIST);
+
                 return false;
             }
-        } else {
-            foreach ($directories as $directory) {
-                if (! isset($directory) || '' === $directory) {
-                    continue;
-                }
 
-                $check = true;
-                if (file_exists($directory . DIRECTORY_SEPARATOR . $fileInfo['basename'])) {
-                    $this->error(self::DOES_EXIST);
-                    return false;
-                }
-            }
+            $file = FileInformation::factory($value);
+
+            $value = $file->baseName;
         }
 
-        if (! $check) {
-            $this->error(self::DOES_EXIST);
-            return false;
+        $this->value = $value;
+
+        if (! is_string($value)) {
+            // Not a file path, therefore it cannot exist.
+            return true;
+        }
+
+        foreach ($this->directories as $directory) {
+            $path = sprintf(
+                '%s%s%s',
+                rtrim($directory, DIRECTORY_SEPARATOR),
+                DIRECTORY_SEPARATOR,
+                ltrim($value, DIRECTORY_SEPARATOR),
+            );
+
+            if (file_exists($path)) {
+                $this->error(self::DOES_EXIST);
+
+                return false;
+            }
         }
 
         return true;
+    }
+
+    /** @return list<string> */
+    private function resolveDirectories(string|array|null $directories): array
+    {
+        if ($directories === null || $directories === [] || $directories === '') {
+            return [];
+        }
+
+        if (is_string($directories)) {
+            $directories = explode(',', $directories);
+        }
+
+        return array_values(array_filter(array_map(static function (string $directory): string {
+            return trim($directory);
+        }, $directories)));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes all setters and getters
- Removes inheritance so both classes can be final
- Removes compat with legacy `Laminas\File\Transfer` api
- Improves docs and tests
