### PR TITLE
Fix: Regex validator does not permit customisation of abstract options via options argument

### DIFF
--- a/src/Regex.php
+++ b/src/Regex.php
@@ -50,7 +50,8 @@ final class Regex extends AbstractValidator
      */
     public function __construct(string|array $options)
     {
-        $pattern = is_string($options) ? $options : $options['pattern'] ?? null;
+        $options = is_string($options) ? ['pattern' => $options] : $options;
+        $pattern = $options['pattern'] ?? null;
         /** @psalm-suppress DocblockTypeContradiction The user may still supply an empty string */
         if (! is_string($pattern) || $pattern === '') {
             throw new InvalidArgumentException('A regex pattern is required');
@@ -65,7 +66,7 @@ final class Regex extends AbstractValidator
 
         $this->pattern = $pattern;
 
-        parent::__construct();
+        parent::__construct($options);
     }
 
     /**

--- a/test/RegexTest.php
+++ b/test/RegexTest.php
@@ -86,7 +86,7 @@ final class RegexTest extends TestCase
         self::assertSame(
             $expected,
             $validator->isValid($input),
-            'Reason: ' . implode('', $validator->getMessages())
+            'Reason: ' . implode('', $validator->getMessages()),
         );
     }
 
@@ -143,5 +143,21 @@ final class RegexTest extends TestCase
 
         /** @psalm-suppress InvalidArgument */
         new Regex($options);
+    }
+
+    public function testAbstractOptionsAreProvidedToParentConstructor(): void
+    {
+        $validator = new Regex([
+            'pattern'  => '/^\d+$/',
+            'messages' => [
+                Regex::NOT_MATCH => 'Numbers only',
+            ],
+        ]);
+
+        self::assertFalse($validator->isValid('Not numbers'));
+        $messages = $validator->getMessages();
+        self::assertSame([
+            Regex::NOT_MATCH => 'Numbers only',
+        ], $messages);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Closes #411 