### PR TITLE
Return PHP_INT_MAX when a file size would exceed 2GB on a 32-bit system

### DIFF
--- a/src/File/Bytes.php
+++ b/src/File/Bytes.php
@@ -14,6 +14,7 @@ use function substr;
 use function trim;
 
 use const PHP_INT_MAX;
+use const PHP_INT_SIZE;
 
 /**
  * @internal
@@ -78,19 +79,34 @@ final class Bytes
                 $value = PHP_INT_MAX;
                 break;
             case 'E':
-                if ($value > 7) {
+                if ($value > 7 || PHP_INT_SIZE === 4) {
                     $value = PHP_INT_MAX;
                     break;
                 }
                 $value *= 1024 ** 6;
                 break;
             case 'P':
+                if (PHP_INT_SIZE === 4) {
+                    $value = PHP_INT_MAX;
+                    break;
+                }
+
                 $value *= 1024 ** 5;
                 break;
             case 'T':
+                if (PHP_INT_SIZE === 4) {
+                    $value = PHP_INT_MAX;
+                    break;
+                }
+
                 $value *= 1024 ** 4;
                 break;
             case 'G':
+                if ($value > 2 && PHP_INT_SIZE === 4) {
+                    $value = PHP_INT_MAX;
+                    break;
+                }
+
                 $value *= 1024 ** 3;
                 break;
             case 'M':

--- a/test/File/BytesTest.php
+++ b/test/File/BytesTest.php
@@ -24,6 +24,7 @@ class BytesTest extends TestCase
             [6_442_450_944, '6GB'],
             [6_597_069_766_656, '6TB'],
             [6_755_399_441_055_744, '6PB'],
+            [2_147_483_647, '2GB'], // PHP_INT_MAX on 32-bit
         ];
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| RFC           | yes

### Description

Closes #13 

File sizes > 2GB will return weird values on 32-bit systems as described by #13 

Should we consider this an issue at all?

If so, this patch will yield `PHP_INT_MAX` where it matters for file based validators.