### PR TITLE
Update validator documentation links in set.md

### DIFF
--- a/docs/book/v3/set.md
+++ b/docs/book/v3/set.md
@@ -38,11 +38,7 @@ The following validators come with the laminas-validator distribution.
 
 Several other components offer validators as well:
 
+- [laminas-authentication](https://docs.laminas.dev/laminas-authentication/validator/)
+- [laminas-captcha](https://docs.laminas.dev/laminas-captcha/)
 - [laminas-i18n](https://docs.laminas.dev/laminas-i18n/validators/)
-
-## Deprecated Validators
-
-### Ccnum
-
-The `Ccnum` validator has been deprecated in favor of the `CreditCard`
-validator. For security reasons you should use `CreditCard` instead of `Ccnum`.
+- [laminas-session](https://docs.laminas.dev/laminas-session/validators/introduction/)


### PR DESCRIPTION
Removed deprecated "Ccnum" validator section, suggesting "CreditCard" as replacement. Added new links for laminas-authentication, laminas-session and laminas-captcha validators.