### PR TITLE
Firm up Callback arguments and document `$context` parameter.

### DIFF
--- a/docs/book/v3/validators/credit-card.md
+++ b/docs/book/v3/validators/credit-card.md
@@ -126,7 +126,7 @@ use Laminas\Validator\CreditCard;
 // Your service class
 class CcService
 {
-    public function checkOnline(string $cardNumber, array $types): bool
+    public function checkOnline(string $cardNumber, array $context, array $types): bool
     {
         // some online validation
     }
@@ -141,4 +141,26 @@ $valid   = new CreditCard([
 ```
 
 The callback method will be called with the credit card number as the first
-parameter, and the accepted types as the second parameter.
+parameter, the wider validation context as the second parameter and the accepted types as the third parameter.
+
+The `$context` parameter will typically be the entire `$_POST` array, un-filtered and un-validated when it is available.
+
+When used via [`laminas-inputfilter`](https://docs.laminas.dev/laminas-inputfilter/) or [`laminas-form`](https://docs.laminas.dev/laminas-form/), the context parameter will be non-empty, but in standalone usage, the context must be provided manually if required:
+
+```php
+use Laminas\Validator\CreditCard;
+
+$formPayload = [
+    'card' => '4444 4444 4444 4444',
+    'other-value' => 'Foo',
+];
+
+$validator = new CreditCard([
+    'type' => CreditCard::VISA,
+    'service' => static function (mixed $value, array $context = [], array $types = []): bool {
+        return true;
+    },
+]);
+
+$validator->isValid($formPayload['card'], $formPayload);
+```

--- a/src/CreditCard.php
+++ b/src/CreditCard.php
@@ -24,7 +24,7 @@ use function strtoupper;
 /**
  * @psalm-type OptionsArgument = array{
  *     type?: value-of<CreditCard::TYPES>|list<value-of<CreditCard::TYPES>>,
- *     service?: callable(mixed...): bool,
+ *     service?: callable(mixed, array<string, mixed>, mixed...): bool,
  *     messages?: array<string, string>,
  *     translator?: TranslatorInterface|null,
  *     translatorTextDomain?: string|null,
@@ -303,10 +303,13 @@ final class CreditCard extends AbstractValidator
 
     /**
      * Returns true if and only if $value follows the Luhn algorithm (mod-10 checksum)
+     *
+     * @param array<string, mixed>|null $context Validation context, i.e the form payload
      */
     public function isValid(
         #[SensitiveParameter]
         mixed $value,
+        ?array $context = null,
     ): bool {
         $this->setValue($value);
 
@@ -362,7 +365,7 @@ final class CreditCard extends AbstractValidator
 
         if ($this->callback !== null) {
             try {
-                if (! $this->callback->isValid($value)) {
+                if (! $this->callback->isValid($value, $context)) {
                     $this->error(self::SERVICE);
                     return false;
                 }

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -36,11 +36,13 @@ final class CallbackTest extends TestCase
 
     /** @param array<string, mixed>|null $context */
     #[DataProvider('emptyContextProvider')]
-    public function testOptionsArePassedAsSecondArgumentWhenGivenWithoutContext(?array $context): void
+    public function testOptionsArePassedAsThirdArgumentWhenNoContextIsPresent(?array $context): void
     {
         $validator = new Callback([
             'throwExceptions' => true,
-            'callback'        => static function (mixed $value, string $foo): bool {
+            'callback'        => static function (mixed $value, array $context, string $foo): bool {
+                self::assertSame([], $context);
+
                 return $value === 'test' && $foo === 'foo';
             },
             'callbackOptions' => ['foo' => 'foo'],

--- a/test/CreditCardTest.php
+++ b/test/CreditCardTest.php
@@ -297,7 +297,22 @@ final class CreditCardTest extends TestCase
 
         $input = '4111111111111111';
 
-        $callback = function (string $cardNumber, array $types) use ($list, $input): bool {
+        $formPayload = [
+            'card'      => $input,
+            'someValue' => '1',
+            'foo'       => 'bar',
+        ];
+
+        $callback = function (
+            string $cardNumber,
+            array $context,
+            array $types,
+        ) use (
+            $list,
+            $input,
+            $formPayload,
+        ): bool {
+            self::assertSame($formPayload, $context);
             self::assertSame($list, $types);
             self::assertSame($input, $cardNumber);
 
@@ -309,6 +324,6 @@ final class CreditCardTest extends TestCase
             'service' => $callback,
         ]);
 
-        self::assertTrue($validator->isValid($input));
+        self::assertTrue($validator->isValid($input, $formPayload));
     }
 }


### PR DESCRIPTION
Changes the Callback validator so that the callable always receives `(mixed $value, array $context, ...$otherArgs)` - this stabilizes the args for all environments, i.e. standalone usage and when part of input-filter etc.

Because the Callback validator is used internally, by the CreditCard validator, this also affects the signature of the `service` option to include context and declares the `$context` param in `CreditCard::isValid()` so that it can correctly be passed to the composed callback validator.

Will need to document this change in #253 

Edit: a bit more clarity…

Previously, the callback might receive `(mixed $value, ...$userDefinedArgs)` or `(mixed $value, array $context, ...$userDefinedArgs)` depending on whether the context was given to `Callback::isValid()` as the second param. This is difficult to document and hard to understand when the given arguments might differ.

This change means that the required signature of the callback is consistent at all times, but `$context` might be === [] in standalone usage.