### PR TITLE
Refactor file `Count` validator

### DIFF
--- a/docs/book/v3/validators/file/count.md
+++ b/docs/book/v3/validators/file/count.md
@@ -21,8 +21,7 @@ $validator = new Laminas\Validator\File\Count([
     'max' => 5,
 ]);
 
-// Setting to the $_FILES superglobal; could also use the laminas-http
-// request's `getFiles()` or PSR-7 ServerRequest's `getUploadedFiles()`.
+// Setting to the $_FILES superglobal or PSR-7 ServerRequest's `getUploadedFiles()`.
 $files = $_FILES;
 
 if ($validator->isValid($files)) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -44,6 +44,7 @@
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
       <code><![CDATA[$this->options]]></code>
+      <code><![CDATA[$this->options]]></code>
     </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Barcode/Code128.php">
@@ -88,55 +89,6 @@
     <TooManyArguments>
       <code><![CDATA[isValid]]></code>
     </TooManyArguments>
-  </file>
-  <file src="src/File/Count.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($options)]]></code>
-    </DocblockTypeContradiction>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->files[$name]]]></code>
-      <code><![CDATA[$this->files[$name]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-      <code><![CDATA[$name]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[int]]></code>
-      <code><![CDATA[int]]></code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$file['destination']]]></code>
-      <code><![CDATA[$file['name']]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->options['max']]]></code>
-      <code><![CDATA[$this->options['min']]]></code>
-    </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$value]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$value]]></code>
-    </PossiblyInvalidCast>
-    <PropertyNotSetInConstructor>
-      <code><![CDATA[$count]]></code>
-      <code><![CDATA[$files]]></code>
-    </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$this->getMax() !== null]]></code>
-      <code><![CDATA[$this->getMax() !== null]]></code>
-      <code><![CDATA[$this->getMin() !== null]]></code>
-      <code><![CDATA[$this->getMin() !== null]]></code>
-      <code><![CDATA[is_string($file)]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/File/ExcludeExtension.php">
     <InvalidClassConstantType>
@@ -477,13 +429,8 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/CountTest.php">
-    <MixedArgument>
-      <code><![CDATA[$max]]></code>
-      <code><![CDATA[$min]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
-      <code><![CDATA[invalidMinMaxValues]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ExcludeExtensionTest.php">

--- a/src/File/Count.php
+++ b/src/File/Count.php
@@ -5,279 +5,105 @@ declare(strict_types=1);
 namespace Laminas\Validator\File;
 
 use Laminas\Validator\AbstractValidator;
-use Laminas\Validator\Exception;
-use Psr\Http\Message\UploadedFileInterface;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
-use function array_key_exists;
-use function array_shift;
-use function count;
-use function dirname;
-use function func_get_args;
-use function func_num_args;
 use function is_array;
-use function is_numeric;
-use function is_string;
-
-use const DIRECTORY_SEPARATOR;
 
 /**
  * Validator for counting all given files
+ *
+ * @psalm-type OptionsArgument = array{
+ *     min?: positive-int|null,
+ *     max?: positive-int|null,
+ * }
  */
 final class Count extends AbstractValidator
 {
-    /**#@+
-     *
-     * @const string Error constants
-     */
-    public const TOO_MANY = 'fileCountTooMany';
-    public const TOO_FEW  = 'fileCountTooFew';
-    /**#@-*/
+    public const TOO_MANY        = 'fileCountTooMany';
+    public const TOO_FEW         = 'fileCountTooFew';
+    public const ERROR_NOT_ARRAY = 'fileListNotCountable';
 
     /** @var array<string, string> */
     protected array $messageTemplates = [
-        self::TOO_MANY => "Too many files, maximum '%max%' are allowed but '%count%' are given",
-        self::TOO_FEW  => "Too few files, minimum '%min%' are expected but '%count%' are given",
+        self::TOO_MANY        => "Too many files, maximum '%max%' are allowed but '%count%' are given",
+        self::TOO_FEW         => "Too few files, minimum '%min%' are expected but '%count%' are given",
+        self::ERROR_NOT_ARRAY => 'Invalid type provided. The file list must an array.',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string> */
     protected array $messageVariables = [
-        'min'   => ['options' => 'min'],
-        'max'   => ['options' => 'max'],
+        'min'   => 'min',
+        'max'   => 'max',
         'count' => 'count',
     ];
 
-    /**
-     * Actual filecount
-     *
-     * @var int
-     */
-    protected $count;
-
-    /**
-     * Internal file array
-     *
-     * @var array
-     */
-    protected $files;
-
-    /**
-     * Options for this validator
-     *
-     * @var array
-     */
-    protected $options = [
-        'min' => null, // Minimum file count, if null there is no minimum file count
-        'max' => null, // Maximum file count, if null there is no maximum file count
-    ];
+    protected int $count;
+    protected readonly int|null $min;
+    protected readonly int|null $max;
 
     /**
      * Sets validator options
      *
-     * Min limits the file count, when used with max=null it is the maximum file count
-     * It also accepts an array with the keys 'min' and 'max'
-     *
-     * If $options is an integer, it will be used as maximum file count
-     * As Array is accepts the following keys:
-     * 'min': Minimum filecount
-     * 'max': Maximum filecount
-     *
-     * @param int|array|Traversable $options Options for the adapter
+     * @param OptionsArgument $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options = [])
     {
-        if (1 < func_num_args()) {
-            $args    = func_get_args();
-            $options = [
-                'min' => array_shift($args),
-                'max' => array_shift($args),
-            ];
+        $min = $options['min'] ?? 0;
+        $max = $options['max'] ?? null;
+
+        if ($max !== null && $min > $max) {
+            throw new InvalidArgumentException(
+                'The `min` option cannot exceed the `max` option',
+            );
         }
 
-        if (is_string($options) || is_numeric($options)) {
-            $options = ['max' => $options];
-        }
+        $this->count = 0;
+        $this->min   = $min;
+        $this->max   = $max;
+
+        unset($options['min'], $options['max']);
 
         parent::__construct($options);
     }
 
     /**
-     * Returns the minimum file count
-     *
-     * @return int
-     */
-    public function getMin()
-    {
-        return $this->options['min'];
-    }
-
-    /**
-     * Sets the minimum file count
-     *
-     * @param  int|array $min The minimum file count
-     * @return $this Provides a fluent interface
-     * @throws Exception\InvalidArgumentException When min is greater than max.
-     */
-    public function setMin($min)
-    {
-        if (is_array($min) && isset($min['min'])) {
-            $min = $min['min'];
-        }
-
-        if (! is_numeric($min)) {
-            throw new Exception\InvalidArgumentException('Invalid options to validator provided');
-        }
-
-        $min = (int) $min;
-        if (($this->getMax() !== null) && ($min > $this->getMax())) {
-            throw new Exception\InvalidArgumentException(
-                "The minimum must be less than or equal to the maximum file count, but {$min} > {$this->getMax()}"
-            );
-        }
-
-        $this->options['min'] = $min;
-        return $this;
-    }
-
-    /**
-     * Returns the maximum file count
-     *
-     * @return int
-     */
-    public function getMax()
-    {
-        return $this->options['max'];
-    }
-
-    /**
-     * Sets the maximum file count
-     *
-     * @param  int|array $max The maximum file count
-     * @return $this Provides a fluent interface
-     * @throws Exception\InvalidArgumentException When max is smaller than min.
-     */
-    public function setMax($max)
-    {
-        if (is_array($max) && isset($max['max'])) {
-            $max = $max['max'];
-        }
-
-        if (! is_numeric($max)) {
-            throw new Exception\InvalidArgumentException('Invalid options to validator provided');
-        }
-
-        $max = (int) $max;
-        if (($this->getMin() !== null) && ($max < $this->getMin())) {
-            throw new Exception\InvalidArgumentException(
-                "The maximum must be greater than or equal to the minimum file count, but {$max} < {$this->getMin()}"
-            );
-        }
-
-        $this->options['max'] = $max;
-        return $this;
-    }
-
-    /**
-     * Adds a file for validation
-     *
-     * @param string|array|UploadedFileInterface $file
-     * @return $this
-     */
-    public function addFile($file)
-    {
-        if (is_string($file)) {
-            $file = [$file];
-        }
-
-        if (is_array($file)) {
-            foreach ($file as $name) {
-                if (! isset($this->files[$name]) && ! empty($name)) {
-                    $this->files[$name] = $name;
-                }
-            }
-        }
-
-        if ($file instanceof UploadedFileInterface && is_string($file->getClientFilename())) {
-            $this->files[(string) $file->getClientFilename()] = $file->getClientFilename();
-        }
-
-        return $this;
-    }
-
-    /**
      * Returns true if and only if the file count of all checked files is at least min and
-     * not bigger than max (when max is not null). Attention: When checking with set min you
-     * must give all files with the first call, otherwise you will get a false.
-     *
-     * @param  string|array|UploadedFileInterface $value Filenames to check for count
-     * @param  array                              $file  File data from \Laminas\File\Transfer\Transfer
+     * not bigger than max (when max is not null).
      */
-    public function isValid(mixed $value, $file = null): bool
+    public function isValid(mixed $value): bool
     {
-        if ($this->isUploadedFilterInterface($value)) {
-            $this->addFile($value);
-        } elseif ($file !== null) {
-            if (! array_key_exists('destination', $file)) {
-                $file['destination'] = dirname($value);
+        if (FileInformation::isPossibleFile($value)) {
+            $value = [$value];
+        }
+
+        if (! is_array($value)) {
+            $this->error(self::ERROR_NOT_ARRAY);
+
+            return false;
+        }
+
+        $this->count = 0;
+        /** @psalm-var mixed $item */
+        foreach ($value as $item) {
+            if (! FileInformation::isPossibleFile($item)) {
+                continue;
             }
 
-            if (array_key_exists('tmp_name', $file)) {
-                $value = $file['destination'] . DIRECTORY_SEPARATOR . $file['name'];
-            }
+            $this->count++;
         }
 
-        if (($file === null) || ! empty($file['tmp_name'])) {
-            $this->addFile($value);
+        if ($this->min !== null && $this->count < $this->min) {
+            $this->error(self::TOO_FEW);
+
+            return false;
         }
 
-        $this->count = count($this->files);
+        if ($this->max !== null && $this->count > $this->max) {
+            $this->error(self::TOO_MANY);
 
-        if (($this->getMax() !== null) && ($this->count > $this->getMax())) {
-            return $this->throwError($file, self::TOO_MANY);
-        }
-
-        if (($this->getMin() !== null) && ($this->count < $this->getMin())) {
-            return $this->throwError($file, self::TOO_FEW);
+            return false;
         }
 
         return true;
-    }
-
-    /**
-     * Throws an error of the given type
-     *
-     * @param  string|null|array $file
-     * @param  string $errorType
-     * @return false
-     */
-    protected function throwError($file, $errorType)
-    {
-        if ($file !== null) {
-            if (is_array($file)) {
-                if (array_key_exists('name', $file)) {
-                    $this->value = $file['name'];
-                }
-            } elseif (is_string($file)) {
-                $this->value = $file;
-            }
-        }
-
-        $this->error($errorType);
-        return false;
-    }
-
-    /**
-     * Checks if the type of uploaded file is UploadedFileInterface.
-     *
-     * @param  string|array|UploadedFileInterface $value Filenames to check for count
-     * @return bool
-     */
-    private function isUploadedFilterInterface($value)
-    {
-        if ($value instanceof UploadedFileInterface) {
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Removes compat with legacy `Laminas\File\Transfer` api
- Removes all option setters and getters
- Accept only an options array to the constructor
