### PR TITLE
Add a simple factory for creating validator chains from configuration

### DIFF
--- a/docs/book/v3/validator-chains.md
+++ b/docs/book/v3/validator-chains.md
@@ -95,3 +95,50 @@ if ($validatorChain->isValid($username)) {
 
 // This first example will display: The input is less than 7 characters long
 ```
+
+## The Validator Chain Factory
+
+It is often desirable to create validator chains from configuration arrays.
+The `ValidatorChainFactory` enables this and expects configuration in the following shape:
+
+```php
+use Laminas\Validator\NotEmpty;
+use Laminas\Validator\StringLength;
+
+$chainConfiguration = [
+    'First' => [
+        'name' => NotEmpty::class,
+        'break_chain_on_failure' => true,
+        'options' => [],
+        'priority' => 1,
+    ],
+    'Second' => [
+        'name' => StringLength::class,
+        'break_chain_on_failure' => true,
+        'options' => [
+            'min' => 5,
+            'max' => 10,
+        ],
+        'priority' => 1,
+    ],
+];
+```
+
+Note: The top-level array keys `First` and `Second` above are entirely optional and only serve to improve readability; a list is perfectly acceptable.
+
+Each element of the array **must** contain the `name` key that resolves to a validator that is configured for use in the `ValidatorPluginManager`.
+The other 3 keys `break_chain_on_failure`, `options` and `priority` are optional.
+
+- `options` are passed to the requested validator type unaltered.
+- `break_chain_on_failure`, when true, will prevent later validators from executing if validation fails
+- `priority` can be any arbitrary integer. Lower numbers execute first.
+
+Retrieve the `ValidatorChainFactory` from your application's DI container and pass the chain configuration to the factory's `fromArray` method:
+
+```php
+use Laminas\Validator\ValidatorChainFactory;
+
+$factory = $container->get(ValidatorChainFactory::class);
+$chain = $factory->fromArray($chainConfiguration);
+$chain->isValid('Some Value');
+```

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -33,6 +33,7 @@ final class ConfigProvider
                 'ValidatorManager' => ValidatorPluginManager::class,
             ],
             'factories' => [
+                ValidatorChainFactory::class  => ValidatorChainFactoryFactory::class,
                 ValidatorPluginManager::class => ValidatorPluginManagerFactory::class,
             ],
         ];

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator;
+
+use function assert;
+
+/**
+ * @psalm-type ValidatorSpecification = array{
+ *     name: string|class-string<ValidatorInterface>,
+ *     priority?: int,
+ *     break_chain_on_failure?: bool,
+ *     options?: array<string, mixed>,
+ * }
+ */
+final class ValidatorChainFactory
+{
+    public function __construct(private readonly ValidatorPluginManager $pluginManager)
+    {
+    }
+
+    /** @param array<array-key, ValidatorSpecification> $specification */
+    public function fromArray(array $specification): ValidatorChain
+    {
+        $chain = new ValidatorChain($this->pluginManager);
+        foreach ($specification as $spec) {
+            $priority   = $spec['priority'] ?? ValidatorChain::DEFAULT_PRIORITY;
+            $breakChain = $spec['break_chain_on_failure'] ?? false;
+            $options    = $spec['options'] ?? [];
+            $validator  = $this->pluginManager->build($spec['name'], $options);
+            assert($validator instanceof ValidatorInterface);
+            $chain->attach($validator, $breakChain, $priority);
+        }
+
+        return $chain;
+    }
+}

--- a/src/ValidatorChainFactoryFactory.php
+++ b/src/ValidatorChainFactoryFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator;
+
+use Psr\Container\ContainerInterface;
+
+final class ValidatorChainFactoryFactory
+{
+    public function __invoke(ContainerInterface $container): ValidatorChainFactory
+    {
+        return new ValidatorChainFactory($container->get(ValidatorPluginManager::class));
+    }
+}

--- a/test/ValidatorChainFactoryFactoryTest.php
+++ b/test/ValidatorChainFactoryFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator;
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Validator\ValidatorChainFactory;
+use Laminas\Validator\ValidatorChainFactoryFactory;
+use Laminas\Validator\ValidatorPluginManager;
+use LaminasTest\Validator\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\TestCase;
+
+class ValidatorChainFactoryFactoryTest extends TestCase
+{
+    public function testFactoryWillBeCreated(): void
+    {
+        $container = new InMemoryContainer();
+        $container->set(ValidatorPluginManager::class, new ValidatorPluginManager(new ServiceManager()));
+
+        $factory = (new ValidatorChainFactoryFactory())->__invoke($container);
+
+        self::assertInstanceOf(ValidatorChainFactory::class, $factory);
+    }
+}

--- a/test/ValidatorChainFactoryTest.php
+++ b/test/ValidatorChainFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Validator;
+
+use Laminas\ServiceManager\ServiceManager;
+use Laminas\Validator\NotEmpty;
+use Laminas\Validator\StringLength;
+use Laminas\Validator\ValidatorChainFactory;
+use Laminas\Validator\ValidatorPluginManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+
+class ValidatorChainFactoryTest extends TestCase
+{
+    private ValidatorChainFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new ValidatorChainFactory(new ValidatorPluginManager(new ServiceManager()));
+    }
+
+    public function testBasicChain(): void
+    {
+        $chain = $this->factory->fromArray([
+            'notEmpty'     => [
+                'name' => NotEmpty::class,
+            ],
+            'stringLength' => [
+                'name'    => StringLength::class,
+                'options' => [
+                    'min' => 5,
+                ],
+            ],
+        ]);
+
+        self::assertFalse($chain->isValid(''));
+        $messages = $chain->getMessages();
+        self::assertArrayHasKey(NotEmpty::IS_EMPTY, $messages);
+        self::assertArrayHasKey(StringLength::TOO_SHORT, $messages);
+    }
+
+    public function testValidatorAliasesCanBeUsed(): void
+    {
+        $chain = $this->factory->fromArray([
+            'notEmpty'     => [
+                'name' => 'NotEmpty',
+            ],
+            'stringLength' => [
+                'name'    => 'StringLength',
+                'options' => [
+                    'min' => 5,
+                ],
+            ],
+        ]);
+
+        self::assertFalse($chain->isValid(''));
+        $messages = $chain->getMessages();
+        self::assertArrayHasKey(NotEmpty::IS_EMPTY, $messages);
+        self::assertArrayHasKey(StringLength::TOO_SHORT, $messages);
+    }
+
+    public function testCreatedChainRespectsBreakChainOption(): void
+    {
+        $chain = $this->factory->fromArray([
+            'notEmpty'     => [
+                'name'                   => NotEmpty::class,
+                'break_chain_on_failure' => true,
+            ],
+            'stringLength' => [
+                'name'    => StringLength::class,
+                'options' => [
+                    'min' => 5,
+                ],
+            ],
+        ]);
+
+        self::assertFalse($chain->isValid(''));
+        $messages = $chain->getMessages();
+        self::assertArrayHasKey(NotEmpty::IS_EMPTY, $messages);
+        self::assertArrayNotHasKey(StringLength::TOO_SHORT, $messages);
+    }
+
+    public function testCreatedChainRespectsPriorityOption(): void
+    {
+        $chain = $this->factory->fromArray([
+            'notEmpty'     => [
+                'name'                   => NotEmpty::class,
+                'priority'               => 10,
+                'break_chain_on_failure' => true,
+            ],
+            'stringLength' => [
+                'name'                   => StringLength::class,
+                'options'                => [
+                    'min' => 5,
+                ],
+                'break_chain_on_failure' => true,
+                'priority'               => 20,
+            ],
+        ]);
+
+        self::assertFalse($chain->isValid(''));
+        $messages = $chain->getMessages();
+        self::assertArrayNotHasKey(NotEmpty::IS_EMPTY, $messages);
+        self::assertArrayHasKey(StringLength::TOO_SHORT, $messages);
+    }
+
+    public function testPsrContainerNotFoundIsThrownForInvalidServiceNames(): void
+    {
+        $this->expectException(NotFoundExceptionInterface::class);
+        $this->factory->fromArray([
+            'invalid' => [
+                'name' => 'Unknown',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| New Feature   | yes

### Description

Adds a factory for creating validator chains from a well-known array shape.

The array shape is already in use in `laminas/laminas-inputfilter` and the factory introduced here can be used to to replace code in input-filter.

There's further background in #370 as this is a pre-requisite for introducing the proposed conditional validator.