### PR TITLE
Refactor `ValidatorChain`

### DIFF
--- a/docs/book/v3/validator-chains.md
+++ b/docs/book/v3/validator-chains.md
@@ -2,29 +2,20 @@
 
 ## Basic Usage
 
-> ### Installation requirements
->
-> The validator chain depends on the laminas-servicemanager component, so be sure
-> to have it installed before getting started:
->
-> ```bash
-> $ composer require laminas/laminas-servicemanager
-> ```
-
 Often, multiple validations should be applied to some value in a particular
 order. The following code demonstrates a way to solve the example from the
 [introduction](intro.md), where a username must be between 6 and 12 alphanumeric
 characters:
 
 ```php
-use Laminas\I18n\Validator\Alnum;
+use Laminas\Validator\Regex;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\ValidatorChain;
 
 // Create a validator chain and add validators to it
 $validatorChain = new ValidatorChain();
 $validatorChain->attach(new StringLength(['min' => 6, 'max' => 12]));
-$validatorChain->attach(new Alnum());
+$validatorChain->attach(new Regex(['pattern' => '/^[a-z0-9]+$/i']));
 
 // Validate the username
 if ($validatorChain->isValid($username)) {
@@ -55,7 +46,7 @@ string length validation fails:
 
 ```php
 $chain->attach(new StringLength(['min' => 6, 'max' => 12]), true);
-$chain->attach(new Alnum());
+$chain->attach(new Regex(['pattern' => '/^[a-z0-9]+$/i']));
 ```
 
 Any object that implements `Laminas\Validator\ValidatorInterface` may be used in a
@@ -73,7 +64,6 @@ length is between 7 and 9 characters, and then it is checked to ensure that its
 length is between 3 and 5 characters.
 
 ```php
-use Laminas\I18n\Validator\Alnum;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\ValidatorChain;
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -193,12 +193,7 @@
     </UnusedClass>
   </file>
   <file src="src/ValidatorChain.php">
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[new PriorityQueue()]]></code>
-    </MixedPropertyTypeCoercion>
     <PossiblyUnusedMethod>
-      <code><![CDATA[addByName]]></code>
-      <code><![CDATA[addValidator]]></code>
       <code><![CDATA[count]]></code>
     </PossiblyUnusedMethod>
     <TooManyArguments>

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -8,12 +8,12 @@ use Countable;
 use IteratorAggregate;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\PriorityQueue;
-use ReturnTypeWillChange;
 use Traversable;
 
 use function array_replace;
 use function assert;
 use function count;
+use function is_bool;
 use function rsort;
 
 use const SORT_NUMERIC;
@@ -29,38 +29,35 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      */
     public const DEFAULT_PRIORITY = 1;
 
-    /** @var ValidatorPluginManager|null */
-    protected $plugins;
-
     /**
      * Validator chain
      *
      * @var PriorityQueue<QueueElement, int>
      */
-    protected $validators;
+    private PriorityQueue $validators;
 
     /**
      * Array of validation failure messages
      *
      * @var array<string, string>
      */
-    protected $messages = [];
+    private array $messages = [];
 
     /**
      * Initialize validator chain
      */
-    public function __construct()
-    {
-        $this->validators = new PriorityQueue();
+    public function __construct(
+        private ValidatorPluginManager|null $pluginManager = null
+    ) {
+        /** @var PriorityQueue<QueueElement, int> $queue */
+        $queue            = new PriorityQueue();
+        $this->validators = $queue;
     }
 
     /**
      * Return the count of attached validators
-     *
-     * @return int
      */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->validators);
     }
@@ -68,44 +65,41 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
     /**
      * Get plugin manager instance
      *
-     * @return ValidatorPluginManager
+     * @internal \Laminas
      */
-    public function getPluginManager()
+    public function getPluginManager(): ValidatorPluginManager
     {
-        if (! $this->plugins) {
-            $this->setPluginManager(new ValidatorPluginManager(new ServiceManager()));
+        if ($this->pluginManager === null) {
+            $this->pluginManager = new ValidatorPluginManager(new ServiceManager());
         }
-        return $this->plugins;
+
+        return $this->pluginManager;
     }
 
     /**
      * Set plugin manager instance
      *
-     * @param  ValidatorPluginManager $plugins Plugin manager
-     * @psalm-assert ValidatorPluginManager $this->plugins
-     * @return $this
+     * @internal \Laminas
      */
-    public function setPluginManager(ValidatorPluginManager $plugins)
+    public function setPluginManager(ValidatorPluginManager $plugins): void
     {
-        $this->plugins = $plugins;
-        return $this;
+        $this->pluginManager = $plugins;
     }
 
     /**
      * Retrieve a validator by name
      *
-     * @param string|class-string<ValidatorInterface> $name    Name of validator to return
-     * @param null|array                              $options Options to pass to validator constructor
-     *                                                         (if not already instantiated)
-     * @return ValidatorInterface
+     * @internal \Laminas
+     *
+     * @param string|class-string<T> $name    Name of validator to return
+     * @param array<string, mixed>   $options Options to pass to validator constructor
+     *                                        (if not already instantiated)
      * @template T of ValidatorInterface
-     * @psalm-param string|class-string<T> $name
-     * @psalm-return ValidatorInterface
+     * @return ($name is class-string<T> ? T : ValidatorInterface)
      */
-    public function plugin($name, ?array $options = null)
+    public function plugin(string $name, array $options = []): ValidatorInterface
     {
-        $plugins = $this->getPluginManager();
-        return $plugins->build($name, $options);
+        return $this->getPluginManager()->build($name, $options);
     }
 
     /**
@@ -113,44 +107,20 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      * If $breakChainOnFailure is true, then if the validator fails, the next validator in the chain,
      * if one exists, will not be executed.
      *
-     * @param bool $breakChainOnFailure
-     * @param int  $priority            Priority at which to enqueue validator; defaults to
-     *                                  1 (higher executes earlier)
-     * @return $this
      * @throws Exception\InvalidArgumentException
      */
     public function attach(
         ValidatorInterface $validator,
-        $breakChainOnFailure = false,
-        $priority = self::DEFAULT_PRIORITY
-    ) {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
+        bool $breakChainOnFailure = false,
+        int $priority = self::DEFAULT_PRIORITY
+    ): void {
         $this->validators->insert(
             [
                 'instance'            => $validator,
-                'breakChainOnFailure' => (bool) $breakChainOnFailure,
+                'breakChainOnFailure' => $breakChainOnFailure,
             ],
             $priority
         );
-
-        return $this;
-    }
-
-    /**
-     * Proxy to attach() to keep BC
-     *
-     * @deprecated Please use attach()
-     *
-     * @param  bool                 $breakChainOnFailure
-     * @param  int                  $priority
-     * @return ValidatorChain Provides a fluent interface
-     */
-    public function addValidator(
-        ValidatorInterface $validator,
-        $breakChainOnFailure = false,
-        $priority = self::DEFAULT_PRIORITY
-    ) {
-        return $this->attach($validator, $breakChainOnFailure, $priority);
     }
 
     /**
@@ -158,11 +128,8 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * If $breakChainOnFailure is true, then if the validator fails, the next validator in the chain,
      * if one exists, will not be executed.
-     *
-     * @param  bool                 $breakChainOnFailure
-     * @return $this Provides a fluent interface
      */
-    public function prependValidator(ValidatorInterface $validator, $breakChainOnFailure = false)
+    public function prependValidator(ValidatorInterface $validator, bool $breakChainOnFailure = false): void
     {
         $priority = self::DEFAULT_PRIORITY;
 
@@ -172,69 +139,50 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
             $priority = $extractedNodes[0] + 1;
         }
 
-        /** @psalm-suppress RedundantCastGivenDocblockType */
         $this->validators->insert(
             [
                 'instance'            => $validator,
-                'breakChainOnFailure' => (bool) $breakChainOnFailure,
+                'breakChainOnFailure' => $breakChainOnFailure,
             ],
             $priority
         );
-        return $this;
     }
 
     /**
      * Use the plugin manager to add a validator by name
      *
-     * @param  string|class-string<ValidatorInterface> $name
-     * @param  array                                   $options
-     * @param  bool                                    $breakChainOnFailure
-     * @param  int                                     $priority
-     * @return $this
+     * @param string|class-string<ValidatorInterface> $name
+     * @param array<string, mixed> $options
      */
-    public function attachByName($name, $options = [], $breakChainOnFailure = false, $priority = self::DEFAULT_PRIORITY)
-    {
-        if (isset($options['break_chain_on_failure'])) {
-            $breakChainOnFailure = (bool) $options['break_chain_on_failure'];
+    public function attachByName(
+        string $name,
+        array $options = [],
+        bool $breakChainOnFailure = false,
+        int $priority = self::DEFAULT_PRIORITY,
+    ): void {
+        $bc = null;
+        foreach (['break_chain_on_failure', 'breakchainonfailure'] as $key) {
+            /** @psalm-var mixed $value */
+            $value = $options[$key] ?? null;
+            if (is_bool($value)) {
+                $bc = $value;
+            }
         }
 
-        if (isset($options['breakchainonfailure'])) {
-            $breakChainOnFailure = (bool) $options['breakchainonfailure'];
-        }
+        $bc = $bc ?? $breakChainOnFailure;
 
-        $this->attach($this->plugin($name, $options), $breakChainOnFailure, $priority);
-
-        return $this;
-    }
-
-    /**
-     * Proxy to attachByName() to keep BC
-     *
-     * @deprecated Please use attachByName()
-     *
-     * @param  string $name
-     * @param  array  $options
-     * @param  bool   $breakChainOnFailure
-     * @return ValidatorChain
-     */
-    public function addByName($name, $options = [], $breakChainOnFailure = false)
-    {
-        return $this->attachByName($name, $options, $breakChainOnFailure);
+        $this->attach($this->plugin($name, $options), $bc, $priority);
     }
 
     /**
      * Use the plugin manager to prepend a validator by name
      *
-     * @param  string|class-string<ValidatorInterface> $name
-     * @param  array                                   $options
-     * @param  bool                                    $breakChainOnFailure
-     * @return $this
+     * @param string|class-string<ValidatorInterface> $name
+     * @param array<string, mixed>                    $options
      */
-    public function prependByName($name, $options = [], $breakChainOnFailure = false)
+    public function prependByName(string $name, array $options = [], bool $breakChainOnFailure = false): void
     {
-        $validator = $this->plugin($name, $options);
-        $this->prependValidator($validator, $breakChainOnFailure);
-        return $this;
+        $this->prependValidator($this->plugin($name, $options), $breakChainOnFailure);
     }
 
     /**
@@ -242,9 +190,9 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * Validators are run in the order in which they were added to the chain (FIFO).
      *
-     * @param  mixed $context Extra "context" to provide the validator
+     * @param array<string, mixed> $context Extra "context" to provide the validator
      */
-    public function isValid(mixed $value, $context = null): bool
+    public function isValid(mixed $value, ?array $context = null): bool
     {
         $this->messages = [];
         $result         = true;
@@ -254,28 +202,25 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
             if ($validator->isValid($value, $context)) {
                 continue;
             }
+
             $result         = false;
-            $messages       = $validator->getMessages();
-            $this->messages = array_replace($this->messages, $messages);
+            $this->messages = array_replace($this->messages, $validator->getMessages());
             if ($element['breakChainOnFailure']) {
                 break;
             }
         }
+
         return $result;
     }
 
     /**
      * Merge the validator chain with the one given in parameter
-     *
-     * @return $this
      */
-    public function merge(ValidatorChain $validatorChain)
+    public function merge(ValidatorChain $validatorChain): void
     {
         foreach ($validatorChain->validators->toArray(PriorityQueue::EXTR_BOTH) as $item) {
             $this->attach($item['data']['instance'], $item['data']['breakChainOnFailure'], $item['priority']);
         }
-
-        return $this;
     }
 
     /**
@@ -283,7 +228,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * @return array<string, string>
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->messages;
     }
@@ -293,17 +238,15 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * @return list<QueueElement>
      */
-    public function getValidators()
+    public function getValidators(): array
     {
         return $this->validators->toArray(PriorityQueue::EXTR_DATA);
     }
 
     /**
      * Invoke chain as command
-     *
-     * @return bool
      */
-    public function __invoke(mixed $value)
+    public function __invoke(mixed $value): bool
     {
         return $this->isValid($value);
     }
@@ -324,9 +267,9 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      * and next invocation to getPluginManager() sets
      * the default plugin manager instance (ValidatorPluginManager).
      *
-     * @return array
+     * @return list<string>
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['validators', 'messages'];
     }

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -63,7 +63,12 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
     }
 
     /**
-     * Get plugin manager instance
+     * Retrieve the Validator Plugin Manager used by this instance
+     *
+     * If you need an instance of the plugin manager, you should retrieve it from your DI container. This method is
+     * only for internal use and is kept for compatibility with laminas-inputfilter.
+     *
+     * It is not subject to BC because it is marked as internal and the method may be removed in a minor release.
      *
      * @internal \Laminas
      */
@@ -79,6 +84,9 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
     /**
      * Set plugin manager instance
      *
+     * This method is retained for BC with laminas-inputfilter. It is internal and not subject to BC guarantees.
+     * It may be removed in a minor release.
+     *
      * @internal \Laminas
      */
     public function setPluginManager(ValidatorPluginManager $plugins): void
@@ -88,6 +96,9 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
 
     /**
      * Retrieve a validator by name
+     *
+     * This method is retained for BC with laminas-inputfilter. It is internal and not subject to BC guarantees.
+     * It may be removed in a minor release.
      *
      * @internal \Laminas
      *


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Adds native parameter and return types
- Drops "fluent" returns from all relevant methods
- Adds optional plugin manager constructor argument - one day we'll get rid of set/get plugin manager…
- Marks `getPluginManager`, `setPluginManager` and `plugin` methods as internal to the \Laminas namespace
- Removed deprecated methods
- Improve test coverage
- Minor changes to the docs such as referencing only validators shipped by this lib (As opposed to I18n) and removing the notice about service manager dependency requirement
