### PR TITLE
Fix `ValidatorChainFactory` Building Plugins Manually

### DIFF
--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use function assert;
-
 /**
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
  */
@@ -28,9 +26,7 @@ final class ValidatorChainFactory
             $priority   = $spec['priority'] ?? ValidatorChainInterface::DEFAULT_PRIORITY;
             $breakChain = $spec['break_chain_on_failure'] ?? false;
             $options    = $spec['options'] ?? [];
-            $validator  = $this->pluginManager->build($spec['name'], $options);
-            assert($validator instanceof ValidatorInterface);
-            $chain->attach($validator, $breakChain, $priority);
+            $chain->attachByName($spec['name'], $options, $breakChain, $priority);
         }
 
         return $chain;

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
-use Laminas\Validator\Exception\InvalidArgumentException;
-
-use function is_array;
-use function is_bool;
-use function is_int;
-use function is_string;
-
 /**
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
  */
@@ -20,18 +13,15 @@ final class ValidatorChainFactory
     {
     }
 
-    /** @param array<array-key, mixed> $specification */
+    /** @param array<array-key, ValidatorSpecification|ValidatorInterface> $specification */
     public function fromArray(array $specification): ValidatorChain
     {
         $chain = new ValidatorChain($this->pluginManager);
-        /** @psalm-var mixed $spec */
         foreach ($specification as $spec) {
             if ($spec instanceof ValidatorInterface) {
                 $chain->attach($spec);
                 continue;
             }
-
-            $spec = $this->assertSpec($spec);
 
             $priority   = $spec['priority'] ?? ValidatorChainInterface::DEFAULT_PRIORITY;
             $breakChain = $spec['break_chain_on_failure'] ?? false;
@@ -40,32 +30,5 @@ final class ValidatorChainFactory
         }
 
         return $chain;
-    }
-
-    /** @return ValidatorSpecification */
-    private function assertSpec(mixed $spec): array
-    {
-        if (! is_array($spec)) {
-            throw new InvalidArgumentException('Validator specifications must be an array');
-        }
-
-        if (! isset($spec['name']) || ! is_string($spec['name']) || $spec['name'] === '') {
-            throw new InvalidArgumentException('Validator specifications should have a `name` key');
-        }
-
-        if (isset($spec['priority']) && ! is_int($spec['priority'])) {
-            throw new InvalidArgumentException('Validator priorities must be integers');
-        }
-
-        if (isset($spec['options']) && ! is_array($spec['options'])) {
-            throw new InvalidArgumentException('Validator options should be arrays');
-        }
-
-        if (isset($spec['break_chain_on_failure']) && ! is_bool($spec['break_chain_on_failure'])) {
-            throw new InvalidArgumentException('The `break_chain_on_failure` key must contain a boolean when set');
-        }
-
-        /** @psalm-var ValidatorSpecification */
-        return $spec;
     }
 }

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+use Laminas\Validator\Exception\InvalidArgumentException;
+
+use function is_array;
+use function is_bool;
+use function is_int;
+use function is_string;
+
 /**
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
  */
@@ -13,15 +20,18 @@ final class ValidatorChainFactory
     {
     }
 
-    /** @param array<array-key, ValidatorSpecification|ValidatorInterface> $specification */
+    /** @param array<array-key, mixed> $specification */
     public function fromArray(array $specification): ValidatorChain
     {
         $chain = new ValidatorChain($this->pluginManager);
+        /** @psalm-var mixed $spec */
         foreach ($specification as $spec) {
             if ($spec instanceof ValidatorInterface) {
                 $chain->attach($spec);
                 continue;
             }
+
+            $spec = $this->assertSpec($spec);
 
             $priority   = $spec['priority'] ?? ValidatorChainInterface::DEFAULT_PRIORITY;
             $breakChain = $spec['break_chain_on_failure'] ?? false;
@@ -30,5 +40,32 @@ final class ValidatorChainFactory
         }
 
         return $chain;
+    }
+
+    /** @return ValidatorSpecification */
+    private function assertSpec(mixed $spec): array
+    {
+        if (! is_array($spec)) {
+            throw new InvalidArgumentException('Validator specifications must be an array');
+        }
+
+        if (! isset($spec['name']) || ! is_string($spec['name']) || $spec['name'] === '') {
+            throw new InvalidArgumentException('Validator specifications should have a `name` key');
+        }
+
+        if (isset($spec['priority']) && ! is_int($spec['priority'])) {
+            throw new InvalidArgumentException('Validator priorities must be integers');
+        }
+
+        if (isset($spec['options']) && ! is_array($spec['options'])) {
+            throw new InvalidArgumentException('Validator options should be arrays');
+        }
+
+        if (isset($spec['break_chain_on_failure']) && ! is_bool($spec['break_chain_on_failure'])) {
+            throw new InvalidArgumentException('The `break_chain_on_failure` key must contain a boolean when set');
+        }
+
+        /** @psalm-var ValidatorSpecification */
+        return $spec;
     }
 }

--- a/test/ValidatorChainFactoryTest.php
+++ b/test/ValidatorChainFactoryTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\ServiceManager\ServiceManager;
-use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\ValidatorChainFactory;
 use Laminas\Validator\ValidatorPluginManager;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -151,45 +149,5 @@ final class ValidatorChainFactoryTest extends TestCase
         self::assertCount(2, $chain);
         self::assertSame($notEmpty, $validators[0]['instance']);
         self::assertSame($stringLength, $validators[1]['instance']);
-    }
-
-    /** @return array<string, array{0: array, 1: string}> */
-    public static function invalidSpecProvider(): array
-    {
-        return [
-            'Null'                 => [
-                [null],
-                'Validator specifications must be an array',
-            ],
-            'String'               => [
-                ['foo'],
-                'Validator specifications must be an array',
-            ],
-            'Missing Name'         => [
-                [['priority' => 10]],
-                'Validator specifications should have a `name` key',
-            ],
-            'Non-int Priority'     => [
-                [['name' => 'foo', 'priority' => 'a']],
-                'Validator priorities must be integers',
-            ],
-            'Non-array options'    => [
-                [['name' => 'foo', 'options' => 'a']],
-                'Validator options should be arrays',
-            ],
-            'Non-bool break chain' => [
-                [['name' => 'foo', 'break_chain_on_failure' => 'a']],
-                'The `break_chain_on_failure` key must contain a boolean when set',
-            ],
-        ];
-    }
-
-    /** @param mixed[] $spec */
-    #[DataProvider('invalidSpecProvider')]
-    public function testInvalidSpecsWillCauseExceptions(array $spec, string $expectMessage): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectMessage);
-        $this->factory->fromArray($spec);
     }
 }

--- a/test/ValidatorChainFactoryTest.php
+++ b/test/ValidatorChainFactoryTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace LaminasTest\Validator;
 
 use Laminas\ServiceManager\ServiceManager;
+use Laminas\Validator\Exception\InvalidArgumentException;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\ValidatorChainFactory;
 use Laminas\Validator\ValidatorPluginManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\NotFoundExceptionInterface;
 
@@ -149,5 +151,45 @@ final class ValidatorChainFactoryTest extends TestCase
         self::assertCount(2, $chain);
         self::assertSame($notEmpty, $validators[0]['instance']);
         self::assertSame($stringLength, $validators[1]['instance']);
+    }
+
+    /** @return array<string, array{0: array, 1: string}> */
+    public static function invalidSpecProvider(): array
+    {
+        return [
+            'Null'                 => [
+                [null],
+                'Validator specifications must be an array',
+            ],
+            'String'               => [
+                ['foo'],
+                'Validator specifications must be an array',
+            ],
+            'Missing Name'         => [
+                [['priority' => 10]],
+                'Validator specifications should have a `name` key',
+            ],
+            'Non-int Priority'     => [
+                [['name' => 'foo', 'priority' => 'a']],
+                'Validator priorities must be integers',
+            ],
+            'Non-array options'    => [
+                [['name' => 'foo', 'options' => 'a']],
+                'Validator options should be arrays',
+            ],
+            'Non-bool break chain' => [
+                [['name' => 'foo', 'break_chain_on_failure' => 'a']],
+                'The `break_chain_on_failure` key must contain a boolean when set',
+            ],
+        ];
+    }
+
+    /** @param mixed[] $spec */
+    #[DataProvider('invalidSpecProvider')]
+    public function testInvalidSpecsWillCauseExceptions(array $spec, string $expectMessage): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectMessage);
+        $this->factory->fromArray($spec);
     }
 }


### PR DESCRIPTION
As per fix #435 - The factory now delegates to the chain when given a specification so that validators are either 'built' or 'got' depending on the presence of options so that `services` can be used in specifications.

Also adds runtime validation of the spec which could be considered a BC break 😬
