### PR TITLE
Refactor `AbstractValidator`

### DIFF
--- a/docs/book/v3/writing-validators.md
+++ b/docs/book/v3/writing-validators.md
@@ -41,7 +41,7 @@ namespace MyValid;
 
 use Laminas\Validator\AbstractValidator;
 
-class Float extends AbstractValidator
+final class Float extends AbstractValidator
 {
     const FLOAT = 'float';
 
@@ -92,14 +92,14 @@ namespace MyValid;
 
 use Laminas\Validator\AbstractValidator;
 
-class NumericBetween extends AbstractValidator
+final class NumericBetween extends AbstractValidator
 {
     const MSG_NUMERIC = 'msgNumeric';
     const MSG_MINIMUM = 'msgMinimum';
     const MSG_MAXIMUM = 'msgMaximum';
 
-    public $minimum = 0;
-    public $maximum = 100;
+    protected readonly $minimum;
+    protected readonly $maximum;
 
     protected array $messageVariables = [
         'min' => 'minimum',
@@ -111,6 +111,11 @@ class NumericBetween extends AbstractValidator
         self::MSG_MINIMUM => "'%value%' must be at least '%min%'",
         self::MSG_MAXIMUM => "'%value%' must be no more than '%max%'",
     ];
+    
+    public function __construct(int $min, int $max) {
+        $this->minimum = $min;
+        $this->maximum = $max;
+    }
 
     public function isValid(mixed $value): bool
     {
@@ -136,7 +141,7 @@ class NumericBetween extends AbstractValidator
 }
 ```
 
-The public properties `$minimum` and `$maximum` have been established to provide
+The protected properties `$minimum` and `$maximum` have been established to provide
 the minimum and maximum boundaries, respectively, for a value to successfully
 validate. The class also defines two message variables that correspond to the
 public properties and allow `min` and `max` to be used in message templates as
@@ -169,7 +174,7 @@ namespace MyValid;
 
 use Laminas\Validator\AbstractValidator;
 
-class PasswordStrength extends AbstractValidator
+final class PasswordStrength extends AbstractValidator
 {
     const LENGTH = 'length';
     const UPPER  = 'upper';
@@ -215,7 +220,7 @@ class PasswordStrength extends AbstractValidator
 ```
 
 Note that the four criteria tests in `isValid()` do not immediately return
-`false`. This allows the validation class to provide **all** of the reasons that
+`false`. This allows the validation class to provide **all** the reasons that
 the input password failed to meet the validation requirements. If, for example,
 a user were to input the string `#$%` as a password, `isValid()` would cause
 all four validation failure messages to be returned by a subsequent call to

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,70 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
-  <file src="src/AbstractValidator.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-      <code><![CDATA[isTranslatorEnabled]]></code>
-      <code><![CDATA[isValueObscured]]></code>
-      <code><![CDATA[self::getDefaultTranslatorTextDomain()]]></code>
-      <code><![CDATA[self::getMessageLength()]]></code>
-      <code><![CDATA[setOptions]]></code>
-      <code><![CDATA[setTranslatorTextDomain]]></code>
-    </DeprecatedMethod>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$value]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$this->{key($property)}[current($property)]]]></code>
-      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
-      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->abstractOptions['messages'][$messageKey]]]></code>
-    </MixedArrayAssignment>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->{key($property)}[current($property)]]]></code>
-      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
-      <code><![CDATA[$this->{key($result)}[current($result)]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$property]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->abstractOptions]]></code>
-    </MixedPropertyTypeCoercion>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getOptions]]></code>
-    </PossiblyUnusedMethod>
-    <PossiblyUnusedParam>
-      <code><![CDATA[$messageKey]]></code>
-    </PossiblyUnusedParam>
-    <UndefinedThisPropertyAssignment>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-      <code><![CDATA[$this->options]]></code>
-    </UndefinedThisPropertyAssignment>
+  <file src="src/Barcode.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$length]]></code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/Barcode/Code128.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="src/Callback.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$options]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
   <file src="src/Date.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>
     </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/DateComparison.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$maxString]]></code>
+      <code><![CDATA[$minString]]></code>
+      <code><![CDATA[$type]]></code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/DateStep.php">
     <ArgumentTypeCoercion>
@@ -72,15 +33,10 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="src/EmailAddress.php">
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[AbstractValidator]]></code>
-    </LessSpecificImplementedReturnType>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->abstractOptions['messages'][$code]]]></code>
-    </MixedArrayAssignment>
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$this->abstractOptions]]></code>
-    </MixedPropertyTypeCoercion>
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$hostname]]></code>
+      <code><![CDATA[$localPart]]></code>
+    </PossiblyUnusedProperty>
     <TypeDoesNotContainType>
       <code><![CDATA[UConverter::transcode($localPart, 'UTF-8', 'UTF-8') === false]]></code>
     </TypeDoesNotContainType>
@@ -95,9 +51,46 @@
       <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
       <code><![CDATA[$this->getPluginManager()->get($validator)]]></code>
     </MixedReturnStatement>
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$error]]></code>
+    </PossiblyUnusedProperty>
     <TooManyArguments>
       <code><![CDATA[isValid]]></code>
     </TooManyArguments>
+  </file>
+  <file src="src/File/ExcludeExtension.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$extensionList]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/File/Exists.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$directoriesAsString]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/File/Extension.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$extensionList]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/File/FilesSize.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$maxString]]></code>
+      <code><![CDATA[$minString]]></code>
+      <code><![CDATA[$size]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/File/NotExists.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$directoriesAsString]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/File/Size.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$maxString]]></code>
+      <code><![CDATA[$minString]]></code>
+      <code><![CDATA[$size]]></code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/GpsPoint.php">
     <InvalidOperand>
@@ -108,6 +101,11 @@
       <code><![CDATA[$value]]></code>
     </MixedArgument>
   </file>
+  <file src="src/HostWithPublicIPv4Address.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$type]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="src/Hostname.php">
     <MixedArgument>
       <code><![CDATA[$regexChar]]></code>
@@ -116,10 +114,23 @@
       <code><![CDATA[$regexChar]]></code>
     </MixedAssignment>
   </file>
+  <file src="src/Identical.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$tokenString]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/IsArray.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$type]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="src/IsJsonString.php">
     <InvalidArgument>
       <code><![CDATA[$this->maxDepth]]></code>
     </InvalidArgument>
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$type]]></code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/Module.php">
     <PossiblyUnusedParam>
@@ -176,53 +187,14 @@
     </UnusedClass>
   </file>
   <file src="test/AbstractValidatorTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[AbstractValidator::getDefaultTranslator()]]></code>
-      <code><![CDATA[AbstractValidator::getDefaultTranslator()]]></code>
-      <code><![CDATA[AbstractValidator::getDefaultTranslatorTextDomain()]]></code>
-      <code><![CDATA[AbstractValidator::getDefaultTranslatorTextDomain()]]></code>
-      <code><![CDATA[AbstractValidator::hasDefaultTranslator()]]></code>
-      <code><![CDATA[AbstractValidator::hasDefaultTranslator()]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-      <code><![CDATA[getTranslatorTextDomain]]></code>
-      <code><![CDATA[hasTranslator]]></code>
-      <code><![CDATA[hasTranslator]]></code>
-      <code><![CDATA[isTranslatorEnabled]]></code>
-      <code><![CDATA[isTranslatorEnabled]]></code>
-      <code><![CDATA[isTranslatorEnabled]]></code>
-      <code><![CDATA[isTranslatorEnabled]]></code>
-      <code><![CDATA[isValueObscured]]></code>
-      <code><![CDATA[isValueObscured]]></code>
-      <code><![CDATA[isValueObscured]]></code>
-      <code><![CDATA[setMessages]]></code>
-      <code><![CDATA[setOptions]]></code>
-      <code><![CDATA[setTranslatorEnabled]]></code>
-      <code><![CDATA[setTranslatorEnabled]]></code>
-      <code><![CDATA[setValueObscured]]></code>
-      <code><![CDATA[setValueObscured]]></code>
-      <code><![CDATA[setValueObscured]]></code>
-    </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA[$options]]></code>
-    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$message]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$message]]></code>
     </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[invalidOptionsArguments]]></code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="test/BarcodeTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[invalidAdapterArguments]]></code>
       <code><![CDATA[validAdapterOptions]]></code>
@@ -247,11 +219,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/CreditCardTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicValues]]></code>
       <code><![CDATA[jcbValues]]></code>
@@ -268,11 +235,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/DateStepTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[moscowWinterTimeDataProvider]]></code>
       <code><![CDATA[stepTestsDataProvider]]></code>
@@ -288,53 +250,16 @@
     </UnusedParam>
   </file>
   <file src="test/DigitsTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/EmailAddressTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageVariables]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[setMessages]]></code>
-    </DeprecatedMethod>
-    <InvalidArgument>
-      <code><![CDATA[[
-            'hostnameValidator' => $hostnameValidator,
-            'translator'        => new Translator($translations),
-        ]]]></code>
-      <code><![CDATA[[
-            'message'           => 'TestMessage',
-            'hostnameValidator' => $hostname,
-        ]]]></code>
-      <code><![CDATA[['messages' => [EmailAddress::INVALID => 'TestMessage']]]]></code>
-    </InvalidArgument>
     <PossiblyUnusedMethod>
       <code><![CDATA[emailAddressesForMxChecks]]></code>
-      <code><![CDATA[errorHandler]]></code>
       <code><![CDATA[invalidEmailAddresses]]></code>
       <code><![CDATA[validEmailAddresses]]></code>
     </PossiblyUnusedMethod>
-    <UnusedParam>
-      <code><![CDATA[$errno]]></code>
-      <code><![CDATA[$errstr]]></code>
-    </UnusedParam>
   </file>
   <file src="test/File/BytesTest.php">
     <PossiblyUnusedMethod>
@@ -428,11 +353,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/HexTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
@@ -445,13 +365,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/HostnameTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageVariables]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <MixedArrayOffset>
       <code><![CDATA[$translations[$code]]]></code>
     </MixedArrayOffset>
@@ -481,33 +394,18 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/IbanTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[ibanDataProvider]]></code>
       <code><![CDATA[invalidValues]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/InArrayTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[nonStrictValidationSet]]></code>
       <code><![CDATA[strictValidationSet]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/IpTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[iPvFutureAddressesProvider]]></code>
       <code><![CDATA[invalidIpV4Addresses]]></code>
@@ -524,12 +422,6 @@
       <code><![CDATA[conflictingOptionsProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="test/IsInstanceOfTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="test/IsJsonStringTest.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[allowProvider]]></code>
@@ -544,41 +436,12 @@
       <code><![CDATA[isbnValueProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="test/MessageTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[__get]]></code>
-      <code><![CDATA[__get]]></code>
-      <code><![CDATA[__get]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageVariables]]></code>
-      <code><![CDATA[getMessageVariables]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[setMessages]]></code>
-      <code><![CDATA[unknownProperty]]></code>
-    </DeprecatedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[assertIsArray]]></code>
-    </RedundantConditionGivenDocblockType>
-    <UndefinedMagicPropertyFetch>
-      <code><![CDATA[$this->validator->unknownProperty]]></code>
-    </UndefinedMagicPropertyFetch>
-    <UndefinedThisPropertyFetch>
-      <code><![CDATA[$this->validator->__get('max')]]></code>
-      <code><![CDATA[$this->validator->__get('min')]]></code>
-      <code><![CDATA[$this->validator->__get('value')]]></code>
-    </UndefinedThisPropertyFetch>
-  </file>
   <file src="test/NotEmptyTest.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[[
             'type' => [$string, $string],
         ]]]></code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[arrayConfigNotationWithoutKeyProvider]]></code>
       <code><![CDATA[arrayConstantNotationProvider]]></code>
@@ -606,12 +469,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/RegexTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[basicDataProvider]]></code>
       <code><![CDATA[invalidConstructorArgumentsProvider]]></code>
@@ -625,10 +482,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StepTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[decimalHundredthStepValues]]></code>
       <code><![CDATA[decimalStepSubtractionBugValues]]></code>
@@ -651,20 +504,12 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/UndisclosedPasswordTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[goodPasswordProvider]]></code>
       <code><![CDATA[seenPasswordProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/UriTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getMessageTemplates]]></code>
-      <code><![CDATA[getOption]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[allowOptionsDataProvider]]></code>
       <code><![CDATA[invalidValueTypes]]></code>

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -89,13 +89,13 @@ abstract class AbstractValidator implements
     private bool $valueObscured = false;
 
     /** Whether translation should be enabled or not */
-    private bool $translatorEnabled;
+    private bool $translatorEnabled = true;
 
     /** The text domain for translations */
-    private string $translatorTextDomain;
+    private string $translatorTextDomain = 'default';
 
     /** A custom translator, the default translator, or null */
-    private TranslatorInterface|null $translator;
+    private TranslatorInterface|null $translator = null;
 
     /**
      * Error messages that have occurred during the last validation

--- a/src/AbstractValidator.php
+++ b/src/AbstractValidator.php
@@ -4,42 +4,39 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\Stdlib\ArrayUtils;
 use Laminas\Translator\TranslatorInterface;
-use Traversable;
+use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_key_exists;
 use function array_keys;
 use function array_unique;
-use function current;
+use function assert;
 use function implode;
 use function is_array;
+use function is_bool;
 use function is_object;
 use function is_string;
 use function key;
 use function method_exists;
+use function property_exists;
+use function sprintf;
 use function str_repeat;
 use function str_replace;
 use function strlen;
 use function substr;
-use function ucfirst;
 use function var_export;
 
 use const SORT_REGULAR;
 
 /**
  * @psalm-type AbstractOptions = array{
- *     messages: array<string, string>,
- *     messageTemplates: array<string, string>,
- *     messageVariables: array<string, mixed>,
- *     translator: TranslatorInterface|null,
- *     translatorTextDomain: string|null,
- *     translatorEnabled: bool,
- *     valueObscured: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
+ *     ...<string, mixed>
  * }
- * @property array<string, mixed> $options
- * @property array<string, string> $messageTemplates
- * @property array<string, mixed> $messageVariables
  */
 abstract class AbstractValidator implements
     Translator\TranslatorAwareInterface,
@@ -55,30 +52,57 @@ abstract class AbstractValidator implements
     /**
      * Default translation object for all validate objects
      */
-    protected static ?TranslatorInterface $defaultTranslator = null;
+    private static ?TranslatorInterface $defaultTranslator = null;
 
     /**
      * Default text domain to be used with translator
      */
-    protected static string $defaultTranslatorTextDomain = 'default';
+    private static string $defaultTranslatorTextDomain = 'default';
 
     /**
      * Limits the maximum returned length of an error message
-     *
-     * @var int
      */
-    protected static $messageLength = -1;
+    private static int $messageLength = -1;
 
-    /** @var AbstractOptions&array<string, mixed> */
-    protected array $abstractOptions = [
-        'messages'             => [], // Array of validation failure messages
-        'messageTemplates'     => [], // Array of validation failure message templates
-        'messageVariables'     => [], // Array of additional variables available for validation failure messages
-        'translator'           => null, // Translator instance to use -> TranslatorInterface
-        'translatorTextDomain' => null, // Translation text domain
-        'translatorEnabled'    => true, // Is translation enabled?
-        'valueObscured'        => false, // Flag indicating whether value should be obfuscated in error messages
-    ];
+    /**
+     * An array that defines the default translations (in english) of the validators error messages
+     *
+     * @var array<string, string>
+     */
+    protected array $messageTemplates = [];
+
+    /**
+     * An array that defines substitutions that will be interpolated into error messages.
+     *
+     * Keys are the placeholder name and the values must be a string that references protected or public properties of
+     * the validator, for example ['myProperty' => 'myProperty'] would replace "%myProperty%" in an error message with
+     * the value of "$this->myProperty".
+     *
+     * You can also specify a replacement as an array such as ['myProperty' => ['props' => 'this-one']]. In this case,
+     * the placeholder '%myProperty%' would be replaced with the value "$this->props['this-one']".
+     *
+     * @var array<string, string|array<string, string>>
+     */
+    protected array $messageVariables = [];
+
+    /** Flag indicating whether value should be obfuscated in error messages */
+    private bool $valueObscured = false;
+
+    /** Whether translation should be enabled or not */
+    private bool $translatorEnabled;
+
+    /** The text domain for translations */
+    private string $translatorTextDomain;
+
+    /** A custom translator, the default translator, or null */
+    private TranslatorInterface|null $translator;
+
+    /**
+     * Error messages that have occurred during the last validation
+     *
+     * @var array<string, string>
+     */
+    protected array $errorMessages = [];
 
     /**
      * Abstract constructor for all validators
@@ -88,107 +112,27 @@ abstract class AbstractValidator implements
      *  - an array f.e. Validator(array($first => 'first', $second => 'second', $third => 'third'))
      *  - an instance of Traversable f.e. Validator($config_instance)
      *
-     * @param array<string, mixed>|Traversable<string, mixed> $options
+     * @param AbstractOptions $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options = [])
     {
-        // The abstract constructor allows no scalar values
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        }
+        $valueObscured        = $options['valueObscured'] ?? false;
+        $translatorEnabled    = $options['translatorEnabled'] ?? true;
+        $translatorTextDomain = $options['translatorTextDomain'] ?? self::$defaultTranslatorTextDomain;
+        $translator           = $options['translator'] ?? self::$defaultTranslator;
+        $messages             = $options['messages'] ?? [];
 
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (isset($this->messageTemplates) && is_array($this->messageTemplates)) {
-            $this->abstractOptions['messageTemplates'] = $this->messageTemplates;
-        }
+        assert(is_bool($translatorEnabled));
+        assert(is_string($translatorTextDomain));
+        assert($translator instanceof TranslatorInterface || $translator === null);
+        assert(is_array($messages));
 
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (isset($this->messageVariables) && is_array($this->messageVariables)) {
-            $this->abstractOptions['messageVariables'] = $this->messageVariables;
-        }
-
-        if (is_array($options)) {
-            $this->setOptions($options);
-        }
-    }
-
-    /**
-     * Returns an option
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *
-     * @param string $option Option to be returned
-     * @return mixed Returned option
-     * @throws Exception\InvalidArgumentException
-     */
-    public function getOption($option)
-    {
-        if (array_key_exists($option, $this->abstractOptions)) {
-            return $this->abstractOptions[$option];
-        }
-
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (isset($this->options) && array_key_exists($option, $this->options)) {
-            return $this->options[$option];
-        }
-
-        throw new Exception\InvalidArgumentException("Invalid option '$option'");
-    }
-
-    /**
-     * Returns all available options
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *
-     * @return array<string, mixed> Array with all available options
-     */
-    public function getOptions()
-    {
-        $result = $this->abstractOptions;
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (isset($this->options) && is_array($this->options)) {
-            $result += $this->options;
-        }
-        return $result;
-    }
-
-    /**
-     * Sets one or multiple options
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0 - Options should be passed to the constructor
-     *
-     * @param array<string, mixed>|Traversable<string, mixed> $options Options to set
-     * @return self Provides fluid interface
-     * @throws Exception\InvalidArgumentException If $options is not an array or Traversable.
-     */
-    public function setOptions($options = [])
-    {
-        /** @psalm-suppress DocblockTypeContradiction */
-        if (! is_array($options) && ! $options instanceof Traversable) {
-            throw new Exception\InvalidArgumentException(__METHOD__ . ' expects an array or Traversable');
-        }
-
-        /**
-         * @psalm-suppress RedundantConditionGivenDocblockType
-         * @psalm-var mixed $option
-         */
-        foreach ($options as $name => $option) {
-            $fname  = 'set' . ucfirst($name);
-            $fname2 = 'is' . ucfirst($name);
-            if (($name !== 'setOptions') && method_exists($this, $name)) {
-                $this->{$name}($option);
-            } elseif (($fname !== 'setOptions') && method_exists($this, $fname)) {
-                $this->{$fname}($option);
-            } elseif (method_exists($this, $fname2)) {
-                $this->{$fname2}($option);
-            } elseif (isset($this->options) && is_array($this->options)) {
-                $this->options[$name] = $option;
-            } else {
-                $this->abstractOptions[$name] = $option;
-            }
-        }
-
-        return $this;
+        $this->valueObscured        = $valueObscured;
+        $this->translatorEnabled    = $translatorEnabled;
+        $this->translatorTextDomain = $translatorTextDomain;
+        $this->translator           = $translator;
+        /** @psalm-var array<string, string> $messages Psalm cannot infer this from the declared type */
+        $this->overrideMessagesWith($messages);
     }
 
     /**
@@ -196,126 +140,39 @@ abstract class AbstractValidator implements
      *
      * @return array<string, string>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
-        return array_unique($this->abstractOptions['messages'], SORT_REGULAR);
+        return array_unique($this->errorMessages, SORT_REGULAR);
     }
 
     /**
      * Invoke as command
-     *
-     * @return bool
      */
-    public function __invoke(mixed $value)
+    public function __invoke(mixed $value): bool
     {
         return $this->isValid($value);
     }
 
     /**
-     * Returns an array of the names of variables that are used in constructing validation failure messages
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *
-     * @return list<string>
-     */
-    public function getMessageVariables()
-    {
-        return array_keys($this->abstractOptions['messageVariables']);
-    }
-
-    /**
-     * Returns the message templates from the validator
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *
-     * @return array<string, string>
-     */
-    public function getMessageTemplates()
-    {
-        return $this->abstractOptions['messageTemplates'];
-    }
-
-    /**
      * Sets the validation failure message template for a particular key
      *
-     * @param  string      $messageString
-     * @param  string|null $messageKey     OPTIONAL
-     * @return $this Provides a fluent interface
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public function setMessage($messageString, $messageKey = null)
+    public function setMessage(string $messageString, ?string $messageKey = null): void
     {
         if ($messageKey === null) {
-            $keys = array_keys($this->abstractOptions['messageTemplates']);
+            $keys = array_keys($this->messageTemplates);
             foreach ($keys as $key) {
                 $this->setMessage($messageString, $key);
             }
-            return $this;
+            return;
         }
 
-        if (! isset($this->abstractOptions['messageTemplates'][$messageKey])) {
-            throw new Exception\InvalidArgumentException("No message template exists for key '$messageKey'");
+        if (! isset($this->messageTemplates[$messageKey])) {
+            throw new InvalidArgumentException("No message template exists for key '$messageKey'");
         }
 
-        $this->abstractOptions['messageTemplates'][$messageKey] = $messageString;
-        return $this;
-    }
-
-    /**
-     * Sets validation failure message templates given as an array, where the array keys are the message keys,
-     * and the array values are the message template strings.
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *             Provide customised messages via the `messages` constructor option
-     *
-     * @param array<string, string> $messages
-     * @return $this
-     */
-    public function setMessages(array $messages)
-    {
-        foreach ($messages as $key => $message) {
-            $this->setMessage($message, $key);
-        }
-        return $this;
-    }
-
-    /**
-     * Magic function returns the value of the requested property, if and only if it is the value or a
-     * message variable.
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0 - It will no longer be possible to fetch any internal
-     *             properties
-     *
-     * @param string $property
-     * @return mixed
-     * @throws Exception\InvalidArgumentException
-     */
-    public function __get($property)
-    {
-        if ($property === 'value') {
-            return $this->value;
-        }
-
-        if (array_key_exists($property, $this->abstractOptions['messageVariables'])) {
-            /** @psalm-var mixed $result */
-            $result = $this->abstractOptions['messageVariables'][$property];
-            if (is_array($result)) {
-                return $this->{key($result)}[current($result)];
-            }
-            return $this->{$result};
-        }
-
-        /** @psalm-suppress RedundantConditionGivenDocblockType */
-        if (isset($this->messageVariables) && array_key_exists($property, $this->messageVariables)) {
-            /** @psalm-var mixed $result */
-            $result = $this->{$this->messageVariables[$property]};
-            if (is_array($result)) {
-                return $this->{key($result)}[current($result)];
-            }
-            return $this->{$result};
-        }
-
-        throw new Exception\InvalidArgumentException("No property exists by the name '$property'");
+        $this->messageTemplates[$messageKey] = $messageString;
     }
 
     /**
@@ -326,49 +183,86 @@ abstract class AbstractValidator implements
      * If a translator is available and a translation exists for $messageKey,
      * the translation will be used.
      */
-    protected function createMessage(string $messageKey, mixed $value): ?string
+    private function createMessage(string $messageKey, mixed $value): ?string
     {
-        if (! isset($this->abstractOptions['messageTemplates'][$messageKey])) {
+        if (! isset($this->messageTemplates[$messageKey])) {
             return null;
         }
 
-        $message = $this->abstractOptions['messageTemplates'][$messageKey];
+        $message = $this->translateMessage(
+            $this->messageTemplates[$messageKey],
+        );
 
-        $message = $this->translateMessage($messageKey, $message);
+        $message = $this->substitutePlaceholder(
+            'value',
+            $value,
+            $message,
+            $this->valueObscured,
+        );
 
-        if (is_object($value)) {
-            $value = method_exists($value, '__toString')
-                ? (string) $value
-                : $value::class . ' object';
-        } elseif (is_array($value)) {
-            $value = var_export($value, true);
-        } else {
-            $value = (string) $value;
+        foreach ($this->messageVariables as $id => $property) {
+            $message = $this->substitutePlaceholder(
+                $id,
+                $this->propertyValue($property),
+                $message,
+                false,
+            );
         }
 
-        if ($this->isValueObscured()) {
-            $value = str_repeat('*', strlen($value));
-        }
-
-        $message = str_replace('%value%', $value, $message);
-        foreach ($this->abstractOptions['messageVariables'] as $ident => $property) {
-            if (is_array($property)) {
-                $value = $this->{key($property)}[current($property)];
-                if (is_array($value)) {
-                    $value = '[' . implode(', ', $value) . ']';
-                }
-            } else {
-                $value = $this->$property;
-            }
-            $message = str_replace("%$ident%", (string) $value, $message);
-        }
-
-        $length = self::getMessageLength();
+        $length = self::$messageLength;
         if (($length > -1) && (strlen($message) > $length)) {
             $message = substr($message, 0, $length - 3) . '...';
         }
 
         return $message;
+    }
+
+    /** @param string|array<string, string> $prop */
+    private function propertyValue(string|array $prop): mixed
+    {
+        if (is_string($prop)) {
+            assert(property_exists($this, $prop));
+
+            /** @psalm-var mixed $value */
+            return $this->{$prop};
+        }
+
+        $name = key($prop);
+        assert(property_exists($this, $name));
+
+        $key = $prop[$name];
+        /** @psalm-var mixed $value */
+        $value = $this->$name;
+        assert(is_array($value));
+        assert(array_key_exists($key, $value));
+
+        return $value[$key];
+    }
+
+    private function substitutePlaceholder(string $id, mixed $value, string $message, bool $obscure): string
+    {
+        $search = "%$id%";
+        $value  = $this->stringifyValue($value);
+        if ($obscure) {
+            $value = str_repeat('*', strlen($value));
+        }
+
+        return str_replace($search, $value, $message);
+    }
+
+    private function stringifyValue(mixed $value): string
+    {
+        if (is_object($value)) {
+            return method_exists($value, '__toString')
+                ? (string) $value
+                : $value::class . ' object';
+        }
+
+        if (is_array($value)) {
+            return var_export($value, true);
+        }
+
+        return (string) $value;
     }
 
     protected function error(string $messageKey, mixed $value = null): void
@@ -383,56 +277,24 @@ abstract class AbstractValidator implements
             return;
         }
 
-        $this->abstractOptions['messages'][$messageKey] = $message;
+        $this->errorMessages[$messageKey] = $message;
     }
 
     /**
      * Returns the validation value
-     *
-     * @return mixed Value to be validated
      */
-    protected function getValue()
+    protected function getValue(): mixed
     {
         return $this->value;
     }
 
     /**
      * Sets the value to be validated and clears the messages and errors arrays
-     *
-     * @return void
      */
-    protected function setValue(mixed $value)
+    protected function setValue(mixed $value): void
     {
-        $this->value                       = $value;
-        $this->abstractOptions['messages'] = [];
-    }
-
-    /**
-     * Set flag indicating whether or not value should be obfuscated in messages
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0 - Use the `valueObscured` option via the constructor
-     *
-     * @param bool $flag
-     * @return $this
-     */
-    public function setValueObscured($flag)
-    {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
-        $this->abstractOptions['valueObscured'] = (bool) $flag;
-        return $this;
-    }
-
-    /**
-     * Retrieve flag indicating whether or not value should be obfuscated in
-     * messages
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     *
-     * @return bool
-     */
-    public function isValueObscured()
-    {
-        return $this->abstractOptions['valueObscured'];
+        $this->value         = $value;
+        $this->errorMessages = [];
     }
 
     /**
@@ -440,9 +302,9 @@ abstract class AbstractValidator implements
      */
     public function setTranslator(?TranslatorInterface $translator = null, ?string $textDomain = null): void
     {
-        $this->abstractOptions['translator'] = $translator;
-        if (null !== $textDomain) {
-            $this->setTranslatorTextDomain($textDomain);
+        $this->translator = $translator;
+        if ($textDomain !== null) {
+            $this->translatorTextDomain = $textDomain;
         }
     }
 
@@ -451,52 +313,7 @@ abstract class AbstractValidator implements
      */
     public function getTranslator(): ?TranslatorInterface
     {
-        if (! $this->isTranslatorEnabled()) {
-            return null;
-        }
-
-        $translator = $this->abstractOptions['translator'] ?? null;
-        if ($translator instanceof TranslatorInterface) {
-            return $translator;
-        }
-
-        return self::$defaultTranslator;
-    }
-
-    /**
-     * Does this validator have its own specific translator?
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public function hasTranslator(): bool
-    {
-        return $this->abstractOptions['translator'] instanceof TranslatorInterface;
-    }
-
-    /**
-     * Set translation text domain
-     *
-     * @deprecated  since 2.61.0 This method will be removed in 3.0 Use the `translatorTextDomain` option, or set
-     *              the text domain at the same time as the translator via `setTranslator()`
-     */
-    public function setTranslatorTextDomain(string $textDomain = 'default'): void
-    {
-        $this->abstractOptions['translatorTextDomain'] = $textDomain;
-    }
-
-    /**
-     * Return the translation text domain
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public function getTranslatorTextDomain(): string
-    {
-        if (null === $this->abstractOptions['translatorTextDomain']) {
-            $this->abstractOptions['translatorTextDomain'] =
-                self::getDefaultTranslatorTextDomain();
-        }
-
-        return $this->abstractOptions['translatorTextDomain'];
+        return $this->translator;
     }
 
     /**
@@ -506,30 +323,10 @@ abstract class AbstractValidator implements
         ?TranslatorInterface $translator = null,
         ?string $textDomain = null,
     ): void {
-        static::$defaultTranslator = $translator;
+        self::$defaultTranslator = $translator;
         if (null !== $textDomain) {
             self::setDefaultTranslatorTextDomain($textDomain);
         }
-    }
-
-    /**
-     * Return the default translator
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public static function getDefaultTranslator(): ?TranslatorInterface
-    {
-        return static::$defaultTranslator;
-    }
-
-    /**
-     * Is there a default translator available
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public static function hasDefaultTranslator(): bool
-    {
-        return self::$defaultTranslator !== null;
     }
 
     /**
@@ -537,47 +334,7 @@ abstract class AbstractValidator implements
      */
     public static function setDefaultTranslatorTextDomain(string $textDomain = 'default'): void
     {
-        static::$defaultTranslatorTextDomain = $textDomain;
-    }
-
-    /**
-     * Get default translation text domain for all validate objects
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public static function getDefaultTranslatorTextDomain(): string
-    {
-        return static::$defaultTranslatorTextDomain;
-    }
-
-    /**
-     * Indicate whether or not translation should be enabled
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public function setTranslatorEnabled(bool $enabled = true): void
-    {
-        $this->abstractOptions['translatorEnabled'] = $enabled;
-    }
-
-    /**
-     * Is translation enabled?
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public function isTranslatorEnabled(): bool
-    {
-        return $this->abstractOptions['translatorEnabled'];
-    }
-
-    /**
-     * Returns the maximum allowed message length
-     *
-     * @deprecated Since 2.61.0 This method will be removed in 3.0
-     */
-    public static function getMessageLength(): int
-    {
-        return static::$messageLength;
+        self::$defaultTranslatorTextDomain = $textDomain;
     }
 
     /**
@@ -585,21 +342,38 @@ abstract class AbstractValidator implements
      */
     public static function setMessageLength(int $length = -1): void
     {
-        static::$messageLength = $length;
+        self::$messageLength = $length;
     }
 
     /**
      * Translate a validation message
-     *
-     * @param  string $messageKey
      */
-    protected function translateMessage($messageKey, string $message): string
+    private function translateMessage(string $message): string
     {
-        $translator = $this->getTranslator();
-        if (! $translator) {
+        if (! $this->translatorEnabled || ! $this->translator) {
             return $message;
         }
 
-        return $translator->translate($message, $this->getTranslatorTextDomain());
+        return $this->translator->translate($message, $this->translatorTextDomain);
+    }
+
+    /**
+     * Overrides message templates for this instance
+     *
+     * @param array<string, string> $customMessages
+     */
+    private function overrideMessagesWith(array $customMessages): void
+    {
+        foreach ($customMessages as $key => $message) {
+            if (! array_key_exists($key, $this->messageTemplates)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The error message key "%s" does not exist. Possible keys are "%s"',
+                    $key,
+                    implode(', ', array_keys($this->messageTemplates)),
+                ));
+            }
+
+            $this->messageTemplates[$key] = $message;
+        }
     }
 }

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Barcode\AdapterInterface;
 use Laminas\Validator\Barcode\Ean13;
 use Laminas\Validator\Exception\InvalidArgumentException;
@@ -21,6 +22,11 @@ use function ucfirst;
  * @psalm-type OptionsArgument = array{
  *     adapter?: AdapterInterface|class-string<AdapterInterface>|string,
  *     useChecksum?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  * @psalm-import-type AllowedLength from AdapterInterface
  */
@@ -39,11 +45,7 @@ final class Barcode extends AbstractValidator
         self::INVALID        => 'Invalid type given. String expected',
     ];
 
-    /**
-     * Additional variables available for validation failure messages
-     *
-     * @var array<string, string>
-     */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'length' => 'length',
     ];

--- a/src/Bitwise.php
+++ b/src/Bitwise.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
+
 use function is_float;
 use function is_numeric;
 
@@ -12,6 +14,11 @@ use function is_numeric;
  *     operator?: Bitwise::OP_AND|Bitwise::OP_XOR|null,
  *     control: int,
  *     strict?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Bitwise extends AbstractValidator
@@ -38,11 +45,7 @@ final class Bitwise extends AbstractValidator
         self::NOT_INTEGER    => "Expected an integer to compare '%control%' against",
     ];
 
-    /**
-     * Additional variables available for validation failure messages
-     *
-     * @var array<string, string>
-     */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'control' => 'control',
     ];

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -6,6 +6,7 @@ namespace Laminas\Validator;
 
 use Closure;
 use Exception;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_merge;
@@ -20,7 +21,12 @@ use function is_callable;
  *     callbackOptions?: array<array-key, mixed>,
  *     bind?: bool,
  *     throwExceptions?: bool,
- * }&array<string, mixed>
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
+ * }
  */
 final class Callback extends AbstractValidator
 {

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use SensitiveParameter;
 use Throwable;
@@ -24,6 +25,11 @@ use function strtoupper;
  * @psalm-type OptionsArgument = array{
  *     type?: value-of<CreditCard::TYPES>|list<value-of<CreditCard::TYPES>>,
  *     service?: callable(mixed...): bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class CreditCard extends AbstractValidator

--- a/src/Date.php
+++ b/src/Date.php
@@ -7,6 +7,7 @@ namespace Laminas\Validator;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use Laminas\Translator\TranslatorInterface;
 
 use function gettype;
 use function implode;
@@ -17,6 +18,11 @@ use function implode;
  * @psalm-type OptionsArgument = array{
  *     format?: string|null,
  *     strict?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 class Date extends AbstractValidator
@@ -41,7 +47,7 @@ class Date extends AbstractValidator
         self::FALSEFORMAT  => "The input does not fit the date format '%format%'",
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'format' => 'format',
     ];

--- a/src/DateComparison.php
+++ b/src/DateComparison.php
@@ -96,8 +96,8 @@ final class DateComparison extends AbstractValidator
 
     public function isValid(mixed $value): bool
     {
-        $this->type  = get_debug_type($value);
-        $this->value = $value;
+        $this->type = get_debug_type($value);
+        $this->setValue($value);
 
         if (! is_string($value) && ! $value instanceof DateTimeInterface) {
             $this->error(self::ERROR_INVALID_TYPE);

--- a/src/DateComparison.php
+++ b/src/DateComparison.php
@@ -7,6 +7,7 @@ namespace Laminas\Validator;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function assert;
@@ -21,6 +22,11 @@ use function preg_match;
  *     inclusiveMin?: bool,
  *     inclusiveMax?: bool,
  *     inputFormat?: string|null,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class DateComparison extends AbstractValidator
@@ -42,7 +48,7 @@ final class DateComparison extends AbstractValidator
         self::ERROR_NOT_LESS              => 'A date before %max% is required',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'type' => 'type',
         'min'  => 'minString',

--- a/src/DateStep.php
+++ b/src/DateStep.php
@@ -9,6 +9,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_combine;
@@ -34,6 +35,11 @@ use const PHP_INT_MAX;
  *     strict?: bool,
  *     baseValue?: string|DateTimeInterface,
  *     step?: string|DateInterval,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class DateStep extends Date

--- a/src/Explode.php
+++ b/src/Explode.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\RuntimeException;
 
 use function explode;
@@ -19,6 +20,11 @@ use function sprintf;
  *     validatorPluginManager?: ValidatorPluginManager|null,
  *     validator?: ValidatorInterface|class-string<ValidatorInterface>|ValidatorSpecification,
  *     breakOnFirstFailure?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
  */
@@ -42,7 +48,7 @@ final class Explode extends AbstractValidator
     protected int $count     = 0;
     protected ?string $error = null;
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'count' => 'count',
         'error' => 'error',

--- a/src/File/Count.php
+++ b/src/File/Count.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -15,6 +16,11 @@ use function is_array;
  * @psalm-type OptionsArgument = array{
  *     min?: positive-int|null,
  *     max?: positive-int|null,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Count extends AbstractValidator
@@ -30,7 +36,7 @@ final class Count extends AbstractValidator
         self::ERROR_NOT_ARRAY => 'Invalid type provided. The file list must an array.',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min'   => 'min',
         'max'   => 'max',

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -77,6 +77,7 @@ final class ExcludeExtension extends AbstractValidator
      */
     public function isValid(mixed $value): bool
     {
+        $this->setValue($value);
         $isFile = FileInformation::isPossibleFile($value);
 
         if (! $isFile && ! $this->allowNonExistentFile) {

--- a/src/File/ExcludeExtension.php
+++ b/src/File/ExcludeExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 
 use function assert;
@@ -17,6 +18,11 @@ use function is_string;
  *     case?: bool,
  *     extension: non-empty-string|list<non-empty-string>,
  *     allowNonExistentFile?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class ExcludeExtension extends AbstractValidator
@@ -32,7 +38,7 @@ final class ExcludeExtension extends AbstractValidator
         self::ERROR_INVALID_TYPE => 'The value is neither a file, nor a string',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'extension' => 'extensionList',
     ];

--- a/src/File/Exists.php
+++ b/src/File/Exists.php
@@ -83,7 +83,7 @@ final class Exists extends AbstractValidator
             $value = $file->baseName;
         }
 
-        $this->value = $value;
+        $this->setValue($value);
 
         if (! is_string($value)) {
             $this->error(self::DOES_NOT_EXIST);

--- a/src/File/Exists.php
+++ b/src/File/Exists.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 
 use function array_filter;
@@ -27,6 +28,11 @@ use const DIRECTORY_SEPARATOR;
  * @psalm-type OptionsArgument = array{
  *     directory?: string|list<string>,
  *     all?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Exists extends AbstractValidator
@@ -38,7 +44,7 @@ final class Exists extends AbstractValidator
         self::DOES_NOT_EXIST => 'File does not exist',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'directory' => 'directoriesAsString',
     ];

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -25,6 +26,11 @@ use function trim;
  *     case?: bool,
  *     extension: non-empty-string|list<non-empty-string>,
  *     allowNonExistentFile?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Extension extends AbstractValidator
@@ -40,7 +46,7 @@ final class Extension extends AbstractValidator
         self::ERROR_INVALID_TYPE => 'The value is neither a file, nor a string',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'extension' => 'extensionList',
     ];

--- a/src/File/Extension.php
+++ b/src/File/Extension.php
@@ -85,6 +85,7 @@ final class Extension extends AbstractValidator
      */
     public function isValid(mixed $value): bool
     {
+        $this->setValue($value);
         $isFile = FileInformation::isPossibleFile($value);
         if (! $isFile && ! $this->allowNonExistentFile) {
             $this->error(self::NOT_FOUND);

--- a/src/File/FilesSize.php
+++ b/src/File/FilesSize.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Psr\Http\Message\UploadedFileInterface;
@@ -19,6 +20,11 @@ use function is_string;
  *     min?: string|numeric|null,
  *     max?: string|numeric|null,
  *     useByteString?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class FilesSize extends AbstractValidator
@@ -34,7 +40,7 @@ final class FilesSize extends AbstractValidator
         self::NOT_READABLE => 'One or more files can not be read',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min'  => 'minString',
         'max'  => 'maxString',

--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -20,6 +21,11 @@ use function strtolower;
  * @psalm-type OptionsArgument = array{
  *     hash: non-empty-string|list<non-empty-string>,
  *     algorithm?: non-empty-string|null,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Hash extends AbstractValidator

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -136,7 +136,7 @@ final class ImageSize extends AbstractValidator
             return false;
         }
 
-        $this->value = $file->clientFileName ?? $file->baseName;
+        $this->setValue($file->clientFileName ?? $file->baseName);
 
         $size = getimagesize($file->path);
 

--- a/src/File/ImageSize.php
+++ b/src/File/ImageSize.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -18,6 +19,11 @@ use function getimagesize;
  *     maxWidth?: int|null,
  *     minHeight?: int|null,
  *     maxHeight?: int|null,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class ImageSize extends AbstractValidator
@@ -42,7 +48,7 @@ final class ImageSize extends AbstractValidator
         self::NOT_READABLE     => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'minwidth'  => 'minWidth',
         'maxwidth'  => 'maxWidth',

--- a/src/File/MimeType.php
+++ b/src/File/MimeType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -22,6 +23,11 @@ use function trim;
  *
  * @psalm-type OptionsArgument = array{
  *     mimeType?: string|list<string>,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 class MimeType extends AbstractValidator
@@ -40,7 +46,7 @@ class MimeType extends AbstractValidator
         self::NOT_READABLE => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'type' => 'type',
     ];

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -82,7 +82,7 @@ final class NotExists extends AbstractValidator
             $value = $file->baseName;
         }
 
-        $this->value = $value;
+        $this->setValue($value);
 
         if (! is_string($value)) {
             // Not a file path, therefore it cannot exist.

--- a/src/File/NotExists.php
+++ b/src/File/NotExists.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 
 use function array_filter;
@@ -24,7 +25,12 @@ use const DIRECTORY_SEPARATOR;
  * Validator which checks if the destination file does not exist
  *
  * @psalm-type OptionsArgument = array{
- *      directory?: string|list<string>,
+ *     directory?: string|list<string>,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  *  }
  */
 final class NotExists extends AbstractValidator
@@ -36,7 +42,7 @@ final class NotExists extends AbstractValidator
         self::DOES_EXIST => 'File exists',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'directory' => 'directoriesAsString',
     ];

--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -16,6 +17,11 @@ use function is_string;
  *     min?: string|numeric|null,
  *     max?: string|numeric|null,
  *     useByteString?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Size extends AbstractValidator
@@ -31,7 +37,7 @@ final class Size extends AbstractValidator
         self::NOT_FOUND => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string|array> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min'  => 'minString',
         'max'  => 'maxString',

--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -120,7 +120,7 @@ final class Size extends AbstractValidator
 
         $file = FileInformation::factory($value);
 
-        $this->value = $file->clientFileName ?? $file->baseName;
+        $this->setValue($file->clientFileName ?? $file->baseName);
 
         if (! $file->readable) {
             $this->error(self::NOT_FOUND);

--- a/src/File/WordCount.php
+++ b/src/File/WordCount.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator\File;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
@@ -16,6 +17,11 @@ use function str_word_count;
  * @psalm-type OptionsArgument = array{
  *     min?: numeric,
  *     max?: numeric,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class WordCount extends AbstractValidator
@@ -34,7 +40,7 @@ final class WordCount extends AbstractValidator
         self::NOT_FOUND => 'File is not readable or does not exist',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min'   => 'min',
         'max'   => 'max',

--- a/src/GpsPoint.php
+++ b/src/GpsPoint.php
@@ -48,7 +48,7 @@ final class GpsPoint extends AbstractValidator
 
     private function isValidCoordinate(string $value, float $maxBoundary): bool
     {
-        $this->value = $value;
+        $this->setValue($value);
 
         $value = $this->removeWhiteSpace($value);
         if ($this->isDMSValue($value)) {

--- a/src/HostWithPublicIPv4Address.php
+++ b/src/HostWithPublicIPv4Address.php
@@ -87,7 +87,7 @@ final class HostWithPublicIPv4Address extends AbstractValidator
             return false;
         }
 
-        $this->value = $value;
+        $this->setValue($value);
 
         if (filter_var($value, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
             $addressList = gethostbynamel($value);

--- a/src/HostWithPublicIPv4Address.php
+++ b/src/HostWithPublicIPv4Address.php
@@ -62,7 +62,7 @@ final class HostWithPublicIPv4Address extends AbstractValidator
     public const ERROR_HOSTNAME_NOT_RESOLVED = 'hostnameNotResolved';
     public const ERROR_PRIVATE_IP_FOUND      = 'privateIpAddressFound';
 
-    /** @var array<non-empty-string, non-empty-string> */
+    /** @var array<string, string> */
     protected array $messageTemplates = [
         self::ERROR_NOT_STRING            => 'Expected a string hostname but received %type%',
         self::ERROR_HOSTNAME_NOT_RESOLVED => 'The hostname "%value%" cannot be resolved',
@@ -71,7 +71,7 @@ final class HostWithPublicIPv4Address extends AbstractValidator
 
     protected string $type = 'null';
 
-    /** @var array<non-empty-string, non-empty-string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'type'  => 'type',
         'value' => 'value',

--- a/src/Hostname.php
+++ b/src/Hostname.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Laminas\Stdlib\StringUtils;
+use Laminas\Translator\TranslatorInterface;
 
 use function array_key_exists;
 use function array_pop;
@@ -42,6 +43,11 @@ use function substr;
  *    useIdnCheck?: bool,
  *    useTldCheck?: bool,
  *    ipValidator?: null|Ip,
+ *    messages?: array<string, string>,
+ *    translator?: TranslatorInterface|null,
+ *    translatorTextDomain?: string|null,
+ *    translatorEnabled?: bool,
+ *    valueObscured?: bool,
  * }
  */
 final class Hostname extends AbstractValidator
@@ -73,7 +79,7 @@ final class Hostname extends AbstractValidator
         self::UNKNOWN_TLD             => "The input appears to be a DNS hostname but cannot match TLD against known list",
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'tld' => 'tld',
     ];

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_key_exists;
@@ -22,6 +23,11 @@ use function substr;
  * @psalm-type OptionsArgument = array{
  *     country_code?: string,
  *     allow_non_sepa?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Iban extends AbstractValidator

--- a/src/Identical.php
+++ b/src/Identical.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
+
 use function is_array;
 use function is_int;
 use function is_string;
@@ -15,6 +17,11 @@ use function var_export;
  *     token?: mixed,
  *     strict?: bool,
  *     literal?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Identical extends AbstractValidator
@@ -28,7 +35,7 @@ final class Identical extends AbstractValidator
         self::MISSING_TOKEN => 'No token was provided to match against',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'token' => 'tokenString',
     ];

--- a/src/InArray.php
+++ b/src/InArray.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use RecursiveArrayIterator;
 use RecursiveIteratorIterator;
@@ -20,6 +21,11 @@ use function is_string;
  *     haystack: array,
  *     strict?: bool|InArray::COMPARE_*,
  *     recursive?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class InArray extends AbstractValidator

--- a/src/Ip.php
+++ b/src/Ip.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
+
 use function bindec;
 use function hexdec;
 use function ip2long;
@@ -23,6 +25,11 @@ use function substr_count;
  *     allowipv6?: bool,
  *     allowipvfuture?: bool,
  *     allowliteral?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Ip extends AbstractValidator

--- a/src/IsArray.php
+++ b/src/IsArray.php
@@ -11,12 +11,12 @@ final class IsArray extends AbstractValidator
 {
     public const NOT_ARRAY = 'NotArray';
 
-    /** @var array<non-empty-string, non-empty-string> */
+    /** @var array<string, string> */
     protected array $messageTemplates = [
         self::NOT_ARRAY => 'Expected an array value but %type% provided',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'type' => 'type',
     ];

--- a/src/IsCountable.php
+++ b/src/IsCountable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function count;
@@ -28,6 +29,11 @@ use function is_countable;
  *     count?: int|null,
  *     min?: int|null,
  *     max?: int|null,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class IsCountable extends AbstractValidator
@@ -49,11 +55,7 @@ final class IsCountable extends AbstractValidator
         self::LESS_THAN     => "The input count must be greater than '%min%', inclusively",
     ];
 
-    /**
-     * Additional variables available for validation failure messages
-     *
-     * @var array<string, string>
-     */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'count' => 'count',
         'min'   => 'min',

--- a/src/IsInstanceOf.php
+++ b/src/IsInstanceOf.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function class_exists;
@@ -11,6 +12,11 @@ use function class_exists;
 /**
  * @psalm-type OptionsArgument = array{
  *     className: class-string,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class IsInstanceOf extends AbstractValidator
@@ -26,11 +32,7 @@ final class IsInstanceOf extends AbstractValidator
         self::NOT_INSTANCE_OF => "The input is not an instance of '%className%'",
     ];
 
-    /**
-     * Additional variables available for validation failure messages
-     *
-     * @var array<string, string>
-     */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'className' => 'className',
     ];

--- a/src/IsJsonString.php
+++ b/src/IsJsonString.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use JsonException;
+use Laminas\Translator\TranslatorInterface;
 
 use function gettype;
 use function is_float;
@@ -21,6 +22,11 @@ use const JSON_THROW_ON_ERROR;
  * @psalm-type OptionsArgument = array{
  *     allow?: int-mask-of<self::ALLOW_*>,
  *     maxDepth?: positive-int,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class IsJsonString extends AbstractValidator
@@ -37,7 +43,7 @@ final class IsJsonString extends AbstractValidator
     public const ALLOW_OBJECT = 0b0010000;
     public const ALLOW_ALL    = 0b0011111;
 
-    /** @var array<self::ERROR_*, non-empty-string> */
+    /** @var array<string, string> */
     protected array $messageTemplates = [
         self::ERROR_NOT_STRING         => 'Expected a string but %type% was received',
         self::ERROR_TYPE_NOT_ALLOWED   => 'Received a JSON %type% but this type is not acceptable',
@@ -45,7 +51,7 @@ final class IsJsonString extends AbstractValidator
         self::ERROR_INVALID_JSON       => 'An invalid JSON payload was received',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'type'     => 'type',
         'maxDepth' => 'maxDepth',

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function in_array;
@@ -17,6 +18,11 @@ use function substr;
 /**
  * @psalm-type OptionsArgument = array{
  *     type?: Isbn::AUTO|Isbn::ISBN10|Isbn::ISBN13,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Isbn extends AbstractValidator

--- a/src/NotEmpty.php
+++ b/src/NotEmpty.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Countable;
+use Laminas\Translator\TranslatorInterface;
 
 use function array_search;
 use function assert;
@@ -38,6 +39,11 @@ use function preg_match;
  * @psalm-type TypeArgument = TypeIntMask | list<TypeIntMask> | list<value-of<NotEmpty::TYPE_NAMES>> | value-of<NotEmpty::TYPE_NAMES>
  * @psalm-type OptionsArgument = array{
  *     type?: TypeArgument,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class NotEmpty extends AbstractValidator

--- a/src/NumberComparison.php
+++ b/src/NumberComparison.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function is_numeric;
@@ -14,6 +15,11 @@ use function is_numeric;
  *     max?: numeric|null,
  *     inclusiveMin?: bool,
  *     inclusiveMax?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class NumberComparison extends AbstractValidator
@@ -33,7 +39,7 @@ final class NumberComparison extends AbstractValidator
         self::ERROR_NOT_LESS              => 'Values must be less than %max%. Received "%value%"',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min' => 'min',
         'max' => 'max',

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function is_string;
@@ -12,6 +13,11 @@ use function preg_match;
 /**
  * @psalm-type OptionsArgument = array{
  *     pattern: non-empty-string,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Regex extends AbstractValidator
@@ -25,7 +31,7 @@ final class Regex extends AbstractValidator
         self::NOT_MATCH => "The input does not match against pattern '%pattern%'",
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'pattern' => 'pattern',
     ];

--- a/src/Step.php
+++ b/src/Step.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
+
 use function floor;
 use function is_numeric;
 use function round;
@@ -15,6 +17,11 @@ use function substr;
  * @psalm-type OptionsArgument = array{
  *     baseValue?: numeric,
  *     step?: numeric,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Step extends AbstractValidator

--- a/src/StringLength.php
+++ b/src/StringLength.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use Laminas\Stdlib\StringUtils;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Throwable;
 
@@ -15,6 +16,11 @@ use function is_string;
  *     min?: int,
  *     max?: int|null,
  *     encoding?: string,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class StringLength extends AbstractValidator
@@ -30,7 +36,7 @@ final class StringLength extends AbstractValidator
         self::TOO_LONG  => 'The input is more than %max% characters long',
     ];
 
-    /** @var array<string, string> */
+    /** @var array<string, string|array<string, string>> */
     protected array $messageVariables = [
         'min'    => 'min',
         'max'    => 'max',

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Validator;
 
 use DateTimeZone;
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function array_key_exists;
@@ -16,6 +17,11 @@ use function strtolower;
 /**
  * @psalm-type OptionsArgument = array{
  *     type?: int-mask<Timezone::LOCATION,Timezone::ABBREVIATION,Timezone::ALL>,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Timezone extends AbstractValidator

--- a/src/Translator/TranslatorAwareInterface.php
+++ b/src/Translator/TranslatorAwareInterface.php
@@ -22,41 +22,4 @@ interface TranslatorAwareInterface
      * Returns translator used in object
      */
     public function getTranslator(): ?TranslatorInterface;
-
-    /**
-     * Checks if the object has a translator
-     *
-     * @deprecated since 2.61.0 This method will be removed in 3.0
-     */
-    public function hasTranslator(): bool;
-
-    /**
-     * Sets whether translator is enabled and should be used
-     *
-     * @deprecated since 2.61.0 This method will be removed in 3.0 disable translation via the
-     *            `translatorEnabled` option
-     */
-    public function setTranslatorEnabled(bool $enabled = true): void;
-
-    /**
-     * Returns whether translator is enabled and should be used
-     *
-     * @deprecated since 2.61.0 This method will be removed in 3.0
-     */
-    public function isTranslatorEnabled(): bool;
-
-    /**
-     * Set translation text domain
-     *
-     * @deprecated since 2.61.0 This method will be removed in 3.0 Use the `translatorTextDomain` option, or set
-     *             the text domain at the same time as the translator via `setTranslator()`
-     */
-    public function setTranslatorTextDomain(string $textDomain = 'default'): void;
-
-    /**
-     * Return the translation text domain
-     *
-     * @deprecated since 2.61.0 This method will be removed in 3.0
-     */
-    public function getTranslatorTextDomain(): string;
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Translator\TranslatorInterface;
 use Laminas\Validator\Exception\InvalidArgumentException;
 
 use function is_array;
@@ -14,6 +15,11 @@ use function parse_url;
  * @psalm-type Options = array{
  *     allowRelative?: bool,
  *     allowAbsolute?: bool,
+ *     messages?: array<string, string>,
+ *     translator?: TranslatorInterface|null,
+ *     translatorTextDomain?: string|null,
+ *     translatorEnabled?: bool,
+ *     valueObscured?: bool,
  * }
  */
 final class Uri extends AbstractValidator

--- a/test/BarcodeTest.php
+++ b/test/BarcodeTest.php
@@ -12,8 +12,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class BarcodeTest extends TestCase
 {
     /** @return list<array{0: string|AdapterInterface}> */
@@ -537,24 +535,5 @@ final class BarcodeTest extends TestCase
         ]);
 
         self::assertFalse($barcode->isValid('3RH1131-1BB40'));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new Barcode([
-            'adapter'     => Barcode\Code128::class,
-            'useChecksum' => true,
-        ]);
-
-        self::assertSame(
-            [
-                Barcode::FAILED,
-                Barcode::INVALID_CHARS,
-                Barcode::INVALID_LENGTH,
-                Barcode::INVALID,
-            ],
-            array_keys($validator->getMessageTemplates()),
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 }

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
 use function current;
 
 final class CreditCardTest extends TestCase
@@ -287,25 +286,6 @@ final class CreditCardTest extends TestCase
         $message = $validator->getMessages();
 
         self::assertStringContainsString('not from an allowed institute', current($message));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new CreditCard();
-
-        self::assertSame(
-            [
-                CreditCard::CHECKSUM,
-                CreditCard::CONTENT,
-                CreditCard::INVALID,
-                CreditCard::LENGTH,
-                CreditCard::PREFIX,
-                CreditCard::SERVICE,
-                CreditCard::SERVICEFAILURE,
-            ],
-            array_keys($validator->getMessageTemplates()),
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testThatTheCallbackReceivesTheExpectedParameters(): void

--- a/test/DateStepTest.php
+++ b/test/DateStepTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
-use function array_keys;
 use function date;
 
 final class DateStepTest extends TestCase
@@ -141,22 +140,6 @@ final class DateStepTest extends TestCase
         $validator = new DateStep();
 
         self::assertSame([], $validator->getMessages());
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new DateStep([]);
-
-        self::assertSame(
-            [
-                DateStep::INVALID,
-                DateStep::INVALID_DATE,
-                DateStep::FALSEFORMAT,
-                DateStep::NOT_STEP,
-            ],
-            array_keys($validator->getMessageTemplates())
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     public function testStepError(): void

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -8,8 +8,6 @@ use Laminas\Validator\Digits;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class DigitsTest extends TestCase
 {
     private Digits $validator;
@@ -89,18 +87,5 @@ final class DigitsTest extends TestCase
     public function testNonStringValidation(): void
     {
         self::assertFalse($this->validator->isValid([1 => 1]));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                Digits::NOT_DIGITS,
-                Digits::STRING_EMPTY,
-                Digits::INVALID,
-            ],
-            array_keys($this->validator->getMessageTemplates())
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 }

--- a/test/HexTest.php
+++ b/test/HexTest.php
@@ -8,8 +8,6 @@ use Laminas\Validator\Hex;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class HexTest extends TestCase
 {
     private Hex $validator;
@@ -70,17 +68,5 @@ final class HexTest extends TestCase
     public function testGetMessages(): void
     {
         self::assertSame([], $this->validator->getMessages());
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                Hex::INVALID,
-                Hex::NOT_HEX,
-            ],
-            array_keys($this->validator->getMessageTemplates())
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 }

--- a/test/HostnameTest.php
+++ b/test/HostnameTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_key_exists;
-use function array_keys;
 use function implode;
 use function ini_get;
 use function ini_set;
@@ -629,35 +628,6 @@ final class HostnameTest extends TestCase
         self::assertTrue($validator->isValid('città-caffè.it'));
         self::assertTrue($validator->isValid('edgetest-àâäèéêëìîïòôöùûüæœçÿß.it'));
         self::assertFalse($validator->isValid('رات.it'));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                Hostname::CANNOT_DECODE_PUNYCODE,
-                Hostname::INVALID,
-                Hostname::INVALID_DASH,
-                Hostname::INVALID_HOSTNAME,
-                Hostname::INVALID_HOSTNAME_SCHEMA,
-                Hostname::INVALID_LOCAL_NAME,
-                Hostname::INVALID_URI,
-                Hostname::IP_ADDRESS_NOT_ALLOWED,
-                Hostname::LOCAL_NAME_NOT_ALLOWED,
-                Hostname::UNDECIPHERABLE_TLD,
-                Hostname::UNKNOWN_TLD,
-            ],
-            array_keys($this->validator->getMessageTemplates()),
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
-    }
-
-    public function testEqualsMessageVariables(): void
-    {
-        $messageVariables = ['tld' => 'tld'];
-
-        self::assertSame($messageVariables, $this->validator->getOption('messageVariables'));
-        self::assertSame(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 
     public function testHostnameWithOnlyIpChars(): void

--- a/test/IbanTest.php
+++ b/test/IbanTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
 use function array_merge;
 use function implode;
 
@@ -144,22 +143,6 @@ final class IbanTest extends TestCase
         $validator = new IbanValidator();
 
         self::assertTrue($validator->isValid('AT611904300234573201'));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new IbanValidator();
-
-        self::assertSame(
-            [
-                IbanValidator::NOTSUPPORTED,
-                IbanValidator::SEPANOTSUPPORTED,
-                IbanValidator::FALSEFORMAT,
-                IbanValidator::CHECKFAILED,
-            ],
-            array_keys($validator->getMessageTemplates())
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     /**

--- a/test/InArrayTest.php
+++ b/test/InArrayTest.php
@@ -9,8 +9,6 @@ use Laminas\Validator\InArray;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class InArrayTest extends TestCase
 {
     private InArray $validator;
@@ -331,17 +329,6 @@ final class InArrayTest extends TestCase
 
         self::assertTrue($validator->isValid(0));
         self::assertFalse($validator->isValid('0'));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                InArray::NOT_IN_ARRAY,
-            ],
-            array_keys($this->validator->getMessageTemplates())
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     /**

--- a/test/IpTest.php
+++ b/test/IpTest.php
@@ -11,8 +11,6 @@ use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class IpTest extends TestCase
 {
     /**
@@ -371,19 +369,6 @@ final class IpTest extends TestCase
     {
         $validator = new Ip();
         self::assertSame([], $validator->getMessages());
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new Ip();
-        self::assertSame(
-            [
-                Ip::INVALID,
-                Ip::NOT_IP_ADDRESS,
-            ],
-            array_keys($validator->getMessageTemplates())
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
     }
 
     /**

--- a/test/IsInstanceOfTest.php
+++ b/test/IsInstanceOfTest.php
@@ -9,7 +9,6 @@ use Exception;
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\IsInstanceOf;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 final class IsInstanceOfTest extends TestCase
 {
@@ -43,32 +42,6 @@ final class IsInstanceOfTest extends TestCase
         $validator = new IsInstanceOf(['className' => DateTime::class]);
 
         self::assertSame([], $validator->getMessages());
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator  = new IsInstanceOf(['className' => DateTime::class]);
-        $reflection = new ReflectionClass($validator);
-
-        $property = $reflection->getProperty('messageTemplates');
-
-        self::assertSame(
-            $property->getValue($validator),
-            $validator->getOption('messageTemplates')
-        );
-    }
-
-    public function testEqualsMessageVariables(): void
-    {
-        $validator  = new IsInstanceOf(['className' => DateTime::class]);
-        $reflection = new ReflectionClass($validator);
-
-        $property = $reflection->getProperty('messageVariables');
-
-        self::assertSame(
-            $property->getValue($validator),
-            $validator->getOption('messageVariables')
-        );
     }
 
     public function testPassOptionsWithoutClassNameKey(): void

--- a/test/MessageTest.php
+++ b/test/MessageTest.php
@@ -6,13 +6,11 @@ namespace LaminasTest\Validator;
 
 use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\StringLength;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function current;
 
-#[Group('Laminas_Validator')]
 final class MessageTest extends TestCase
 {
     private StringLength $validator;
@@ -180,123 +178,25 @@ final class MessageTest extends TestCase
      */
     public function testSetMessages(): void
     {
-        $this->validator->setMessages(
-            [
+        $validator = new StringLength([
+            'min'      => 4,
+            'max'      => 8,
+            'messages' => [
                 StringLength::TOO_LONG  => 'Your value is too long',
                 StringLength::TOO_SHORT => 'Your value is too short',
-            ]
-        );
+            ],
+        ]);
 
-        self::assertFalse($this->validator->isValid('abcdefghij'));
+        self::assertFalse($validator->isValid('abcdefghij'));
 
-        $messages = $this->validator->getMessages();
+        $messages = $validator->getMessages();
 
         self::assertSame('Your value is too long', current($messages));
 
-        self::assertFalse($this->validator->isValid('abc'));
+        self::assertFalse($validator->isValid('abc'));
 
-        $messages = $this->validator->getMessages();
+        $messages = $validator->getMessages();
 
         self::assertSame('Your value is too short', current($messages));
-    }
-
-    /**
-     * Ensures that the magic getter gives us access to properties
-     * that are permitted to be substituted in the message string.
-     * The access is by the parameter name, not by the protected
-     * property variable name.
-     */
-    public function testGetProperty(): void
-    {
-        $this->validator->setMessage(
-            'Your value is too long',
-            StringLength::TOO_LONG
-        );
-
-        $inputInvalid = 'abcdefghij';
-
-        self::assertFalse($this->validator->isValid($inputInvalid));
-
-        $messages = $this->validator->getMessages();
-
-        self::assertSame('Your value is too long', current($messages));
-
-        self::assertSame($inputInvalid, $this->validator->__get('value'));
-        self::assertSame(8, $this->validator->__get('max'));
-        self::assertSame(4, $this->validator->__get('min'));
-    }
-
-    /**
-     * Ensures that the class throws an exception when we try to
-     * access a property that doesn't exist as a parameter.
-     */
-    public function testGetPropertyException(): void
-    {
-        $this->validator->setMessage(
-            'Your value is too long',
-            StringLength::TOO_LONG
-        );
-
-        self::assertFalse($this->validator->isValid('abcdefghij'));
-
-        $messages = $this->validator->getMessages();
-
-        self::assertSame('Your value is too long', current($messages));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('No property exists by the name ');
-
-        $this->validator->unknownProperty;
-    }
-
-    /**
-     * Ensures that getMessageVariables() returns an array of
-     * strings and that these strings that can be used as variables
-     * in a message.
-     */
-    public function testGetMessageVariables(): void
-    {
-        $vars = $this->validator->getMessageVariables();
-
-        self::assertIsArray($vars);
-        self::assertSame(['min', 'max', 'length'], $vars);
-
-        $message = 'variables: %notvar% ';
-        foreach ($vars as $var) {
-            $message .= "%$var% ";
-        }
-
-        $this->validator->setMessage($message, StringLength::TOO_SHORT);
-
-        self::assertFalse($this->validator->isValid('abc'));
-
-        $messages = $this->validator->getMessages();
-
-        self::assertSame('variables: %notvar% 4 8 3 ', current($messages));
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                StringLength::INVALID,
-                StringLength::TOO_SHORT,
-                StringLength::TOO_LONG,
-            ],
-            array_keys($this->validator->getMessageTemplates())
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
-    }
-
-    public function testEqualsMessageVariables(): void
-    {
-        $messageVariables = [
-            'min'    => 'min',
-            'max'    => 'max',
-            'length' => 'length',
-        ];
-
-        self::assertSame($messageVariables, $this->validator->getOption('messageVariables'));
-        self::assertSame(array_keys($messageVariables), $this->validator->getMessageVariables());
     }
 }

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -695,14 +695,4 @@ final class NotEmptyTest extends TestCase
             [null, true],
         ];
     }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $messageTemplates = [
-            'isEmpty'         => "Value is required and can't be empty",
-            'notEmptyInvalid' => "Invalid type given. String, integer, float, boolean or array expected",
-        ];
-
-        self::assertSame($messageTemplates, $this->validator->getOption('messageTemplates'));
-    }
 }

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -9,7 +9,6 @@ use Laminas\Validator\Regex;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
 use function implode;
 use function restore_error_handler;
 use function set_error_handler;
@@ -109,30 +108,6 @@ final class RegexTest extends TestCase
             [true, 'èùòìiieeà'],
             [false, 'test99'],
         ];
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new Regex('//');
-
-        self::assertSame(
-            [
-                Regex::INVALID,
-                Regex::NOT_MATCH,
-            ],
-            array_keys($validator->getMessageTemplates())
-        );
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
-    }
-
-    public function testEqualsMessageVariables(): void
-    {
-        $validator        = new Regex('//');
-        $messageVariables = [
-            'pattern' => 'pattern',
-        ];
-
-        self::assertSame($messageVariables, $validator->getOption('messageVariables'));
     }
 
     /**

--- a/test/StepTest.php
+++ b/test/StepTest.php
@@ -189,13 +189,6 @@ final class StepTest extends TestCase
         self::assertSame([], $this->validator->getMessages());
     }
 
-    public function testEqualsMessageTemplates(): void
-    {
-        $validator = new Step();
-
-        self::assertSame($validator->getOption('messageTemplates'), $validator->getMessageTemplates());
-    }
-
     public function testFModNormalizesZeroToFloatOne(): void
     {
         $validator = new Step();

--- a/test/TestAsset/ConcreteValidator.php
+++ b/test/TestAsset/ConcreteValidator.php
@@ -11,6 +11,8 @@ final class ConcreteValidator extends AbstractValidator
     public const FOO_MESSAGE = 'fooMessage';
     public const BAR_MESSAGE = 'barMessage';
 
+    public string $validValue = 'VALID';
+
     /** @var array<string, string> */
     protected array $messageTemplates = [
         'fooMessage' => '%value% was passed',
@@ -20,6 +22,11 @@ final class ConcreteValidator extends AbstractValidator
     public function isValid(mixed $value): bool
     {
         $this->setValue($value);
+
+        if ($value === $this->validValue) {
+            return true;
+        }
+
         $this->error(self::FOO_MESSAGE);
         $this->error(self::BAR_MESSAGE);
 

--- a/test/UndisclosedPasswordTest.php
+++ b/test/UndisclosedPasswordTest.php
@@ -196,15 +196,6 @@ final class UndisclosedPasswordTest extends TestCase
     }
 
     /**
-     * Test that the message templates are getting initialized via
-     * the parent::_construct call
-     */
-    public function testMessageTemplatesAreInitialized(): void
-    {
-        self::assertNotEmpty($this->validator->getMessageTemplates());
-    }
-
-    /**
      * Testing that we capture any failures when trying to connect with
      * the HIBP web service.
      */

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -9,8 +9,6 @@ use Laminas\Validator\Uri;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-use function array_keys;
-
 final class UriTest extends TestCase
 {
     private Uri $validator;
@@ -99,20 +97,6 @@ final class UriTest extends TestCase
     public function testGetMessages(): void
     {
         self::assertSame([], $this->validator->getMessages());
-    }
-
-    public function testEqualsMessageTemplates(): void
-    {
-        self::assertSame(
-            [
-                Uri::INVALID,
-                Uri::NOT_URI,
-                Uri::NOT_ABSOLUTE,
-                Uri::NOT_RELATIVE,
-            ],
-            array_keys($this->validator->getMessageTemplates()),
-        );
-        self::assertSame($this->validator->getOption('messageTemplates'), $this->validator->getMessageTemplates());
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

Removes methods from `TranslatorAwareInterface` and the implementations in `AbstractValidator`:

- `hasTranslator`
- `setTranslatorEnabled`
- `isTranslatorEnabled`
- `setTranslatorTextDomain`
- `getTranslatorTextDomain`

Leaving only `setTranslator` and `getTranslator`

Enabling and disabling translation can be done via options. The getters are unnecessary.

Removes methods from `AbstractValidator`:

- `getOption`
- `getOptions`
- `setOptions`
- `getMessageVariables`
- `getMessageTemplates`
- `setMessages`
- `setValueObscured`
- `isValueObscured`
- `getDefaultTranslator`
- `hasDefaultTranslator`
- `getDefaultTranslatorTextDomain`
- `getMessageLength`

Reduces the API surface of `AbstractValidator` making a number of previously `protected` methods `private`.

Removes `abstractOptions` property in favour of protected or private instance properties.

Remove a number of useless tests that verified the content of internal properties, i.e. ensuring that `messageTemplates` were identical to the declaration.

Appends the options relevant to the abstract class such as `translator`, `messages` etc to all the options declarations in concrete validators. Psalm does not support unions of array shapes in type declarations.

Adds more types: Down to ~230 psalm issues and 99.2% type coverage