### PR TITLE
Deprecate `ValidatorPluginManagerAwareInterface`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -202,6 +202,9 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="test/ValidatorPluginManagerTest.php">
+    <DeprecatedInterface>
+      <code><![CDATA[class implements ValidatorInterface, ValidatorPluginManagerAwareInterface]]></code>
+    </DeprecatedInterface>
     <DeprecatedMethod>
       <code><![CDATA[setService]]></code>
     </DeprecatedMethod>

--- a/src/ValidatorPluginManagerAwareInterface.php
+++ b/src/ValidatorPluginManagerAwareInterface.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Laminas\Validator;
 
+/**
+ * @deprecated Since 3.9.0 In world where we should be implementing dependency injection, this interface should not
+ *             be required. It's presence indicates ongoing use of initializers which are not performant and lead to
+ *             objects being constructed in an invalid state. This interface will be removed in 4.0.0
+ */
 interface ValidatorPluginManagerAwareInterface
 {
     /**


### PR DESCRIPTION
This should have been removed in 3.0.0