### PR TITLE
`NotEmpty` Validator Input Filter Affordances

### DIFF
--- a/src/NotEmpty.php
+++ b/src/NotEmpty.php
@@ -260,4 +260,22 @@ final class NotEmpty extends AbstractValidator
 
         return true;
     }
+
+    /**
+     * Return the configured message templates
+     *
+     * This method is an affordance to laminas-inputfilter.
+     * It needs to introspect configured message templates in order to provide a default error message for empty inputs.
+     *
+     * In future versions of laminas-validator, this method will likely be deprecated and removed. Please avoid.
+     *
+     * @internal
+     *
+     * @psalm-internal \Laminas
+     * @return array<string, string>
+     */
+    public function getMessageTemplates(): array
+    {
+        return $this->messageTemplates;
+    }
 }

--- a/test/NotEmptyTest.php
+++ b/test/NotEmptyTest.php
@@ -695,4 +695,13 @@ final class NotEmptyTest extends TestCase
             [null, true],
         ];
     }
+
+    public function testRetrievalOfMessageTemplates(): void
+    {
+        /** @psalm-suppress InternalMethod */
+        $templates = (new NotEmpty())->getMessageTemplates();
+        self::assertNotSame([], $templates);
+        self::assertArrayHasKey(NotEmpty::IS_EMPTY, $templates);
+        self::assertArrayHasKey(NotEmpty::INVALID, $templates);
+    }
 }


### PR DESCRIPTION
### Description

InputFilter needs access to the internal message templates of the `NotEmpty` validator in order to present error messages when a required field is empty. This patch re-introduces `getMessageTemplates` only on the NotEmpty validator and marks the method as internal.

https://github.com/laminas/laminas-inputfilter/blob/15e25a10db958c4f12b3eda19ae47f38d193eb58/src/Input.php#L457-L481
