### PR TITLE
Create and implement `ValidatorChainInterface` in final class `ValidatorChain`

### DIFF
--- a/src/Conditional.php
+++ b/src/Conditional.php
@@ -20,7 +20,7 @@ final class Conditional implements ValidatorInterface
 {
     /** @var Closure(array<string, mixed>): bool */
     private readonly Closure $rule;
-    private readonly ValidatorChain $chain;
+    private readonly ValidatorChainInterface $chain;
 
     /** @param OptionsArgument $options */
     public function __construct(ValidatorChainFactory $chainFactory, array $options)

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -30,7 +30,8 @@ final class ConfigProvider
     {
         return [
             'aliases'   => [
-                'ValidatorManager' => ValidatorPluginManager::class,
+                'ValidatorManager'             => ValidatorPluginManager::class,
+                ValidatorChainInterface::class => ValidatorChain::class,
             ],
             'factories' => [
                 ValidatorChainFactory::class  => ValidatorChainFactoryFactory::class,

--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -22,12 +22,14 @@ use const SORT_NUMERIC;
  * @psalm-type QueueElement = array{instance: ValidatorInterface, breakChainOnFailure: bool}
  * @implements IteratorAggregate<array-key, QueueElement>
  */
-final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInterface
+final class ValidatorChain implements Countable, IteratorAggregate, ValidatorChainInterface
 {
     /**
      * Default priority at which validators are added
+     *
+     * @deprecated Use ValidatorChainInterface::DEFAULT_PRIORITY instead.
      */
-    public const DEFAULT_PRIORITY = 1;
+    public const DEFAULT_PRIORITY = ValidatorChainInterface::DEFAULT_PRIORITY;
 
     /**
      * Validator chain
@@ -102,8 +104,8 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      *
      * @internal \Laminas
      *
-     * @param string|class-string<T> $name    Name of validator to return
-     * @param array<string, mixed>   $options Options to pass to validator constructor
+     * @param string|class-string<T> $name Name of validator to return
+     * @param array<string, mixed> $options Options to pass to validator constructor
      *                                        (if not already instantiated)
      * @template T of ValidatorInterface
      * @return ($name is class-string<T> ? T : ValidatorInterface)
@@ -126,7 +128,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
     public function attach(
         ValidatorInterface $validator,
         bool $breakChainOnFailure = false,
-        int $priority = self::DEFAULT_PRIORITY
+        int $priority = ValidatorChainInterface::DEFAULT_PRIORITY
     ): void {
         $this->validators->insert(
             [
@@ -145,7 +147,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      */
     public function prependValidator(ValidatorInterface $validator, bool $breakChainOnFailure = false): void
     {
-        $priority = self::DEFAULT_PRIORITY;
+        $priority = ValidatorChainInterface::DEFAULT_PRIORITY;
 
         if (! $this->validators->isEmpty()) {
             $extractedNodes = $this->validators->toArray(PriorityQueue::EXTR_PRIORITY);
@@ -172,7 +174,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
         string $name,
         array $options = [],
         bool $breakChainOnFailure = false,
-        int $priority = self::DEFAULT_PRIORITY,
+        int $priority = ValidatorChainInterface::DEFAULT_PRIORITY,
     ): void {
         $bc = null;
         foreach (['break_chain_on_failure', 'breakchainonfailure'] as $key) {
@@ -192,7 +194,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorInt
      * Use the plugin manager to prepend a validator by name
      *
      * @param string|class-string<ValidatorInterface> $name
-     * @param array<string, mixed>                    $options
+     * @param array<string, mixed> $options
      */
     public function prependByName(string $name, array $options = [], bool $breakChainOnFailure = false): void
     {

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -16,7 +16,7 @@ final class ValidatorChainFactory
     }
 
     /** @param array<array-key, ValidatorSpecification> $specification */
-    public function fromArray(array $specification): ValidatorChainInterface
+    public function fromArray(array $specification): ValidatorChain
     {
         $chain = new ValidatorChain($this->pluginManager);
         foreach ($specification as $spec) {

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -16,11 +16,11 @@ final class ValidatorChainFactory
     }
 
     /** @param array<array-key, ValidatorSpecification> $specification */
-    public function fromArray(array $specification): ValidatorChain
+    public function fromArray(array $specification): ValidatorChainInterface
     {
         $chain = new ValidatorChain($this->pluginManager);
         foreach ($specification as $spec) {
-            $priority   = $spec['priority'] ?? ValidatorChain::DEFAULT_PRIORITY;
+            $priority   = $spec['priority'] ?? ValidatorChainInterface::DEFAULT_PRIORITY;
             $breakChain = $spec['break_chain_on_failure'] ?? false;
             $options    = $spec['options'] ?? [];
             $validator  = $this->pluginManager->build($spec['name'], $options);

--- a/src/ValidatorChainInterface.php
+++ b/src/ValidatorChainInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator;
+
+interface ValidatorChainInterface extends ValidatorInterface
+{
+    public const DEFAULT_PRIORITY = 1;
+
+    /**
+     * Attach a validator to the end of the chain
+     *
+     * @param ValidatorInterface $validator A Validator implementation
+     * @param bool $breakChainOnFailure If true, the chain's next validator will not be executed in case of failure
+     * @param int $priority Priority at which to enqueue validator; defaults to 1 (higher executes earlier)
+     */
+    public function attach(
+        ValidatorInterface $validator,
+        bool $breakChainOnFailure = false,
+        int $priority = self::DEFAULT_PRIORITY
+    ): void;
+
+    /**
+     * Attach a validator to the chain using an alias or FQCN
+     *
+     * Retrieves the validator from the composed plugin manager, and then calls attach() with the retrieved instance.
+     *
+     * @param string|class-string<ValidatorInterface> $name
+     * @param array<string, mixed> $options Construction options for the desired validator
+     * @param bool $breakChainOnFailure If true, the chain's next validator will not be executed in case of failure
+     * @param int $priority Priority at which to enqueue validator; defaults to 1 (higher executes earlier)
+     */
+    public function attachByName(
+        string $name,
+        array $options = [],
+        bool $breakChainOnFailure = false,
+        int $priority = self::DEFAULT_PRIORITY
+    ): void;
+}

--- a/src/ValidatorChainInterface.php
+++ b/src/ValidatorChainInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Override;
+
 interface ValidatorChainInterface extends ValidatorInterface
 {
     public const DEFAULT_PRIORITY = 1;
@@ -37,4 +39,14 @@ interface ValidatorChainInterface extends ValidatorInterface
         bool $breakChainOnFailure = false,
         int $priority = self::DEFAULT_PRIORITY
     ): void;
+
+    /**
+     * Returns true if and only if $value passes all validations in the chain
+     *
+     * Validators are run in the order in which they were added to the chain (FIFO).
+     *
+     * @param array<string, mixed> $context Extra "context" to provide the validator
+     */
+    #[Override]
+    public function isValid(mixed $value, ?array $context = null): bool;
 }


### PR DESCRIPTION
Problem is came up in issue #429, final classes should have an interface.

<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Create a ValidatorChainInterface, which extends ValidatorInterface (similar to filters). 
Also declare DEFAULT_PRIORITY in interface, but keep in ValidatorChain class for backward-compatibility, but with a deprecation note.
