### PR TITLE
Use psalm prefix on phpdoc referring to psalm types

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -64,7 +64,7 @@ class Callback extends AbstractValidator
 
     /**
      * @param array|callable $options
-     * @psalm-param OptionsArgument|callable $options 
+     * @psalm-param OptionsArgument|callable $options
      */
     public function __construct($options = null)
     {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -52,7 +52,8 @@ class Callback extends AbstractValidator
     /**
      * Default options to set for the validator
      *
-     * @var OptionsProperty
+     * @var array
+     * @psalm-var OptionsProperty
      */
     protected $options = [
         'callback'        => null, // Callback in a call_user_func format, string || array
@@ -61,7 +62,10 @@ class Callback extends AbstractValidator
         'bind'            => false, // Bind the callback to the validator instance
     ];
 
-    /** @param OptionsArgument|callable $options */
+    /** 
+     * @param array|callable $options
+     * @psalm-param OptionsArgument|callable $options 
+     */
     public function __construct($options = null)
     {
         if (is_callable($options)) {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -62,7 +62,7 @@ class Callback extends AbstractValidator
         'bind'            => false, // Bind the callback to the validator instance
     ];
 
-    /** 
+    /**
      * @param array|callable $options
      * @psalm-param OptionsArgument|callable $options 
      */


### PR DESCRIPTION
For maximum compatibility with other static analyzers that do not  understand @psalm-type, use @psalm- prefixed phpdoc when a psalm-type is referenced so that they do not consider the psalm-type a missing class.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Currently the [Phan](https://github.com/phan/phan) static analyzer reports issues like:

`PhanTypeMismatchPropertyProbablyReal Assigning ($callback as a field) of type array<string,Closure(mixed,array|mixed=,mixed|string=):(bool|true)> to property but \ZF2Form\Validators\DependentValidate->options is \Laminas\Validator\OptionsProperty (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)`

Because it isn't aware of the meaning of:

```
* @psalm-type OptionsProperty = array{
 *     callback: callable|null,
 *     callbackOptions: array<array-key, mixed>,
 *     throwExceptions: bool,
 *     bind: bool,
 * }
 ```
so when Phan comes across:
```
    /**
     * Default options to set for the validator
     *
     * @var OptionsProperty
     */
    protected $options = [
```
Phan interprets 'OptionsProperty' as a type that doesn't exist.

Specifying @var and @psalm-var versions in this case should keep Psalm (and other static analyzers that understand @psalm* phpdoc) working optimally but also be compatible with other analyzers.

This change will help library users upgrade efficiently by not bothering them (or build systems) with false positives and allowing them to focus on real forwards compatibility issues
