### PR TITLE
Use psalm-param rather than @param when there is a psalm-type

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -48,7 +48,9 @@ final class Callback extends AbstractValidator
     /** @var array<array-key, mixed> */
     private readonly array $callbackOptions;
 
-    /** @param OptionsArgument|callable $options */
+    /** 
+    * @psalm-param OptionsArgument|callable $options
+    */
     public function __construct(array|callable $options)
     {
         if (! is_array($options)) {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -48,9 +48,7 @@ final class Callback extends AbstractValidator
     /** @var array<array-key, mixed> */
     private readonly array $callbackOptions;
 
-    /** 
-    * @psalm-param OptionsArgument|callable $options
-    */
+    /** @psalm-param OptionsArgument|callable $options */
     public function __construct(array|callable $options)
     {
         if (! is_array($options)) {


### PR DESCRIPTION
Use psalm-param rather than param so the psalm-type doesn't confuse psalm phpdoc unaware analyzers


|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Non psalm-type aware analyzers can't understand and @param with a psalm-type so use psalm-var so they aren't confused by an unknown type.

This is current branch version of 
https://github.com/laminas/laminas-validator/pull/415

Compared to that:
- this doesn't need an '@param' because it would just be the same as the type declared on the method
- this doesn't need the changes to the `@var` because this is a final class and the property can't be accessed externally.