### PR TITLE
Loosen the `context` parameter of `isValid` to `array<array-key, mixed>`

### DIFF
--- a/src/ValidatorChain.php
+++ b/src/ValidatorChain.php
@@ -221,7 +221,7 @@ final class ValidatorChain implements Countable, IteratorAggregate, ValidatorCha
      *
      * Validators are run in the order in which they were added to the chain (FIFO).
      *
-     * @param array<string, mixed> $context Extra "context" to provide the validator
+     * @inheritDoc
      */
     public function isValid(mixed $value, ?array $context = null): bool
     {

--- a/src/ValidatorChainInterface.php
+++ b/src/ValidatorChainInterface.php
@@ -45,7 +45,7 @@ interface ValidatorChainInterface extends ValidatorInterface
      *
      * Validators are run in the order in which they were added to the chain (FIFO).
      *
-     * @param array<string, mixed> $context Extra "context" to provide the validator
+     * @param array<array-key, mixed> $context Extra "context" to provide the validator
      */
     #[Override]
     public function isValid(mixed $value, ?array $context = null): bool;


### PR DESCRIPTION
It's entirely possible that the wider validation context might include data with integer keys. Restricting keys to `string` just causes downstream static analysis issues.

I also need this for `laminas-inputfilter` :)