### PR TITLE
Remove outdated version indicators from validator docs

### DIFF
--- a/docs/book/v3/validators/is-array.md
+++ b/docs/book/v3/validators/is-array.md
@@ -1,7 +1,5 @@
 # IsArray Validator
 
-- **Since 2.52.0**
-
 `Laminas\Validator\IsArray` checks that a given value is an array. There are no options.
 
 ## Example Usage

--- a/docs/book/v3/validators/undisclosed-password.md
+++ b/docs/book/v3/validators/undisclosed-password.md
@@ -1,7 +1,5 @@
 # Undisclosed Password Validator
 
-- **Since 2.13.0**
-
 `Laminas\Validator\UndisclosedPassword` allows you to validate if a given password was found in data breaches using the service [Have I Been Pwned?](https://www.haveibeenpwned.com), in a secure, anonymous way using [K-Anonymity](https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2) to ensure passwords are not send in full over the wire.
 
 <!-- markdownlint-disable-next-line MD001 -->

--- a/docs/book/v3/validators/uuid.md
+++ b/docs/book/v3/validators/uuid.md
@@ -17,11 +17,6 @@ The `Uuid` validator is capable of validating whether a string is a valid UUID
 of any version. It does not validate that the UUID exists in your system,
 however, only that it is well-formed.
 
-<!-- markdownlint-disable-next-line MD001 -->
-> ### Introduced in 2.8.0
->
-> `Laminas\Validator\Uuid` was introduced with version 2.8.0.
-
 ## Supported options
 
 The `Uuid` validator has no additional options.


### PR DESCRIPTION
Removed outdated "Since" version indicators from multiple validator documentation files to streamline the content. These lines were no longer necessary and cluttered the information provided about each validator's functionality.