### PR TITLE
Allow validator chain specifications to include instances.

### DIFF
--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -15,11 +15,16 @@ final class ValidatorChainFactory
     {
     }
 
-    /** @param array<array-key, ValidatorSpecification> $specification */
+    /** @param array<array-key, ValidatorSpecification|ValidatorInterface> $specification */
     public function fromArray(array $specification): ValidatorChain
     {
         $chain = new ValidatorChain($this->pluginManager);
         foreach ($specification as $spec) {
+            if ($spec instanceof ValidatorInterface) {
+                $chain->attach($spec);
+                continue;
+            }
+
             $priority   = $spec['priority'] ?? ValidatorChainInterface::DEFAULT_PRIORITY;
             $breakChain = $spec['break_chain_on_failure'] ?? false;
             $options    = $spec['options'] ?? [];

--- a/src/ValidatorChainInvokableFactory.php
+++ b/src/ValidatorChainInvokableFactory.php
@@ -21,7 +21,7 @@ use Psr\Container\ContainerInterface;
 final class ValidatorChainInvokableFactory implements FactoryInterface
 {
     /**
-     * @param array<array-key, ValidatorSpecification>|null $options
+     * @param array<array-key, ValidatorSpecification|ValidatorInterface>|null $options
      * @psalm-suppress MoreSpecificImplementedParamType $options is more specific to prevent psalm from requiring
      *                 runtime validation of the validator chain options payload.
      */

--- a/test/ValidatorChainFactoryTest.php
+++ b/test/ValidatorChainFactoryTest.php
@@ -12,6 +12,8 @@ use Laminas\Validator\ValidatorPluginManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 
+use function iterator_to_array;
+
 final class ValidatorChainFactoryTest extends TestCase
 {
     private ValidatorChainFactory $factory;
@@ -114,5 +116,38 @@ final class ValidatorChainFactoryTest extends TestCase
                 'name' => 'Unknown',
             ],
         ]);
+    }
+
+    public function testSpecificationsCanBeMixedWithInstances(): void
+    {
+        $stringLength = new StringLength(['min' => 5]);
+        $chain        = $this->factory->fromArray([
+            [
+                'name'                   => NotEmpty::class,
+                'priority'               => 10,
+                'break_chain_on_failure' => true,
+            ],
+            $stringLength,
+        ]);
+
+        $validators = iterator_to_array($chain, false);
+        self::assertCount(2, $chain);
+        self::assertInstanceOf(NotEmpty::class, $validators[0]['instance']);
+        self::assertSame($stringLength, $validators[1]['instance']);
+    }
+
+    public function testSpecificationsCanBeAllInstances(): void
+    {
+        $stringLength = new StringLength(['min' => 5]);
+        $notEmpty     = new NotEmpty();
+        $chain        = $this->factory->fromArray([
+            $notEmpty,
+            $stringLength,
+        ]);
+
+        $validators = iterator_to_array($chain, false);
+        self::assertCount(2, $chain);
+        self::assertSame($notEmpty, $validators[0]['instance']);
+        self::assertSame($stringLength, $validators[1]['instance']);
     }
 }


### PR DESCRIPTION
This is a feature/fix primarily for the next version of `input-filter` and allows validator chain specifications to be a mixture of array specs and validator instances.

Relevant to https://github.com/laminas/laminas-inputfilter/pull/149