### PR TITLE
Introduce Opt-In Runtime Validation of Validator Chain Specifications

### DIFF
--- a/src/Exception/InvalidSpecificationArrayException.php
+++ b/src/Exception/InvalidSpecificationArrayException.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Validator\Exception;
+
+use InvalidArgumentException;
+
+use function get_debug_type;
+use function sprintf;
+
+final class InvalidSpecificationArrayException extends InvalidArgumentException implements ExceptionInterface
+{
+    public static function becauseItemsMustBeArraysOrValidators(mixed $spec): self
+    {
+        return new self(sprintf(
+            'Each item in a specification array must be either an array or a validator instance. Received %s',
+            get_debug_type($spec),
+        ));
+    }
+
+    public static function becauseTheNameIsARequiredKey(mixed $name): self
+    {
+        return new self(sprintf(
+            'The `name` key must be defined and should be a string representing the FQCN of a validator or an '
+            . 'alias. Received %s',
+            get_debug_type($name),
+        ));
+    }
+
+    public static function becauseOptionsMustBeAnArray(mixed $options): self
+    {
+        return new self(sprintf(
+            'When given, the `options` key must be an array. Received %s',
+            get_debug_type($options),
+        ));
+    }
+
+    public static function becauseBreakChainMustBeBoolean(mixed $breakChain): self
+    {
+        return new self(sprintf(
+            'When given, the `break_chain_on_failure` key must be boolean. Received %s',
+            get_debug_type($breakChain),
+        ));
+    }
+
+    public static function becausePriorityMustBeAnInteger(mixed $priority): self
+    {
+        return new self(sprintf(
+            'When given, the `priority` key must be an integer. Received %s',
+            get_debug_type($priority),
+        ));
+    }
+}

--- a/src/ValidatorChainFactory.php
+++ b/src/ValidatorChainFactory.php
@@ -7,9 +7,9 @@ namespace Laminas\Validator;
 /**
  * @psalm-import-type ValidatorSpecification from ValidatorInterface
  */
-final class ValidatorChainFactory
+final readonly class ValidatorChainFactory
 {
-    public function __construct(private readonly ValidatorPluginManager $pluginManager)
+    public function __construct(private ValidatorPluginManager $pluginManager)
     {
     }
 

--- a/test/ValidatorChainTest.php
+++ b/test/ValidatorChainTest.php
@@ -8,6 +8,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\Validator\AbstractValidator;
 use Laminas\Validator\Callback;
 use Laminas\Validator\Digits;
+use Laminas\Validator\Exception\InvalidSpecificationArrayException;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\StringLength;
 use Laminas\Validator\Timezone;
@@ -398,5 +399,105 @@ final class ValidatorChainTest extends TestCase
 
         $entries = iterator_to_array($chain, false);
         self::assertSame($validator, $entries[0]['instance']);
+    }
+
+    /** @return array<string, array{0: array, 1: string}> */
+    public static function invalidSpecifications(): array
+    {
+        return [
+            'Non-array item'               => [
+                ['foo'],
+                'Each item in a specification array must be either an array or a validator instance',
+            ],
+            'Name must be defined'         => [
+                [['foo']],
+                'The `name` key must be defined and should be a string',
+            ],
+            'Name Not string'              => [
+                [['name' => 1]],
+                'The `name` key must be defined and should be a string',
+            ],
+            'Name Not Empty'               => [
+                [['name' => '']],
+                'The `name` key must be defined and should be a string',
+            ],
+            'Options not array'            => [
+                [['name' => 'foo', 'options' => 1]],
+                'When given, the `options` key must be an array',
+            ],
+            'Break chain not bool'         => [
+                [['name' => 'foo', 'break_chain_on_failure' => 1]],
+                'When given, the `break_chain_on_failure` key must be boolean',
+            ],
+            'Priority not int'             => [
+                [['name' => 'foo', 'priority' => 'foo']],
+                'When given, the `priority` key must be an integer',
+            ],
+            'Multiple items are validated' => [
+                [
+                    ['name' => 'baz'],
+                    ['name' => 'foo', 'priority' => 'foo'],
+                ],
+                'When given, the `priority` key must be an integer',
+            ],
+        ];
+    }
+
+    /** @param array<array-key, mixed> $spec */
+    #[DataProvider('invalidSpecifications')]
+    public function testInvalidSpecsCauseExceptions(array $spec, string $expectMessage): void
+    {
+        $this->expectException(InvalidSpecificationArrayException::class);
+        $this->expectExceptionMessage($expectMessage);
+
+        ValidatorChain::validateSpecification($spec);
+    }
+
+    /** @return array<string, array{0: array}> */
+    public static function validSpecs(): array
+    {
+        return [
+            'Empty array is OK'             => [[]],
+            'Instances are OK'              => [[new NotEmpty()]],
+            'Only name is required'         => [[['name' => 'foo']]],
+            'Full Spec'                     => [
+                [
+                    [
+                        'name'                   => 'foo',
+                        'options'                => [
+                            'foo' => 'bar',
+                        ],
+                        'break_chain_on_failure' => true,
+                        'priority'               => 1,
+                    ],
+                ],
+            ],
+            'Null and unset are equivalent' => [
+                [
+                    [
+                        'name'                   => 'foo',
+                        'options'                => null,
+                        'break_chain_on_failure' => null,
+                        'priority'               => null,
+                    ],
+                ],
+            ],
+            'Extraneous keys are ignored'   => [
+                [
+                    [
+                        'name' => 'foo',
+                        'baz'  => 'bat',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @param array<array-key, mixed> $spec */
+    #[DataProvider('validSpecs')]
+    public function testValidSpecsDoNotCauseExceptions(array $spec): void
+    {
+        $this->expectNotToPerformAssertions();
+        ValidatorChain::validateSpecification($spec);
     }
 }


### PR DESCRIPTION
As per the PR in `laminas-filter`: https://github.com/laminas/laminas-filter/pull/267

This patch adds a static method to the validator chain to allow consumers to assert chain specs are valid.

