### PR TITLE
Capitalize section headers in docs

### DIFF
--- a/docs/book/v3/intro.md
+++ b/docs/book/v3/intro.md
@@ -4,7 +4,7 @@ laminas-validator provides a set of commonly needed validators. It also provides
 simple validator chaining mechanism by which multiple validators may be applied
 to a single datum in a user-defined order.
 
-## What is a validator?
+## What Is a Validator?
 
 A validator examines its input with respect to some requirements and produces a
 boolean result indicating whether the input successfully validates against the
@@ -18,7 +18,7 @@ validator can be used for ensuring that a username meets these requirements. If
 a chosen username does not meet one or both of the requirements, it would be
 useful to know which of the requirements the username fails to meet.
 
-## Basic usage of validators
+## Basic Usage of Validators
 
 Having defined validation in this way provides the foundation for
 `Laminas\Validator\ValidatorInterface`, which defines two methods, `isValid()` and
@@ -34,7 +34,7 @@ are class-dependent; each validation class defines its own set of validation
 failure messages and the unique keys that identify them. Each class also has a
 `const` definition that matches each identifier for a validation failure cause.
 
-> ### Stateful validators
+> ### Stateful Validators
 >
 > The `getMessages()` methods return validation failure information only for the
 > most recent `isValid()` call. Each call to `isValid()` clears any messages and
@@ -58,7 +58,7 @@ if ($validator->isValid($email)) {
 }
 ```
 
-## Customizing messages
+## Customizing Messages
 
 Validator classes provide a `setMessage()` method with which you can specify the
 format of a message returned by `getMessages()` in case of validation failure.
@@ -132,9 +132,9 @@ if (! $validator->isValid('word')) {
 }
 ```
 
-## Translating messages
+## Translating Messages
 
-> ### Installation requirements
+> ### Installation Requirements
 >
 > The translation of validator messages depends on the laminas-i18n component, so
 > be sure to have it installed before getting started:
@@ -192,7 +192,7 @@ It is also possible to use a translator instead of setting own messages with
 `setMessage()`. But doing so, you should keep in mind, that the translator works
 also on messages you set your own.
 
-> ### Translation compatibility
+> ### Translation Compatibility
 >
 > In versions 2.0 - 2.1, `Laminas\Validator\AbstractValidator` implemented
 > `Laminas\I18n\Translator\TranslatorAwareInterface` and accepted instances of

--- a/docs/book/v3/messages.md
+++ b/docs/book/v3/messages.md
@@ -42,7 +42,7 @@ The second parameter defines the failure which will be overridden. When you omit
 this parameter, then the given message will be set for all possible failures of
 this validator.
 
-## Using pre-translated validation messages
+## Using Pre-Translated Validation Messages
 
 laminas-validator is shipped with more than 45 different validators with more than
 200 failure messages. It can be a tedious task to translate all of these
@@ -72,7 +72,7 @@ $translator->addTranslationFilePattern(
 AbstractValidator::setDefaultTranslator($translator);
 ```
 
-> ### Supported languages
+> ### Supported Languages
 >
 > The supported languages may not be complete. New languages will be added with
 > each release. Additionally feel free to use the existing resource files to
@@ -81,7 +81,7 @@ AbstractValidator::setDefaultTranslator($translator);
 > You could also use these resource files to rewrite existing translations. So
 > you are not in need to create these files manually yourself.
 
-## Limit the size of a validation message
+## Limit the Size of a Validation Message
 
 Sometimes it is necessary to limit the maximum size a validation message can
 have; as an example, when your view allows a maximum size of 100 chars to be
@@ -102,7 +102,7 @@ instead of the rest of the message.
 Laminas\Validator\AbstractValidator::setMessageLength(100);
 ```
 
-> ### Where is this parameter used?
+> ### Where Is This Parameter Used?
 >
 > The set message length is used for all validators, even for self defined ones,
 > as long as they extend `Laminas\Validator\AbstractValidator`.

--- a/docs/book/v3/set.md
+++ b/docs/book/v3/set.md
@@ -34,7 +34,7 @@ The following validators come with the laminas-validator distribution.
 - [Uri](validators/uri.md)
 - [Uuid](validators/uuid.md)
 
-## Additional validators
+## Additional Validators
 
 Several other components offer validators as well:
 

--- a/docs/book/v3/validators/backed-enum-value.md
+++ b/docs/book/v3/validators/backed-enum-value.md
@@ -2,13 +2,13 @@
 
 `Laminas\Validator\BackedEnumValue` allows you to validate that a string or numeric value is a valid value for a specified [enum](https://www.php.net/manual/language.enumerations.php).
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\BackedEnumValue`:
 
 - `enum`: The backed enum class you wish to test against
 
-## Basic usage
+## Basic Usage
 
 ```php
 enum MyEnum: string {

--- a/docs/book/v3/validators/barcode.md
+++ b/docs/book/v3/validators/barcode.md
@@ -256,7 +256,7 @@ The following options are supported for `Laminas\Validator\Barcode`:
 - `adapter`: Sets the barcode adapter which will be used. All the adapters listed above are supported and the option accepts either a FQCN, an adapter instance or a short string such as 'Upca' or 'Gtin13' that corresponds to the class name. Short strings should be avoided in favour of FQCN's.
 - `checksum`: `false` Checksum validation is *off* by default. If you are validating barcodes that are capable of validating a checksum, you should explicitly enable this option by setting it to `true`
 
-## Basic usage
+## Basic Usage
 
 To validate if a given string is a barcode you must know its type. See the
 following example for an EAN13 barcode:
@@ -288,7 +288,7 @@ if ($valid->isValid($input)) {
 }
 ```
 
-> ### Reduced security by disabling checksum validation
+> ### Reduced Security by Disabling Checksum Validation
 >
 > By switching off checksum validation you will also reduce the security of the
 > used barcodes. Additionally, you should note that you can also turn off the

--- a/docs/book/v3/validators/bic.md
+++ b/docs/book/v3/validators/bic.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\BusinessIdentifierCode` validates if a given value **could be a ["Business Identifier Code" (BIC)](https://www.swift.com/standards/data-standards/bic)** as defined by [ISO 9362](https://wikipedia.org/wiki/ISO_9362).
 A BIC is a unique identification code for financial and non-financial institutions.
 
-## Supported options
+## Supported Options
 
 There are no additional supported options for the `BusinessIdentifierCode` validator.
 
@@ -21,7 +21,7 @@ BICs should be a string which length should be equal to 8 or 11.
 - The last 3 characters are optional and can be letters or digits, generally to represent a branch office.
   The code 'XXX' is often used to represent the AIN office when the 11 character code is used.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\BusinessIdentifierCode();

--- a/docs/book/v3/validators/callback.md
+++ b/docs/book/v3/validators/callback.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Callback` allows you to provide a callback with which to
 validate a given value.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Callback`:
 
@@ -12,7 +12,7 @@ The following options are supported for `Laminas\Validator\Callback`:
 - `throwExceptions`: When true, [allows exceptions thrown inside of callbacks to propagate](#exceptions-within-callbacks).
 - `bind`: When true, the callback will bound to the validator's scope allowing the closure to call internal methods of the validator.
 
-## Basic usage
+## Basic Usage
 
 The simplest use case is to pass a function as a callback. Consider the
 following function:
@@ -36,7 +36,7 @@ if ($valid->isValid($input)) {
 }
 ```
 
-## Usage with closures
+## Usage with Closures
 
 The `Callback` validator supports any PHP callable, including PHP
 [closures](http://php.net/functions.anonymous).
@@ -54,7 +54,7 @@ if ($valid->isValid($input)) {
 }
 ```
 
-## Usage with class-based callbacks
+## Usage with Class-Based Callbacks
 
 Of course, it's also possible to use a class method as callback. Consider the
 following class definition:
@@ -124,7 +124,7 @@ if ($valid->isValid($input)) {
 }
 ```
 
-## Adding options
+## Adding Options
 
 `Laminas\Validator\Callback` also allows the usage of options which are provided as additional arguments to the callback.
 

--- a/docs/book/v3/validators/credit-card.md
+++ b/docs/book/v3/validators/credit-card.md
@@ -36,7 +36,7 @@ The following issuing institutes are accepted:
 - Russia Mir
 
 <!-- markdownlint-disable-next-line MD001 -->
-> ### Invalid institutes
+> ### Invalid Institutes
 >
 > The institutes **Bankcard** and **Diners Club enRoute** no longer exist, and
 > are treated as invalid.
@@ -44,7 +44,7 @@ The following issuing institutes are accepted:
 > **Switch** has been rebranded to **Visa** and is therefore also treated as
 > invalid.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\CreditCard`:
 
@@ -53,7 +53,7 @@ The following options are supported for `Laminas\Validator\CreditCard`:
 - `type`: The type of credit card which will be validated. See the below list of
   institutes for details.
 
-## Basic usage
+## Basic Usage
 
 There are several credit card institutes which can be validated by
 `Laminas\Validator\CreditCard`. Per default, all known institutes will be accepted.
@@ -70,7 +70,7 @@ if ($valid->isValid($input)) {
 
 The above example would validate against all known credit card institutes.
 
-## Accepting only specific credit cards
+## Accepting Only Specific Credit Cards
 
 Sometimes it is necessary to accept only specific credit card institutes instead
 of all; e.g., when you have a webshop which accepts only Visa and American
@@ -100,12 +100,12 @@ $valid = new CreditCard([
 ]);
 ```
 
-> ### Default institute
+> ### Default Institute
 >
 > When no institute is given at initiation then `ALL` will be used, which sets
 > all institutes at once.
 
-## Validation using APIs
+## Validation Using APIs
 
 As said before `Laminas\Validator\CreditCard` will only validate the credit card
 number. Fortunately, some institutes provide online APIs which can validate a

--- a/docs/book/v3/validators/date.md
+++ b/docs/book/v3/validators/date.md
@@ -2,14 +2,14 @@
 
 `Laminas\Validator\Date` allows you to validate if a given value contains a date.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Date`:
 
 - `format`: Sets the format which is used to write the date.
 - `strict`: Ensures that string input exactly matches the generated date when formatted
 
-## Default date validation
+## Default Date Validation
 
 The easiest way to validate a date is by using the default date format,
 `Y-m-d`.
@@ -21,7 +21,7 @@ $validator->isValid('2000-10-10');   // returns true
 $validator->isValid('10.10.2000'); // returns false
 ```
 
-## Specifying a date format
+## Specifying a Date Format
 
 `Laminas\Validator\Date` also supports custom date formats. When you want to
 validate such a date, use the `format` option. This option accepts any format
@@ -34,7 +34,7 @@ $validator->isValid('2010'); // returns true
 $validator->isValid('May');  // returns false
 ```
 
-## Strict mode
+## Strict Mode
 
 By default, `Laminas\Validator\Date` only validates that it can convert the
 provided value to a valid `DateTime` value.

--- a/docs/book/v3/validators/digits.md
+++ b/docs/book/v3/validators/digits.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Digits` validates if a given value contains only digits.
 
 <!-- markdownlint-disable-next-line MD001 -->
-> ### Installation requirements
+> ### Installation Requirements
 >
 > `Laminas\Validator\Digits` depends on the laminas-filter component, so be sure to
 > have it installed before getting started:
@@ -12,11 +12,11 @@
 > $ composer require laminas/laminas-filter
 > ```
 
-## Supported options
+## Supported Options
 
 There are no additional options for `Laminas\Validator\Digits`:
 
-## Validating digits
+## Validating Digits
 
 To validate if a given value contains only digits and no other characters,
 call the validator as shown below:
@@ -29,7 +29,7 @@ $validator->isValid(1234);         // returns true
 $validator->isValid('1a234');      // returns false
 ```
 
-> ### Validating numbers
+> ### Validating Numbers
 >
 > When you want to validate numbers or numeric values, be aware that this
 > validator only validates *digits*. This means that any other sign like a

--- a/docs/book/v3/validators/email-address.md
+++ b/docs/book/v3/validators/email-address.md
@@ -4,7 +4,7 @@
 validator first splits the email address on `local-part @ hostname` and attempts
 to match these against known specifications for email addresses and hostnames.
 
-## Basic usage
+## Basic Usage
 
 A basic example of usage is below:
 
@@ -61,7 +61,7 @@ RFC2822. For example, valid emails include `bob@domain.com`,
 Some obsolete email formats will not currently validate (e.g. carriage returns
 or a `\\` character in an email address).
 
-## Validating only the local part
+## Validating Only the Local Part
 
 If you need `Laminas\Validator\EmailAddress` to check only the local part of an
 email address, and want to disable validation of the hostname, you can set the
@@ -73,7 +73,7 @@ $validator = new Laminas\Validator\EmailAddress();
 $validator->setOptions(['useDomainCheck' => false]);
 ```
 
-## Validating different types of hostnames
+## Validating Different Types of Hostnames
 
 The hostname part of an email address is validated against the [Hostname validator](hostname.md).
 By default only DNS hostnames of the form `domain.com` are accepted, though if
@@ -100,7 +100,7 @@ if ($validator->isValid($email)) {
 }
 ```
 
-## Checking if the hostname actually accepts email
+## Checking If the Hostname Actually Accepts Email
 
 Just because an email address is in the correct format, it doesn't necessarily
 mean that email address actually exists. To help solve this problem, you can use
@@ -137,13 +137,13 @@ $validator = new Laminas\Validator\EmailAddress([
 ]);
 ```
 
-> ### Performance warning**
+> ### Performance Warning
 >
 > You should be aware that enabling MX check will slow down you script because
 > of the used network functions. Enabling deep check will slow down your script
 > even more as it searches the given server for 3 additional types.
 
-> ### Disallowed IP addresses
+> ### Disallowed IP Addresses
 >
 > You should note that MX validation is only accepted for external servers. When
 > deep MX validation is enabled, then local IP addresses like `192.168.*` or
@@ -204,7 +204,7 @@ More information on the usage of the `useTldCheck` option appears in the
 
 Please note TLDs are only validated if you allow DNS hostnames to be validated.
 
-## Setting messages
+## Setting Messages
 
 `Laminas\Validator\EmailAddress` makes also use of `Laminas\Validator\Hostname` to
 check the hostname part of a given email address. You can specify messages for

--- a/docs/book/v3/validators/enum-case.md
+++ b/docs/book/v3/validators/enum-case.md
@@ -2,13 +2,13 @@
 
 `Laminas\Validator\EnumCase` allows you to validate that a string is a valid case for a specified [enum](https://www.php.net/manual/language.enumerations.php).
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\BackedEnumValue`:
 
 - `enum`: The backed or unit enum class you wish to test against
 
-## Basic usage
+## Basic Usage
 
 ```php
 enum MyEnum {

--- a/docs/book/v3/validators/explode.md
+++ b/docs/book/v3/validators/explode.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Explode` executes a validator for each item exploded from an
 array.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Explode`:
 
@@ -13,7 +13,7 @@ The following options are supported for `Laminas\Validator\Explode`:
   This may be a validator instance, a validator service name, or a "specification" array.
 - `validatorPluginManager`: The validator plugin manager in use in your application. If this plugin manager is not provided, a plugin manager will be created with the default configuration.
 
-## Basic usage
+## Basic Usage
 
 To validate if every item in an array is in a specified haystack:
 
@@ -30,7 +30,7 @@ $explodeValidator->isValid('1,4,6');    // returns true
 $explodeValidator->isValid('1,4,6,8'); // returns false
 ```
 
-## Configuration using a validator specification
+## Configuration Using a Validator Specification
 
 Instead of creating a validator instance, you can provide an array to describe the validator you wish to use for each element:
 

--- a/docs/book/v3/validators/file/exclude-mime-type.md
+++ b/docs/book/v3/validators/file/exclude-mime-type.md
@@ -1,5 +1,4 @@
-ExcludeMimeType
-===============
+# ExcludeMimeType
 
 `Laminas\Validator\File\ExcludeMimeType` checks the MIME type of files. It will
 assert `false` when a given file matches any of the defined MIME types.

--- a/docs/book/v3/validators/file/exists.md
+++ b/docs/book/v3/validators/file/exists.md
@@ -54,7 +54,7 @@ if ($validator->isValid('/path/to/myfile.txt')) {
 }
 ```
 
-> ### Checks against all directories
+> ### Checks against All Directories
 >
 > By default, this validator checks whether the specified file exists in **all** of the
 > given directories; validation will fail if the file does not exist in one

--- a/docs/book/v3/validators/file/intro.md
+++ b/docs/book/v3/validators/file/intro.md
@@ -19,7 +19,7 @@ uploaded files, such as file size validation and CRC checking.
 - [UploadFile](upload-file.md)
 - [WordCount](word-count.md)
 
-> ### Validation argument
+> ### Validation Argument
 >
 > All of the File validators' `isValid()` methods support both a file path
 > `string` *or* a `$_FILES` array as the supplied argument. When a `$_FILES`

--- a/docs/book/v3/validators/file/mime-type.md
+++ b/docs/book/v3/validators/file/mime-type.md
@@ -39,7 +39,7 @@ if ($validator->isValid('./myfile.jpg')) {
 }
 ```
 
-> ### Validating MIME groups is potentially dangerous
+> ### Validating MIME Groups Is Potentially Dangerous
 >
 > Allowing "groups" of MIME types will accept **all** members of this group, even
 > if your application does not support them. For instance, When you allow

--- a/docs/book/v3/validators/file/not-exists.md
+++ b/docs/book/v3/validators/file/not-exists.md
@@ -28,7 +28,7 @@ if ($validator->isValid('some-file.txt')) {
 }
 ```
 
-> ### Checks against all directories
+> ### Checks against All Directories
 >
 > This validator checks whether the specified file does not exist in **any** of
 > the given directories; validation will fail if the file exists in one (or

--- a/docs/book/v3/validators/hex.md
+++ b/docs/book/v3/validators/hex.md
@@ -15,12 +15,12 @@ if ($validator->isValid('123ABC')) {
 ```
 
 <!-- markdownlint-disable-next-line MD001 -->
-> ### Invalid characters
+> ### Invalid Characters
 >
 > All other characters will return false, including whitespace and decimal
 > points. Additionally, unicode zeros and numbers from other scripts than latin
 > will not be treated as valid.
 
-## Supported options
+## Supported Options
 
 There are no additional options for `Laminas\Validator\Hex`.

--- a/docs/book/v3/validators/host-with-public-ipv4-address.md
+++ b/docs/book/v3/validators/host-with-public-ipv4-address.md
@@ -2,11 +2,11 @@
 
 `Laminas\Validator\HostWithPublicIPv4Address` allows you to validate that an IP address is not a reserved address such as 127.0.0.1, or that a hostname does not point to a known, reserved address.
 
-## Supported options
+## Supported Options
 
 This validator has no options
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\HostWithPublicIPv4Address();
@@ -34,6 +34,6 @@ if ($validator->isValid('192.168.0.1')) {
 }
 ```
 
-## Hostnames with multiple records
+## Hostnames with Multiple Records
 
 When validating a hostname as opposed to an IP address, if that hostname resolves to multiple IPv4 addresses and _any_ of those addresses are private or reserved, then the validator will deem the hostname invalid.

--- a/docs/book/v3/validators/hostname.md
+++ b/docs/book/v3/validators/hostname.md
@@ -5,7 +5,7 @@ known specifications. It is possible to check for three different types of
 hostnames: a DNS Hostname (i.e. `domain.com`), IP address (i.e. 1.2.3.4), and
 Local hostnames (i.e. localhost). By default, only DNS hostnames are matched.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Hostname`:
 
@@ -16,7 +16,7 @@ The following options are supported for `Laminas\Validator\Hostname`:
 - `ipValidator`: Allows defining an [IP validator](ip.md) with custom configuration
 - `tld`: Defines if TLDs are validated. This option defaults to `true`.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\Hostname();
@@ -34,7 +34,7 @@ if ($validator->isValid($hostname)) {
 This will match the hostname `$hostname` and on failure populate `getMessages()`
 with useful error messages.
 
-## Validating different types of hostnames
+## Validating Different Types of Hostnames
 
 You may find you also want to match IP addresses, Local hostnames, or a
 combination of all allowed types. This can be done by passing a parameter to

--- a/docs/book/v3/validators/iban.md
+++ b/docs/book/v3/validators/iban.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Iban` validates if a given value could be a IBAN number. IBAN is
 the abbreviation for "International Bank Account Number".
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Iban`:
 
@@ -11,14 +11,14 @@ The following options are supported for `Laminas\Validator\Iban`:
   for validation.
 - `allow_non_sepa`: A boolean that limits allowable account numbers to SEPA countries when `false`
 
-## IBAN validation
+## IBAN Validation
 
 IBAN numbers are always related to a country. This means that different
 countries use different formats for their IBAN numbers. This is the reason why
 IBAN numbers always need a country code. By knowing this we already know how
 to use `Laminas\Validator\Iban`.
 
-### Ungreedy IBAN validation
+### Ungreedy IBAN Validation
 
 Sometimes it is useful just to validate if the given value is a IBAN number or
 not. This means that you don't want to validate it against a defined country.
@@ -38,7 +38,7 @@ In this situation, any IBAN number from any country will considered valid. Note
 that this should not be done when you accept only accounts from a single
 country!
 
-### Region aware IBAN validation
+### Region Aware IBAN Validation
 
 To validate against a defined country, you must provide a country code. You can
 do this during instantiation via the option `country_code`.

--- a/docs/book/v3/validators/identical.md
+++ b/docs/book/v3/validators/identical.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Identical` allows you to validate if a given value is identical
 with a set token.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Identical`:
 
@@ -14,7 +14,7 @@ The following options are supported for `Laminas\Validator\Identical`:
   in the form context, and validate the token just the way it was provided. The
   default value is `false`.
 
-## Basic usage
+## Basic Usage
 
 To validate if two values are identical, you need to set the original value as
 the token, as demonstrated in the following example:
@@ -30,7 +30,7 @@ $validator->isValid('goat'); // false
 The validation will only then return `true` when both values are 100% identical.
 In our example, when `$value` is `'donkey'`.
 
-## Identical objects
+## Identical Objects
 
 `Laminas\Validator\Identical` can validate not only strings, but any other variable
 type, such as booleans, integers, floats, arrays, or even objects. As already
@@ -46,13 +46,13 @@ if ($validator->isValid($input)) {
 }
 ```
 
-> ### Type comparison
+> ### Type Comparison
 >
 > You should be aware of the variable type used for validation. This means that
 > the string `'3'` is not identical to integer `3`. When you want non-strict
 > validation, you must set the `strict` option to `false`.
 
-## Form elements
+## Form Elements
 
 `Laminas\Validator\Identical` supports the comparison of form elements. This can be
 done by using the element's name as the `token`:
@@ -168,12 +168,12 @@ $inputFilter->add([
 $signUpForm->setInputFilter($inputFilter);
 ```
 
-> #### Use one token per leaf
+> #### Use One Token per Leaf
 >
 > Always make sure that your token array has just one key per level all the way
 > till the leaf, otherwise you can end up with unexpected results.
 
-## Strict validation
+## Strict Validation
 
 As mentioned before, `Laminas\Validator\Identical` validates tokens using strict
 typing. You can change this behaviour by using the `strict` option. The default

--- a/docs/book/v3/validators/in-array.md
+++ b/docs/book/v3/validators/in-array.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\InArray` allows you to validate if a given value is contained
 within an array. It is also able to validate multidimensional arrays.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\InArray`:
 
@@ -22,14 +22,14 @@ The following options are supported for `Laminas\Validator\InArray`:
     but ensures that strings are not cast to integer during comparison,
     preventing `0 == 'foo43'` types of false positives.
 
-> ### Use non-strict carefully
+> ### Use Non-Strict Carefully
 >
 > Non-strict mode (`InArray::COMPARE_NOT_STRICT`) may give false positives when
 > strings are compared against ints or floats owing to `in_array()`'s behaviour
 > of converting strings to int in such cases. Therefore, `'foo'` would become
 > `0`, `'43foo'` would become `43`, while `foo43'` would also become `0`.
 
-## Array validation
+## Array Validation
 
 Basic usage is to provide an array during instantiation:
 
@@ -48,12 +48,12 @@ if ($validator->isValid('value')) {
 This will behave exactly like PHP's `in_array()` method when passed only a
 needle and haystack.
 
-> ### Non-strict by default
+> ### Non-Strict by Default
 >
 > By default, this validation is not strict, nor can it validate
 > multidimensional arrays.
 
-## Array validation modes
+## Array Validation Modes
 
 As previously mentioned, there are possible security issues when using the
 default non-strict comparison mode, so rather than restricting the developer,
@@ -84,11 +84,11 @@ $validator = new Laminas\Validator\InArray([
 ]);
 ```
 
-> ### Non-strict safe-mode by default
+> ### Non-Strict Safe-Mode by Default
 >
 > Note that the `strict` setting is per default `false`.
 
-## Recursive array validation
+## Recursive Array Validation
 
 In addition to PHP's `in_array()` method, this validator can also be used to
 validate multidimensional arrays.
@@ -114,6 +114,6 @@ if ($validator->isValid('value')) {
 Your array will then be validated recursively to see if the given value is
 contained.
 
-> ### Default setting for recursion
+> ### Default Setting for Recursion
 >
 > By default, recursive validation is turned off.

--- a/docs/book/v3/validators/ip.md
+++ b/docs/book/v3/validators/ip.md
@@ -3,7 +3,7 @@
 `Laminas\Validator\Ip` allows you to validate if a given value is an IP address. It
 supports the IPv4, IPv6, and IPvFuture definitions.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Ip`:
 
@@ -16,7 +16,7 @@ The following options are supported for `Laminas\Validator\Ip`:
 - `allowliteral`: Defines if the validator allows IPv6 or IPvFuture with URI
   literal style (the IP surrounded by brackets). This option defaults to `true`.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\Ip();
@@ -28,19 +28,19 @@ if ($validator->isValid($ip)) {
 }
 ```
 
-> ### Invalid IP addresses
+> ### Invalid IP Addresses
 >
 > Keep in mind that `Laminas\Validator\Ip` only validates IP addresses. Addresses
 > like '`mydomain.com`' or '`192.168.50.1/index.html`' are not valid IP
 > addresses. They are either hostnames or valid URLs but not IP addresses.
 
-> ### IPv6/IPvFuture validation
+> ### IPv6/IPvFuture Validation
 >
 > `Laminas\Validator\Ip` validates IPv6/IPvFuture addresses using a regex. The
 > reason is that the filters and methods from PHP itself don't follow the RFC.
 > Many other available classes also don't follow it.
 
-## Validate IPv4 or IPV6 alone
+## Validate IPv4 or IPV6 Alone
 
 Sometimes it's useful to validate only one of the supported formats; e.g., when
 your network only supports IPv4. In this case it would be useless to allow IPv6
@@ -60,7 +60,7 @@ if ($validator->isValid($ip)) {
 }
 ```
 
-> ### Default behaviour
+> ### Default Behaviour
 >
 > The default behaviour which `Laminas\Validator\Ip` follows is to allow both
 > standards.

--- a/docs/book/v3/validators/is-countable.md
+++ b/docs/book/v3/validators/is-countable.md
@@ -11,7 +11,7 @@ Specifying either of the latter two is inconsistent with the first, and, as
 such, the validator does not allow setting both a count and a minimum or maximum
 value. You may, however specify both minimum and maximum values to ensure that the number of elements is between a given range.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\IsCountable`:
 
@@ -22,7 +22,7 @@ The following options are supported for `Laminas\Validator\IsCountable`:
 - `min`: Sets the minimum value for the validation; if the count of the value is
   lower than the minimum, validation fails.
 
-## Default behaviour
+## Default Behaviour
 
 Given no options, the validator simply tests to see that the value may be
 counted (i.e., it's an array or `Countable` instance):
@@ -36,7 +36,7 @@ $validator->isValid(new ArrayObject([10])); // true; value is Countable
 $validator->isValid(new stdClass);          // false; value is not Countable
 ```
 
-## Specifying an exact count
+## Specifying an Exact Count
 
 You can also specify an exact count; if the value is countable, and its count
 matches, the the value is valid.
@@ -50,7 +50,7 @@ $validator->isValid([1]);                        // false; countable, but count 
 $validator->isValid(new ArrayObject([1]));       // false; countable, but count is 1
 ```
 
-## Specifying a minimum count
+## Specifying a Minimum Count
 
 You may specify a minimum count. When you do, the value must be countable, and
 greater than or equal to the minimum count you specify in order to be valid.
@@ -66,7 +66,7 @@ $validator->isValid([1]);                        // false; countable, but count 
 $validator->isValid(new ArrayObject([1]));       // false; countable, but count is 1
 ```
 
-## Specifying a maximum count
+## Specifying a Maximum Count
 
 You may specify a maximum count. When you do, the value must be countable, and
 less than or equal to the maximum count you specify in order to be valid.
@@ -82,7 +82,7 @@ $validator->isValid([1]);                        // true; countable, and count i
 $validator->isValid(new ArrayObject([1]));       // true; countable, and count is 1
 ```
 
-## Specifying both minimum and maximum
+## Specifying Both Minimum and Maximum
 
 If you specify both a minimum and maximum, the count must be _between_ the two,
 inclusively (i.e., it may be the minimum or maximum, and any value between).

--- a/docs/book/v3/validators/isbn.md
+++ b/docs/book/v3/validators/isbn.md
@@ -2,7 +2,7 @@
 
 `Laminas\Validator\Isbn` allows you to validate ISBN-10 or ISBN-13 numbers.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Isbn`:
 
@@ -10,7 +10,7 @@ The following options are supported for `Laminas\Validator\Isbn`:
   `Laminas\Validator\Isbn::AUTO`. For details, take a look at the section on
   [explicit types](#setting-an-explicit-isbn-validation-type).
 
-## Basic usage
+## Basic Usage
 
 A basic example of usage is below:
 
@@ -26,7 +26,7 @@ if ($validator->isValid($isbn)) {
 
 This will validate any ISBN-10 or ISBN-13 with or without separators.
 
-## Setting an explicit ISBN validation type
+## Setting an Explicit ISBN Validation Type
 
 An example of an ISBN type restriction follows:
 

--- a/docs/book/v3/validators/isinstanceof.md
+++ b/docs/book/v3/validators/isinstanceof.md
@@ -3,14 +3,14 @@
 `Laminas\Validator\IsInstanceOf` allows you to validate whether a given object is
 an instance of a specific class or interface.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\IsInstanceOf`:
 
 - `className`: Defines the fully-qualified class name which objects must be an
   instance of.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\IsInstanceOf([

--- a/docs/book/v3/validators/not-empty.md
+++ b/docs/book/v3/validators/not-empty.md
@@ -4,14 +4,14 @@ This validator allows you to validate if a given value is not empty. This is
 often useful when working with form elements or other user input, where you can
 use it to ensure required elements have values associated with them.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\NotEmpty`:
 
 - `type`: Sets the type of validation which will be processed; for details, see
   the section on [specifying empty behavior](#specifying-empty-behavior).
 
-## Default behaviour
+## Default Behaviour
 
 By default, this validator works differently than you would expect when you've
 worked with PHP's `empty()` operator. In particular, this validator will
@@ -24,7 +24,7 @@ $result = $valid->isValid($value);
 // returns false
 ```
 
-## Specifying empty behavior
+## Specifying Empty Behavior
 
 Some projects have differing opinions of what is considered an "empty" value: a
 string with only whitespace might be considered empty, or `0` may be

--- a/docs/book/v3/validators/regex.md
+++ b/docs/book/v3/validators/regex.md
@@ -4,13 +4,13 @@ This validator allows you to validate if a given string conforms a defined regul
 
 It will *not* automatically cast integers or floats to string prior to evaluation - when provided a non string value, validation will fail.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Regex`:
 
 - `pattern`: Sets the regular expression pattern for this validator.
 
-## Usage
+## Basic Usage
 
 Validation with regular expressions allows complex validations without writing a custom validator.
 

--- a/docs/book/v3/validators/sitemap.md
+++ b/docs/book/v3/validators/sitemap.md
@@ -3,7 +3,7 @@
 The following validators conform to the
 [Sitemap XML protocol](http://www.sitemaps.org/protocol.php).
 
-## Supported options
+## Supported Options
 
 There are no additional supported options for any of the `Sitemap` validators.
 
@@ -47,7 +47,7 @@ $validator->isValid('yesterday'); // false
 [Laminas\\Uri\\Uri::isValid()](https://docs.laminas.dev/laminas-uri/usage/#validating-the-uri)
 internally.
 
-> ### Installation requirements
+> ### Installation Requirements
 >
 > `Laminas\Validator\Sitemap\Loc` depends on the laminas-uri component, so be sure to
 > have it installed before getting started:

--- a/docs/book/v3/validators/step.md
+++ b/docs/book/v3/validators/step.md
@@ -4,7 +4,7 @@
 value. This validator requires the value to be a numeric value (either string,
 int or float).
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Step`:
 
@@ -12,7 +12,7 @@ The following options are supported for `Laminas\Validator\Step`:
   This option defaults to `0`
 - `step`: This is the step value. This option defaults to `1`
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\Step();
@@ -24,7 +24,7 @@ if ($validator->isValid(1)) {
 }
 ```
 
-## Using floating-point values
+## Using Floating-Point Values
 
 The `Step` validator also supports floating-point base and step values:
 

--- a/docs/book/v3/validators/string-length.md
+++ b/docs/book/v3/validators/string-length.md
@@ -9,7 +9,7 @@ length.
 > `Laminas\Validator\StringLength` supports only the validation of strings.
 > Integers, floats, dates or objects can not be validated with this validator.
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\StringLength`:
 
@@ -17,7 +17,7 @@ The following options are supported for `Laminas\Validator\StringLength`:
 - `min`: Sets the minimum allowed length for a string. _(Default `0`)_
 - `max`: Sets the maximum allowed length for a string. _(Default `null`)_
 
-## Default behaviour
+## Default Behaviour
 
 By default, this validator checks if a value is between `min` and `max` using a
 default `min` value of `0` and default `max` value of `NULL` (meaning unlimited).
@@ -25,7 +25,7 @@ default `min` value of `0` and default `max` value of `NULL` (meaning unlimited)
 As such, without any options, the validator only checks that the input is a
 string.
 
-## Limiting the maximum string length
+## Limiting the Maximum String Length
 
 To limit the maximum allowed length of a string you need to set the `max`
 property. It accepts an integer value as input.
@@ -37,7 +37,7 @@ $validator->isValid("Test"); // returns true
 $validator->isValid("Testing"); // returns false
 ```
 
-## Limiting the minimum string length
+## Limiting the Minimum String Length
 
 To limit the minimal required string length, set the `min`
 property using an integer value:
@@ -49,7 +49,7 @@ $validator->isValid("Test"); // returns false
 $validator->isValid("Testing"); // returns true
 ```
 
-## Limiting both minimum and maximum string length
+## Limiting Both Minimum and Maximum String Length
 
 Sometimes you will need to set both a minimum and a maximum string length;
 as an example, in a username input, you may want to limit the name to a maximum
@@ -63,7 +63,7 @@ $validator->isValid("Test"); // returns true
 $validator->isValid("Testing"); // returns true
 ```
 
-## Limiting to a strict length
+## Limiting to a Strict Length
 
 If you need a strict length, then set the `min` and `max` properties to the same
 value:
@@ -76,13 +76,13 @@ $validator->isValid('Test'); // returns true
 $validator->isValid('Testi'); // returns false
 ```
 
-> ### Setting a maximum lower than the minimum
+> ### Setting a Maximum Lower than the Minimum
 >
 > When you try to set a lower maximum value than the specified minimum value, or
 > a higher minimum value as the actual maximum value, the validator will raise
 > an exception.
 
-## Encoding of values
+## Encoding of Values
 
 Strings are always using an encoding. Even when you don't set the encoding
 explicitly, PHP uses one. When your application is using a different encoding

--- a/docs/book/v3/validators/undisclosed-password.md
+++ b/docs/book/v3/validators/undisclosed-password.md
@@ -5,7 +5,7 @@
 `Laminas\Validator\UndisclosedPassword` allows you to validate if a given password was found in data breaches using the service [Have I Been Pwned?](https://www.haveibeenpwned.com), in a secure, anonymous way using [K-Anonymity](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2) to ensure passwords are not send in full over the wire.
 
 <!-- markdownlint-disable-next-line MD001 -->
-> ### Installation requirements
+> ### Installation Requirements
 >
 > This validator needs to make a request over HTTP; therefore it requires an HTTP client. The validator provides support only for HTTP clients implementing [PSR-18](https://www.php-fig.org/psr/psr-18/) and [PSR-17](https://www.php-fig.org/psr/psr-17/) request and response factories.
 >
@@ -16,7 +16,7 @@
 > $ composer require psr/http-factory
 > ```
 
-## Basic usage
+## Basic Usage
 
 The validator has two required constructor arguments:
 
@@ -40,7 +40,7 @@ $result = $validator->isValid('8aDk=XiW2E.77tLfuAcB');
 // $result is TRUE because "8aDk=XiW2E.77tLfuAcB" was not found in a data breach
 ```
 
-## A simple command line example
+## A Simple Command Line Example
 
 In this example, I'm using `laminas/laminas-diactoros` to provide HTTP messages, and `php-http/curl-client` as the HTTP client. Let's begin with installation of all required packages:
 

--- a/docs/book/v3/validators/uri.md
+++ b/docs/book/v3/validators/uri.md
@@ -12,7 +12,7 @@ another one in case the parsing of the uri should be done differently.
 > composer require laminas/laminas-uri
 > ```
 
-## Supported options
+## Supported Options
 
 The following options are supported for `Laminas\Validator\Uri`:
 
@@ -23,7 +23,7 @@ The following options are supported for `Laminas\Validator\Uri`:
 - `allowAbsolute`: Defines if absolute paths are allowed. This option defaults
   to `true`.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\Uri();

--- a/docs/book/v3/validators/uuid.md
+++ b/docs/book/v3/validators/uuid.md
@@ -22,11 +22,11 @@ however, only that it is well-formed.
 >
 > `Laminas\Validator\Uuid` was introduced with version 2.8.0.
 
-## Supported options
+## Supported Options
 
 The `Uuid` validator has no additional options.
 
-## Basic usage
+## Basic Usage
 
 ```php
 $validator = new Laminas\Validator\Uuid();

--- a/docs/book/v3/writing-validators.md
+++ b/docs/book/v3/writing-validators.md
@@ -71,7 +71,7 @@ reason for validation failure. Since this class only defines one failure
 message, it is not necessary to provide `error()` with the name of the failure
 message template.
 
-## Writing a Validation Class having Dependent Conditions
+## Writing a Validation Class Having Dependent Conditions
 
 The following example demonstrates a more complex set of validation rules:
 


### PR DESCRIPTION
Updated documentation to consistently capitalize section headers across multiple validator Markdown files. This change ensures uniformity and improves readability throughout the docs.

Reference:

> # Headlines
> 
> Headlines should be used to break longer text sections to brighten up.
> 
> For headlines the Chicago Manual of Style capitalization rules must be used:
> 
> 1. Capitalize the first and the last word.
> 1. Capitalize nouns, pronouns, adjectives, verbs, adverbs, and subordinate conjunctions.
> 1. Lowercase articles (a, an, the), coordinating conjunctions, and prepositions.
> 1. Lowercase the ‘to’ in an infinitive (I want to play guitar).
> 
> ## Helper
> 
> The online tool [capitalizemytitle.com](https://capitalizemytitle.com/style/Chicago/) can help to capitalize and case convert the headlines.
