### PR TITLE
Swap out failing Russian IDN TLD for a Google-owned Japanese TLD.

### DIFF
--- a/test/EmailAddressTest.php
+++ b/test/EmailAddressTest.php
@@ -763,8 +763,9 @@ final class EmailAddressTest extends TestCase
         ];
 
         if (extension_loaded('intl')) {
-            $emailAddresses[] = 'test@кц.рф'; // Registry for .рф-TLD
-            $emailAddresses[] = 'test@xn--j1ay.xn--p1ai';
+            // Google owned Japanese TLD
+            $emailAddresses[] = 'test@nic.みんな';
+            $emailAddresses[] = 'test@nic.xn--q9jyb4c';
         }
 
         foreach ($emailAddresses as $input) {


### PR DESCRIPTION
The previous DN either no longer exists, is not routable or no longer has MX records
