### PR TITLE
Fix options handling bug in Hash validator preventing the use of non-default algorithms

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3377,6 +3377,7 @@
       <code><![CDATA[getHash]]></code>
       <code><![CDATA[getHash]]></code>
       <code><![CDATA[getHash]]></code>
+      <code><![CDATA[getOptions]]></code>
       <code><![CDATA[setHash]]></code>
     </DeprecatedMethod>
     <MixedArgument>
@@ -3393,6 +3394,7 @@
       <code><![CDATA[basicBehaviorDataProvider]]></code>
       <code><![CDATA[hashProvider]]></code>
       <code><![CDATA[invalidHashTypes]]></code>
+      <code><![CDATA[optionsOrderProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/File/ImageSizeTest.php">

--- a/src/File/Hash.php
+++ b/src/File/Hash.php
@@ -69,6 +69,12 @@ class Hash extends AbstractValidator
             $options['algorithm'] = func_get_arg(1);
         }
 
+        // The combination of parent and local logic requires us to have the "algorithm" key before the "hash" key
+        // in the array, or else the default algorithm will be used instead of the passed one.
+        if (isset($options['algorithm'])) {
+            $options = ['algorithm' => $options['algorithm']] + $options;
+        }
+
         parent::__construct($options);
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes issue #398.